### PR TITLE
Default `RandomGraph` keeps num-edges fixed

### DIFF
--- a/rings/perturbations.py
+++ b/rings/perturbations.py
@@ -4,7 +4,7 @@ import torch
 from torch_geometric.transforms import BaseTransform
 from torch_geometric.utils import dense_to_sparse
 
-from rings.utils import Shuffle, is_connected
+from rings.utils import Shuffle, is_connected, ensure_no_self_loops
 
 
 class Original(BaseTransform):
@@ -537,9 +537,10 @@ class RandomGraph(BaseTransform):
             0, num_nodes, (num_edges,), device="cpu", generator=self.generator
         )
 
-        # Remove self-loops
-        mask = row != col
-        row, col = row[mask], col[mask]
+        # Ensure no self-loops
+        row, col = ensure_no_self_loops(
+            row, col, num_nodes, generator=self.generator
+        )
 
         # Create sparse adjacency matrix
         edge_index = torch.stack([row, col], dim=0).to(data.edge_index.device)

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -220,6 +220,27 @@ class TestPerturbations:
         # Check that edge attributes are removed
         assert transformed_data.edge_attr is None
 
+    def test_random_graph_transform_documentation_example(self):
+        """Test RandomGraph transform using the example from documentation."""
+        # Create a simple graph as shown in documentation
+        edge_index = torch.tensor(
+            [[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long
+        )
+        data = Data(edge_index=edge_index, num_nodes=4)
+
+        # Example from documentation: Random graph with same number of edges
+        torch.manual_seed(42)  # For reproducibility
+        transform = RandomGraph()
+        transformed_data = transform(data.clone())
+
+        # Should have same number of edges but different structure
+        assert transformed_data.edge_index.shape[1] == data.edge_index.shape[1]
+        assert not torch.equal(transformed_data.edge_index, data.edge_index)
+
+        # Verify the transform maintains other properties
+        assert transformed_data.num_nodes == data.num_nodes
+        assert transformed_data.edge_attr is None
+
     def test_random_connected_graph_transform_shuffle(self):
         """Test RandomConnectedGraph transform with shuffle=True."""
         transform = RandomConnectedGraph(shuffle=True)


### PR DESCRIPTION
## Description
This PR adds a test case for the `RandomGraph` transform that reflects the example from our documentation. Previously we were dropping self loops when using an erdos reyni model– in order for better transparency we now ensure that we preserve the intended number of edges (i.e. make sure there are no self edges)

## Changes Made
- `esure_no_self_loops` is a standalon utility function used by both `RandomGraph` and `ShuffleTransform`
- Added `test_random_graph_transform_documentation_example()` to `test_perturbations.py`
- This test case exactly replicates the example from our documentation:
  - Creates a simple graph with the specified edge structure
  - Applies the `RandomGraph` transform with default parameters
  - Verifies that the transformed graph has the same number of edges
  - Ensures the edge structure is modified as expected
  - Confirms that node count and edge attributes are preserved correctly

## Why This Matters
Adding tests that mirror our documentation examples serves several important purposes:
1. **Documentation Accuracy**: Ensures our documentation examples are correct and actually work
2. **Regression Prevention**: Protects against future code changes breaking documented behavior
3. **Developer Experience**: Provides a reference implementation that developers can trust

## Testing Done
The new test passes successfully, confirming that the `RandomGraph` transform works as documented.

## Related Issues
Resolves #8: Add tests for documented examples
