### PR TITLE
Adding Separability Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you use RINGS in your research, please cite our paper:
 
 ```bibtex
 @inproceedings{
-coupette2025,
+coupette2025metric,
 title={No Metric to Rule Them All: Toward Principled Evaluations of Graph-Learning Datasets},
 author={Corinna Coupette and Jeremy Wayland and Emily Simons and Bastian Rieck},
 booktitle={Forty-second International Conference on Machine Learning},

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ source .venv/bin/activate
 
 ---
 
-## 🧹 Key Components
+## 🔑 Key Components
 
 ### Mode Perturbations
 

--- a/docs/source/_static/separability-comparator.svg
+++ b/docs/source/_static/separability-comparator.svg
@@ -1,0 +1,3541 @@
+<svg width="2040" height="1040" viewBox="0 0 2040 1040" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="91" width="2036" height="947" rx="32" fill="white" stroke="black" stroke-width="4"/>
+<path d="M469.493 751.332C468.649 751.332 467.924 751.034 467.319 750.438C466.723 749.832 466.424 749.108 466.424 748.264C466.424 747.429 466.723 746.713 467.319 746.116C467.924 745.52 468.649 745.222 469.493 745.222C470.311 745.222 471.027 745.52 471.64 746.116C472.254 746.713 472.561 747.429 472.561 748.264C472.561 748.827 472.416 749.342 472.126 749.811C471.845 750.271 471.474 750.642 471.014 750.923C470.554 751.196 470.047 751.332 469.493 751.332ZM479.495 751.332C478.651 751.332 477.927 751.034 477.322 750.438C476.725 749.832 476.427 749.108 476.427 748.264C476.427 747.429 476.725 746.713 477.322 746.116C477.927 745.52 478.651 745.222 479.495 745.222C480.313 745.222 481.029 745.52 481.643 746.116C482.257 746.713 482.563 747.429 482.563 748.264C482.563 748.827 482.419 749.342 482.129 749.811C481.847 750.271 481.477 750.642 481.017 750.923C480.556 751.196 480.049 751.332 479.495 751.332ZM489.498 751.332C488.654 751.332 487.93 751.034 487.325 750.438C486.728 749.832 486.43 749.108 486.43 748.264C486.43 747.429 486.728 746.713 487.325 746.116C487.93 745.52 488.654 745.222 489.498 745.222C490.316 745.222 491.032 745.52 491.646 746.116C492.259 746.713 492.566 747.429 492.566 748.264C492.566 748.827 492.421 749.342 492.131 749.811C491.85 750.271 491.479 750.642 491.019 750.923C490.559 751.196 490.052 751.332 489.498 751.332Z" fill="black"/>
+<rect x="1044" y="235" width="945" height="675" rx="32" fill="#E6711C" fill-opacity="0.17" stroke="black" stroke-width="4"/>
+<mask id="mask0_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1726" y="775" width="112" height="114">
+<path d="M1726 888.037H1837V775H1726V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_13_16079)">
+<mask id="mask1_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_13_16079)">
+<path d="M1822.72 831.52L1817.2 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask2_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_13_16079)">
+<path d="M1822.72 831.52L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask3_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_13_16079)">
+<path d="M1822.72 831.52L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask4_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_13_16079)">
+<path d="M1822.72 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask5_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_13_16079)">
+<path d="M1817.2 810.532L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask6_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_13_16079)">
+<path d="M1817.2 810.532L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask7_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_13_16079)">
+<path d="M1817.2 810.532L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask8_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_13_16079)">
+<path d="M1802.11 795.168L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask9_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_13_16079)">
+<path d="M1760.89 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask10_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_13_16079)">
+<path d="M1760.89 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask11_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_13_16079)">
+<path d="M1760.89 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask12_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_13_16079)">
+<path d="M1745.8 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask13_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_13_16079)">
+<path d="M1745.8 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask14_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_13_16079)">
+<path d="M1745.8 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask15_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_13_16079)">
+<path d="M1740.28 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask16_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_13_16079)">
+<path d="M1760.89 867.872L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask17_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_13_16079)">
+<path d="M1760.89 867.872H1802.11" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask18_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_13_16079)">
+<path d="M1760.89 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask19_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_13_16079)">
+<path d="M1781.5 873.495L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask20_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_13_16079)">
+<path d="M1781.5 873.495L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask21_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_13_16079)">
+<path d="M1802.11 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask22_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_13_16079)">
+<path d="M1822.72 831.52L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask23_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_13_16079)">
+<path d="M1822.72 831.52L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask24_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_13_16079)">
+<path d="M1822.72 831.52L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask25_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_13_16079)">
+<path d="M1822.72 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask26_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask26_13_16079)">
+<path d="M1822.72 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask27_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask27_13_16079)">
+<path d="M1822.72 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask28_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask28_13_16079)">
+<path d="M1822.72 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask29_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask29_13_16079)">
+<path d="M1817.2 810.532H1745.8" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask30_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask30_13_16079)">
+<path d="M1817.2 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask31_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask31_13_16079)">
+<path d="M1817.2 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask32_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask32_13_16079)">
+<path d="M1817.2 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask33_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask33_13_16079)">
+<path d="M1817.2 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask34_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask34_13_16079)">
+<path d="M1817.2 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask35_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask35_13_16079)">
+<path d="M1817.2 810.532V852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask36_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask36_13_16079)">
+<path d="M1802.11 795.168H1760.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask37_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask37_13_16079)">
+<path d="M1802.11 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask38_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask38_13_16079)">
+<path d="M1802.11 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask39_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask39_13_16079)">
+<path d="M1802.11 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask40_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask40_13_16079)">
+<path d="M1802.11 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask41_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask41_13_16079)">
+<path d="M1802.11 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask42_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask42_13_16079)">
+<path d="M1802.11 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask43_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask43_13_16079)">
+<path d="M1802.11 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask44_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask44_13_16079)">
+<path d="M1781.5 789.544L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask45_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask45_13_16079)">
+<path d="M1781.5 789.544L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask46_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask46_13_16079)">
+<path d="M1781.5 789.544L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask47_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask47_13_16079)">
+<path d="M1781.5 789.544L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask48_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask48_13_16079)">
+<path d="M1781.5 789.544L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask49_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask49_13_16079)">
+<path d="M1781.5 789.544V873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask50_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask50_13_16079)">
+<path d="M1781.5 789.544L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask51_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask51_13_16079)">
+<path d="M1781.5 789.544L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask52_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask52_13_16079)">
+<path d="M1760.89 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask53_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask53_13_16079)">
+<path d="M1760.89 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask54_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask54_13_16079)">
+<path d="M1760.89 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask55_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask55_13_16079)">
+<path d="M1760.89 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask56_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask56_13_16079)">
+<path d="M1745.8 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask57_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask57_13_16079)">
+<path d="M1745.8 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask58_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask58_13_16079)">
+<path d="M1745.8 810.532L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask59_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask59_13_16079)">
+<path d="M1740.28 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask60_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask60_13_16079)">
+<path d="M1740.28 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask61_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask61_13_16079)">
+<path d="M1740.28 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask62_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask62_13_16079)">
+<path d="M1740.28 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask63_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask63_13_16079)">
+<path d="M1745.8 852.508L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask64_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask64_13_16079)">
+<path d="M1745.8 852.508L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask65_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask65_13_16079)">
+<path d="M1745.8 852.508L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask66_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask66_13_16079)">
+<path d="M1745.8 852.508L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask67_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask67_13_16079)">
+<mask id="mask68_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1817" y="826" width="11" height="11">
+<path d="M1817.77 836.568H1827.68V826.472H1817.77V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask68_13_16079)">
+<path d="M1822.72 836.045C1823.9 836.045 1825.03 835.568 1825.87 834.72C1826.7 833.871 1827.17 832.72 1827.17 831.52C1827.17 830.32 1826.7 829.168 1825.87 828.32C1825.03 827.471 1823.9 826.994 1822.72 826.994C1821.54 826.994 1820.41 827.471 1819.58 828.32C1818.75 829.168 1818.28 830.32 1818.28 831.52C1818.28 832.72 1818.75 833.871 1819.58 834.72C1820.41 835.568 1821.54 836.045 1822.72 836.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask69_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask69_13_16079)">
+<mask id="mask70_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="805" width="11" height="11">
+<path d="M1812.24 815.58H1822.16V805.484H1812.24V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask70_13_16079)">
+<path d="M1817.2 815.057C1818.38 815.057 1819.51 814.58 1820.34 813.732C1821.18 812.883 1821.64 811.732 1821.64 810.532C1821.64 809.332 1821.18 808.181 1820.34 807.332C1819.51 806.483 1818.38 806.007 1817.2 806.007C1816.02 806.007 1814.89 806.483 1814.06 807.332C1813.22 808.181 1812.76 809.332 1812.76 810.532C1812.76 811.732 1813.22 812.883 1814.06 813.732C1814.89 814.58 1816.02 815.057 1817.2 815.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask71_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask71_13_16079)">
+<mask id="mask72_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="790" width="11" height="11">
+<path d="M1797.15 800.215H1807.07V790.12H1797.15V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask72_13_16079)">
+<path d="M1802.11 799.693C1803.29 799.693 1804.42 799.216 1805.25 798.367C1806.09 797.519 1806.56 796.368 1806.56 795.168C1806.56 793.967 1806.09 792.816 1805.25 791.968C1804.42 791.119 1803.29 790.642 1802.11 790.642C1800.93 790.642 1799.8 791.119 1798.97 791.968C1798.14 792.816 1797.67 793.967 1797.67 795.168C1797.67 796.368 1798.14 797.519 1798.97 798.367C1799.8 799.216 1800.93 799.693 1802.11 799.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask73_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask73_13_16079)">
+<mask id="mask74_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="784" width="11" height="11">
+<path d="M1776.54 794.592H1786.46V784.496H1776.54V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask74_13_16079)">
+<path d="M1781.5 794.069C1782.68 794.069 1783.81 793.592 1784.64 792.744C1785.48 791.895 1785.95 790.744 1785.95 789.544C1785.95 788.344 1785.48 787.193 1784.64 786.344C1783.81 785.495 1782.68 785.019 1781.5 785.019C1780.32 785.019 1779.19 785.495 1778.36 786.344C1777.53 787.193 1777.06 788.344 1777.06 789.544C1777.06 790.744 1777.53 791.895 1778.36 792.744C1779.19 793.592 1780.32 794.069 1781.5 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask75_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask75_13_16079)">
+<mask id="mask76_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="790" width="11" height="11">
+<path d="M1755.93 800.215H1765.85V790.12H1755.93V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask76_13_16079)">
+<path d="M1760.89 799.693C1762.07 799.693 1763.2 799.216 1764.03 798.367C1764.87 797.519 1765.33 796.368 1765.33 795.168C1765.33 793.967 1764.87 792.816 1764.03 791.968C1763.2 791.119 1762.07 790.642 1760.89 790.642C1759.71 790.642 1758.58 791.119 1757.75 791.968C1756.91 792.816 1756.45 793.967 1756.45 795.168C1756.45 796.368 1756.91 797.519 1757.75 798.367C1758.58 799.216 1759.71 799.693 1760.89 799.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask77_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask77_13_16079)">
+<mask id="mask78_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="805" width="11" height="11">
+<path d="M1740.85 815.58H1750.76V805.484H1740.85V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask78_13_16079)">
+<path d="M1745.8 815.057C1746.98 815.057 1748.11 814.58 1748.94 813.732C1749.78 812.883 1750.25 811.732 1750.25 810.532C1750.25 809.332 1749.78 808.181 1748.94 807.332C1748.11 806.483 1746.98 806.007 1745.8 806.007C1744.62 806.007 1743.49 806.483 1742.66 807.332C1741.83 808.181 1741.36 809.332 1741.36 810.532C1741.36 811.732 1741.83 812.883 1742.66 813.732C1743.49 814.58 1744.62 815.057 1745.8 815.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask79_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask79_13_16079)">
+<mask id="mask80_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1735" y="826" width="11" height="11">
+<path d="M1735.32 836.568H1745.24V826.472H1735.32V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask80_13_16079)">
+<path d="M1740.28 836.045C1741.46 836.045 1742.59 835.568 1743.42 834.72C1744.26 833.871 1744.72 832.72 1744.72 831.52C1744.72 830.32 1744.26 829.168 1743.42 828.32C1742.59 827.471 1741.46 826.994 1740.28 826.994C1739.1 826.994 1737.97 827.471 1737.14 828.32C1736.3 829.168 1735.84 830.32 1735.84 831.52C1735.84 832.72 1736.3 833.871 1737.14 834.72C1737.97 835.568 1739.1 836.045 1740.28 836.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask81_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask81_13_16079)">
+<mask id="mask82_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="847" width="11" height="11">
+<path d="M1740.85 857.555H1750.76V847.46H1740.85V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask82_13_16079)">
+<path d="M1745.8 857.033C1746.98 857.033 1748.11 856.556 1748.94 855.708C1749.78 854.859 1750.25 853.708 1750.25 852.508C1750.25 851.308 1749.78 850.156 1748.94 849.308C1748.11 848.459 1746.98 847.982 1745.8 847.982C1744.62 847.982 1743.49 848.459 1742.66 849.308C1741.83 850.156 1741.36 851.308 1741.36 852.508C1741.36 853.708 1741.83 854.859 1742.66 855.708C1743.49 856.556 1744.62 857.033 1745.8 857.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask83_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask83_13_16079)">
+<mask id="mask84_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="862" width="11" height="11">
+<path d="M1755.93 872.92H1765.85V862.824H1755.93V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask84_13_16079)">
+<path d="M1760.89 872.397C1762.07 872.397 1763.2 871.92 1764.03 871.072C1764.87 870.223 1765.33 869.072 1765.33 867.872C1765.33 866.672 1764.87 865.521 1764.03 864.672C1763.2 863.823 1762.07 863.347 1760.89 863.347C1759.71 863.347 1758.58 863.823 1757.75 864.672C1756.91 865.521 1756.45 866.672 1756.45 867.872C1756.45 869.072 1756.91 870.223 1757.75 871.072C1758.58 871.92 1759.71 872.397 1760.89 872.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask85_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask85_13_16079)">
+<mask id="mask86_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="868" width="11" height="11">
+<path d="M1776.54 878.543H1786.46V868.448H1776.54V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask86_13_16079)">
+<path d="M1781.5 878.021C1782.68 878.021 1783.81 877.544 1784.64 876.695C1785.48 875.847 1785.95 874.696 1785.95 873.496C1785.95 872.295 1785.48 871.144 1784.64 870.296C1783.81 869.447 1782.68 868.97 1781.5 868.97C1780.32 868.97 1779.19 869.447 1778.36 870.296C1777.53 871.144 1777.06 872.295 1777.06 873.496C1777.06 874.696 1777.53 875.847 1778.36 876.695C1779.19 877.544 1780.32 878.021 1781.5 878.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask87_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask87_13_16079)">
+<mask id="mask88_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="862" width="11" height="11">
+<path d="M1797.15 872.92H1807.07V862.824H1797.15V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask88_13_16079)">
+<path d="M1802.11 872.397C1803.29 872.397 1804.42 871.92 1805.25 871.072C1806.09 870.223 1806.56 869.072 1806.56 867.872C1806.56 866.672 1806.09 865.521 1805.25 864.672C1804.42 863.823 1803.29 863.347 1802.11 863.347C1800.93 863.347 1799.8 863.823 1798.97 864.672C1798.14 865.521 1797.67 866.672 1797.67 867.872C1797.67 869.072 1798.14 870.223 1798.97 871.072C1799.8 871.92 1800.93 872.397 1802.11 872.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask89_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask89_13_16079)">
+<mask id="mask90_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="847" width="11" height="11">
+<path d="M1812.24 857.555H1822.16V847.46H1812.24V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask90_13_16079)">
+<path d="M1817.2 857.033C1818.38 857.033 1819.51 856.556 1820.34 855.708C1821.18 854.859 1821.64 853.708 1821.64 852.508C1821.64 851.308 1821.18 850.156 1820.34 849.308C1819.51 848.459 1818.38 847.982 1817.2 847.982C1816.02 847.982 1814.89 848.459 1814.06 849.308C1813.22 850.156 1812.76 851.308 1812.76 852.508C1812.76 853.708 1813.22 854.859 1814.06 855.708C1814.89 856.556 1816.02 857.033 1817.2 857.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask91_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask91_13_16079)">
+<path d="M1822.77 828.274C1822.36 828.274 1822.07 828.389 1821.79 828.642C1821.39 829.057 1821.12 829.885 1821.12 830.737C1821.12 831.542 1821.34 832.394 1821.68 832.808C1821.95 833.13 1822.31 833.291 1822.72 833.291C1823.08 833.291 1823.4 833.176 1823.65 832.923C1824.08 832.532 1824.35 831.68 1824.35 830.783C1824.35 829.287 1823.69 828.274 1822.77 828.274ZM1822.74 828.458C1823.33 828.458 1823.65 829.287 1823.65 830.806C1823.65 832.325 1823.35 833.107 1822.72 833.107C1822.11 833.107 1821.79 832.325 1821.79 830.806C1821.79 829.264 1822.11 828.458 1822.74 828.458Z" fill="white"/>
+</g>
+<mask id="mask92_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask92_13_16079)">
+<path d="M1817.49 807.291L1816.2 807.959V808.051C1816.29 808.005 1816.36 807.982 1816.4 807.982C1816.52 807.913 1816.65 807.89 1816.72 807.89C1816.88 807.89 1816.95 808.005 1816.95 808.235V811.549C1816.95 811.779 1816.88 811.94 1816.77 812.009C1816.65 812.078 1816.56 812.101 1816.25 812.101V812.216H1818.24V812.101C1817.67 812.101 1817.56 812.032 1817.56 811.687V807.291H1817.49Z" fill="white"/>
+</g>
+<mask id="mask93_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask93_13_16079)">
+<path d="M1803.74 795.859L1803.62 795.813C1803.38 796.228 1803.29 796.297 1802.95 796.297H1801.25L1802.45 795.008C1803.08 794.34 1803.35 793.788 1803.35 793.213C1803.35 792.476 1802.79 791.924 1802.04 791.924C1801.64 791.924 1801.27 792.085 1801 792.361C1800.78 792.614 1800.66 792.844 1800.55 793.374L1800.69 793.397C1800.98 792.683 1801.25 792.453 1801.73 792.453C1802.34 792.453 1802.74 792.868 1802.74 793.489C1802.74 794.064 1802.43 794.732 1801.82 795.376L1800.55 796.757V796.849H1803.33L1803.74 795.859Z" fill="white"/>
+</g>
+<mask id="mask94_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask94_13_16079)">
+<path d="M1780.82 788.811C1781.23 788.811 1781.39 788.834 1781.57 788.903C1782.02 789.065 1782.29 789.479 1782.29 789.985C1782.29 790.583 1781.88 791.067 1781.36 791.067C1781.16 791.067 1781.02 791.021 1780.75 790.837C1780.53 790.698 1780.41 790.652 1780.3 790.652C1780.12 790.652 1780.03 790.768 1780.03 790.906C1780.03 791.159 1780.32 791.32 1780.82 791.32C1781.39 791.32 1781.95 791.136 1782.29 790.837C1782.63 790.537 1782.81 790.123 1782.81 789.64C1782.81 789.249 1782.7 788.926 1782.49 788.696C1782.33 788.535 1782.2 788.443 1781.88 788.305C1782.38 787.96 1782.56 787.684 1782.56 787.292C1782.56 786.694 1782.11 786.303 1781.45 786.303C1781.09 786.303 1780.78 786.418 1780.53 786.648C1780.3 786.855 1780.19 787.039 1780.03 787.477L1780.14 787.5C1780.44 786.97 1780.75 786.74 1781.2 786.74C1781.68 786.74 1782 787.062 1782 787.523C1782 787.776 1781.88 788.029 1781.7 788.213C1781.5 788.443 1781.3 788.558 1780.82 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask95_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask95_13_16079)">
+<path d="M1762.49 795.169H1761.75V791.924H1761.43L1759.19 795.169V795.629H1761.2V796.849H1761.75V795.629H1762.49V795.169ZM1761.2 795.169H1759.46L1761.2 792.66V795.169Z" fill="white"/>
+</g>
+<mask id="mask96_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask96_13_16079)">
+<path d="M1745.3 807.959H1746.72C1746.84 807.959 1746.86 807.959 1746.88 807.89L1747.15 807.245L1747.08 807.199C1746.97 807.36 1746.9 807.383 1746.75 807.383H1745.25L1744.49 809.109C1744.46 809.132 1744.46 809.132 1744.46 809.156C1744.46 809.179 1744.51 809.202 1744.55 809.202C1744.78 809.202 1745.07 809.271 1745.37 809.363C1746.18 809.616 1746.56 810.076 1746.56 810.812C1746.56 811.503 1746.13 812.055 1745.57 812.055C1745.43 812.055 1745.3 811.986 1745.1 811.848C1744.87 811.664 1744.69 811.595 1744.55 811.595C1744.35 811.595 1744.24 811.687 1744.24 811.871C1744.24 812.147 1744.58 812.308 1745.12 812.308C1745.71 812.308 1746.23 812.124 1746.59 811.756C1746.93 811.411 1747.06 810.997 1747.06 810.444C1747.06 809.915 1746.93 809.593 1746.56 809.225C1746.27 808.902 1745.84 808.741 1745 808.58L1745.3 807.959Z" fill="white"/>
+</g>
+<mask id="mask97_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask97_13_16079)">
+<path d="M1741.68 828.205C1740.86 828.274 1740.46 828.412 1739.94 828.803C1739.15 829.356 1738.74 830.184 1738.74 831.174C1738.74 831.795 1738.92 832.44 1739.24 832.808C1739.51 833.13 1739.89 833.291 1740.34 833.291C1741.22 833.291 1741.84 832.601 1741.84 831.611C1741.84 830.668 1741.32 830.069 1740.5 830.069C1740.19 830.069 1740.03 830.138 1739.58 830.414C1739.78 829.31 1740.57 828.504 1741.7 828.32L1741.68 828.205ZM1740.23 830.414C1740.84 830.414 1741.2 830.944 1741.2 831.841C1741.2 832.647 1740.91 833.107 1740.41 833.107C1739.78 833.107 1739.39 832.417 1739.39 831.289C1739.39 830.898 1739.46 830.714 1739.6 830.599C1739.76 830.483 1739.98 830.414 1740.23 830.414Z" fill="white"/>
+</g>
+<mask id="mask98_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask98_13_16079)">
+<path d="M1747.22 849.355H1744.58L1744.15 850.436L1744.28 850.482C1744.58 849.999 1744.71 849.907 1745.12 849.907H1746.65L1745.25 854.257H1745.71L1747.22 849.47V849.355Z" fill="white"/>
+</g>
+<mask id="mask99_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask99_13_16079)">
+<path d="M1761.18 866.839C1761.88 866.471 1762.13 866.149 1762.13 865.666C1762.13 865.067 1761.63 864.63 1760.91 864.63C1760.12 864.63 1759.55 865.113 1759.55 865.781C1759.55 866.241 1759.69 866.471 1760.44 867.139C1759.67 867.737 1759.51 867.967 1759.51 868.45C1759.51 869.164 1760.07 869.647 1760.89 869.647C1761.75 869.647 1762.29 869.187 1762.29 868.427C1762.29 867.852 1762.04 867.507 1761.18 866.839ZM1761.05 867.599C1761.57 867.99 1761.75 868.243 1761.75 868.657C1761.75 869.118 1761.43 869.463 1760.95 869.463C1760.41 869.463 1760.05 869.026 1760.05 868.404C1760.05 867.921 1760.21 867.622 1760.62 867.277L1761.05 867.599ZM1760.98 866.724C1760.34 866.287 1760.07 865.965 1760.07 865.551C1760.07 865.136 1760.39 864.837 1760.84 864.837C1761.34 864.837 1761.66 865.159 1761.66 865.643C1761.66 866.057 1761.45 866.402 1761.05 866.678C1761 866.701 1761 866.701 1760.98 866.724Z" fill="white"/>
+</g>
+<mask id="mask100_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask100_13_16079)">
+<path d="M1780.14 875.337C1780.93 875.245 1781.34 875.107 1781.81 874.739C1782.56 874.187 1783.01 873.289 1783.01 872.299C1783.01 871.103 1782.33 870.251 1781.41 870.251C1780.57 870.251 1779.94 870.988 1779.94 871.977C1779.94 872.852 1780.44 873.45 1781.23 873.45C1781.61 873.45 1781.91 873.335 1782.29 873.036C1782 874.21 1781.2 874.992 1780.12 875.199L1780.14 875.337ZM1782.31 872.576C1782.31 872.737 1782.27 872.806 1782.2 872.875C1782 873.036 1781.72 873.128 1781.48 873.128C1780.93 873.128 1780.59 872.576 1780.59 871.724C1780.59 871.31 1780.71 870.873 1780.84 870.665C1780.98 870.527 1781.16 870.458 1781.36 870.458C1781.97 870.458 1782.31 871.08 1782.31 872.299V872.576Z" fill="white"/>
+</g>
+<mask id="mask101_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask101_13_16079)">
+<path d="M1800.61 864.63L1799.32 865.297V865.39C1799.41 865.343 1799.48 865.32 1799.53 865.32C1799.64 865.251 1799.78 865.228 1799.84 865.228C1800 865.228 1800.07 865.343 1800.07 865.574V868.888C1800.07 869.118 1800 869.279 1799.89 869.348C1799.78 869.417 1799.69 869.44 1799.37 869.44V869.555H1801.36V869.44C1800.79 869.44 1800.68 869.371 1800.68 869.026V864.63H1800.61ZM1803.94 864.63C1803.53 864.63 1803.24 864.745 1802.97 864.998C1802.56 865.413 1802.29 866.241 1802.29 867.093C1802.29 867.898 1802.52 868.75 1802.86 869.164C1803.13 869.486 1803.49 869.647 1803.9 869.647C1804.26 869.647 1804.57 869.532 1804.82 869.279C1805.25 868.888 1805.52 868.036 1805.52 867.139C1805.52 865.643 1804.87 864.63 1803.94 864.63ZM1803.92 864.814C1804.51 864.814 1804.82 865.643 1804.82 867.162C1804.82 868.68 1804.53 869.463 1803.9 869.463C1803.29 869.463 1802.97 868.68 1802.97 867.162C1802.97 865.62 1803.29 864.814 1803.92 864.814Z" fill="white"/>
+</g>
+<mask id="mask102_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask102_13_16079)">
+<path d="M1815.7 849.263L1814.41 849.93V850.022C1814.5 849.976 1814.57 849.953 1814.61 849.953C1814.73 849.884 1814.86 849.861 1814.93 849.861C1815.09 849.861 1815.16 849.976 1815.16 850.206V853.52C1815.16 853.75 1815.09 853.911 1814.98 853.981C1814.86 854.05 1814.77 854.073 1814.46 854.073V854.188H1816.44V854.073C1815.88 854.073 1815.77 854.004 1815.77 853.658V849.263H1815.7ZM1819.28 849.263L1817.99 849.93V850.022C1818.08 849.976 1818.15 849.953 1818.2 849.953C1818.31 849.884 1818.44 849.861 1818.51 849.861C1818.67 849.861 1818.74 849.976 1818.74 850.206V853.52C1818.74 853.75 1818.67 853.911 1818.56 853.981C1818.44 854.05 1818.35 854.073 1818.04 854.073V854.188H1820.03V854.073C1819.46 854.073 1819.35 854.004 1819.35 853.658V849.263H1819.28Z" fill="white"/>
+</g>
+</g>
+<g clip-path="url(#clip0_13_16079)">
+<path d="M1160.83 590.958V383H1152V600H1364V590.958H1160.83Z" fill="#E6711C"/>
+<path d="M1364 464.375H1324.25V572.875H1364V464.375Z" fill="#E6711C"/>
+<path d="M1315.42 482.775H1275.67V572.875H1315.42V482.775Z" fill="#E6711C"/>
+<path d="M1266.83 534.367H1227.08V572.884H1266.83V534.367Z" fill="#E6711C"/>
+<path d="M1218.25 512.26H1178.5V572.884H1218.25V512.26Z" fill="#E6711C"/>
+</g>
+<g clip-path="url(#clip1_13_16079)">
+<path d="M569.958 700.042V609H566V704H661V700.042H569.958Z" fill="#F9D925"/>
+<path d="M661 644.625H643.188V692.125H661V644.625Z" fill="#F9D925"/>
+<path d="M639.229 652.68H621.417V692.125H639.229V652.68Z" fill="#F9D925"/>
+<path d="M617.458 675.267H599.646V692.129H617.458V675.267Z" fill="#F9D925"/>
+<path d="M595.687 665.588H577.875V692.129H595.687V665.588Z" fill="#F9D925"/>
+</g>
+<path d="M569.958 441.042V350H566V445H661V441.042H569.958Z" fill="#E6711C"/>
+<path d="M661 385.625H643.188V433.125H661V385.625Z" fill="#E6711C"/>
+<path d="M639.229 393.68H621.417V433.125H639.229V393.68Z" fill="#E6711C"/>
+<path d="M617.458 416.267H599.646V433.129H617.458V416.267Z" fill="#E6711C"/>
+<path d="M595.687 406.588H577.875V433.129H595.687V406.588Z" fill="#E6711C"/>
+<path d="M569.958 571.042V480H566V575H661V571.042H569.958Z" fill="#5C0B4D"/>
+<path d="M661 515.625H643.188V563.125H661V515.625Z" fill="#5C0B4D"/>
+<path d="M639.229 523.68H621.417V563.125H639.229V523.68Z" fill="#5C0B4D"/>
+<path d="M617.458 546.267H599.646V563.129H617.458V546.267Z" fill="#5C0B4D"/>
+<path d="M595.687 536.588H577.875V563.129H595.687V536.588Z" fill="#5C0B4D"/>
+<g clip-path="url(#clip2_13_16079)">
+<path d="M1664.83 590.958V383H1656V600H1868V590.958H1664.83Z" fill="#5C0B4D"/>
+<path d="M1868 464.375H1828.25V572.875H1868V464.375Z" fill="#5C0B4D"/>
+<path d="M1819.42 482.775H1779.67V572.875H1819.42V482.775Z" fill="#5C0B4D"/>
+<path d="M1770.83 534.367H1731.08V572.884H1770.83V534.367Z" fill="#5C0B4D"/>
+<path d="M1722.25 512.26H1682.5V572.884H1722.25V512.26Z" fill="#5C0B4D"/>
+</g>
+<path d="M1154.25 655V628.818H1164.58C1166.56 628.818 1168.26 629.197 1169.65 629.956C1171.05 630.706 1172.12 631.75 1172.85 633.088C1173.59 634.418 1173.96 635.952 1173.96 637.69C1173.96 639.429 1173.59 640.963 1172.84 642.293C1172.09 643.622 1171 644.658 1169.58 645.399C1168.16 646.141 1166.45 646.511 1164.44 646.511H1157.85V642.075H1163.54C1164.61 642.075 1165.49 641.892 1166.18 641.526C1166.88 641.151 1167.4 640.635 1167.74 639.979C1168.09 639.314 1168.26 638.551 1168.26 637.69C1168.26 636.821 1168.09 636.062 1167.74 635.415C1167.4 634.759 1166.88 634.251 1166.18 633.893C1165.48 633.527 1164.59 633.344 1163.52 633.344H1159.78V655H1154.25ZM1185.37 655.384C1183.35 655.384 1181.61 654.974 1180.15 654.156C1178.7 653.33 1177.59 652.162 1176.8 650.653C1176.02 649.136 1175.63 647.342 1175.63 645.271C1175.63 643.251 1176.02 641.479 1176.8 639.953C1177.59 638.428 1178.69 637.239 1180.11 636.386C1181.55 635.534 1183.22 635.108 1185.15 635.108C1186.45 635.108 1187.65 635.317 1188.77 635.734C1189.89 636.143 1190.87 636.761 1191.71 637.588C1192.55 638.415 1193.21 639.455 1193.68 640.707C1194.15 641.952 1194.38 643.409 1194.38 645.08V646.575H1177.8V643.2H1189.25C1189.25 642.416 1189.08 641.722 1188.74 641.116C1188.4 640.511 1187.93 640.038 1187.32 639.697C1186.73 639.348 1186.03 639.173 1185.24 639.173C1184.41 639.173 1183.68 639.365 1183.04 639.749C1182.41 640.124 1181.92 640.631 1181.56 641.27C1181.2 641.901 1181.02 642.604 1181.01 643.379V646.588C1181.01 647.56 1181.19 648.399 1181.55 649.107C1181.91 649.814 1182.43 650.359 1183.09 650.743C1183.76 651.126 1184.55 651.318 1185.46 651.318C1186.06 651.318 1186.62 651.233 1187.12 651.062C1187.62 650.892 1188.05 650.636 1188.41 650.295C1188.77 649.955 1189.04 649.537 1189.23 649.043L1194.27 649.375C1194.01 650.585 1193.49 651.642 1192.69 652.545C1191.91 653.44 1190.9 654.139 1189.65 654.642C1188.41 655.136 1186.99 655.384 1185.37 655.384ZM1197.21 655V635.364H1202.49V638.79H1202.7C1203.06 637.571 1203.66 636.651 1204.5 636.028C1205.35 635.398 1206.32 635.082 1207.42 635.082C1207.69 635.082 1207.98 635.099 1208.3 635.134C1208.61 635.168 1208.89 635.214 1209.13 635.274V640.107C1208.87 640.03 1208.52 639.962 1208.07 639.902C1207.62 639.842 1207.2 639.812 1206.83 639.812C1206.03 639.812 1205.31 639.987 1204.68 640.337C1204.06 640.678 1203.56 641.155 1203.2 641.768C1202.84 642.382 1202.66 643.089 1202.66 643.891V655H1197.21ZM1222.77 635.364V639.455H1210.65V635.364H1222.77ZM1213.42 655V633.945C1213.42 632.521 1213.7 631.341 1214.26 630.403C1214.82 629.466 1215.58 628.763 1216.56 628.294C1217.53 627.825 1218.63 627.591 1219.87 627.591C1220.7 627.591 1221.47 627.655 1222.16 627.783C1222.85 627.911 1223.37 628.026 1223.72 628.128L1222.74 632.219C1222.53 632.151 1222.27 632.087 1221.95 632.027C1221.64 631.967 1221.33 631.938 1221.01 631.938C1220.2 631.938 1219.65 632.125 1219.33 632.5C1219.02 632.866 1218.86 633.382 1218.86 634.047V655H1213.42ZM1233.55 655.384C1231.56 655.384 1229.84 654.962 1228.39 654.118C1226.95 653.266 1225.84 652.081 1225.06 650.564C1224.27 649.038 1223.88 647.27 1223.88 645.259C1223.88 643.23 1224.27 641.457 1225.06 639.94C1225.84 638.415 1226.95 637.23 1228.39 636.386C1229.84 635.534 1231.56 635.108 1233.55 635.108C1235.53 635.108 1237.24 635.534 1238.68 636.386C1240.13 637.23 1241.25 638.415 1242.03 639.94C1242.82 641.457 1243.21 643.23 1243.21 645.259C1243.21 647.27 1242.82 649.038 1242.03 650.564C1241.25 652.081 1240.13 653.266 1238.68 654.118C1237.24 654.962 1235.53 655.384 1233.55 655.384ZM1233.57 651.165C1234.47 651.165 1235.23 650.909 1235.83 650.398C1236.44 649.878 1236.89 649.17 1237.2 648.276C1237.52 647.381 1237.67 646.362 1237.67 645.22C1237.67 644.078 1237.52 643.06 1237.2 642.165C1236.89 641.27 1236.44 640.562 1235.83 640.043C1235.23 639.523 1234.47 639.263 1233.57 639.263C1232.66 639.263 1231.89 639.523 1231.27 640.043C1230.66 640.562 1230.19 641.27 1229.88 642.165C1229.57 643.06 1229.42 644.078 1229.42 645.22C1229.42 646.362 1229.57 647.381 1229.88 648.276C1230.19 649.17 1230.66 649.878 1231.27 650.398C1231.89 650.909 1232.66 651.165 1233.57 651.165ZM1246.03 655V635.364H1251.31V638.79H1251.52C1251.87 637.571 1252.47 636.651 1253.32 636.028C1254.16 635.398 1255.13 635.082 1256.23 635.082C1256.51 635.082 1256.8 635.099 1257.12 635.134C1257.43 635.168 1257.71 635.214 1257.95 635.274V640.107C1257.69 640.03 1257.34 639.962 1256.89 639.902C1256.43 639.842 1256.02 639.812 1255.64 639.812C1254.84 639.812 1254.13 639.987 1253.5 640.337C1252.88 640.678 1252.38 641.155 1252.01 641.768C1251.66 642.382 1251.48 643.089 1251.48 643.891V655H1246.03ZM1260.04 655V635.364H1265.23V638.828H1265.46C1265.87 637.678 1266.55 636.77 1267.51 636.105C1268.46 635.44 1269.6 635.108 1270.93 635.108C1272.28 635.108 1273.43 635.445 1274.37 636.118C1275.32 636.783 1275.95 637.686 1276.26 638.828H1276.47C1276.87 637.703 1277.59 636.804 1278.64 636.131C1279.7 635.449 1280.95 635.108 1282.39 635.108C1284.22 635.108 1285.71 635.692 1286.85 636.859C1288 638.018 1288.58 639.663 1288.58 641.794V655H1283.14V642.868C1283.14 641.777 1282.85 640.959 1282.27 640.413C1281.69 639.868 1280.97 639.595 1280.1 639.595C1279.11 639.595 1278.34 639.911 1277.79 640.541C1277.23 641.163 1276.96 641.986 1276.96 643.009V655H1271.68V642.753C1271.68 641.79 1271.4 641.023 1270.84 640.452C1270.3 639.881 1269.58 639.595 1268.68 639.595C1268.08 639.595 1267.53 639.749 1267.05 640.055C1266.57 640.354 1266.19 640.776 1265.91 641.321C1265.63 641.858 1265.49 642.489 1265.49 643.213V655H1260.04ZM1297.76 655.371C1296.5 655.371 1295.39 655.153 1294.41 654.719C1293.43 654.276 1292.65 653.624 1292.08 652.763C1291.52 651.893 1291.24 650.811 1291.24 649.516C1291.24 648.425 1291.44 647.509 1291.84 646.767C1292.24 646.026 1292.78 645.429 1293.47 644.977C1294.16 644.526 1294.95 644.185 1295.83 643.955C1296.71 643.724 1297.64 643.562 1298.61 643.469C1299.76 643.349 1300.68 643.239 1301.38 643.136C1302.07 643.026 1302.58 642.864 1302.9 642.651C1303.21 642.437 1303.37 642.122 1303.37 641.705V641.628C1303.37 640.818 1303.11 640.192 1302.6 639.749C1302.1 639.305 1301.38 639.084 1300.45 639.084C1299.47 639.084 1298.69 639.301 1298.12 639.736C1297.54 640.162 1297.15 640.699 1296.96 641.347L1291.93 640.938C1292.18 639.744 1292.69 638.713 1293.44 637.844C1294.19 636.966 1295.15 636.293 1296.34 635.824C1297.53 635.347 1298.91 635.108 1300.48 635.108C1301.57 635.108 1302.62 635.236 1303.61 635.491C1304.62 635.747 1305.51 636.143 1306.28 636.68C1307.07 637.217 1307.69 637.908 1308.14 638.751C1308.59 639.587 1308.82 640.588 1308.82 641.756V655H1303.65V652.277H1303.5C1303.18 652.891 1302.76 653.432 1302.23 653.901C1301.7 654.361 1301.07 654.723 1300.33 654.987C1299.59 655.243 1298.73 655.371 1297.76 655.371ZM1299.32 651.612C1300.12 651.612 1300.83 651.455 1301.44 651.139C1302.05 650.815 1302.53 650.381 1302.88 649.835C1303.23 649.29 1303.41 648.672 1303.41 647.982V645.898C1303.24 646.009 1303 646.111 1302.7 646.205C1302.41 646.29 1302.09 646.371 1301.72 646.447C1301.35 646.516 1300.99 646.58 1300.62 646.639C1300.25 646.69 1299.92 646.737 1299.62 646.78C1298.98 646.874 1298.43 647.023 1297.95 647.227C1297.47 647.432 1297.1 647.709 1296.84 648.058C1296.57 648.399 1296.44 648.825 1296.44 649.337C1296.44 650.078 1296.71 650.645 1297.25 651.037C1297.79 651.42 1298.48 651.612 1299.32 651.612ZM1317.77 643.648V655H1312.32V635.364H1317.51V638.828H1317.74C1318.18 637.686 1318.9 636.783 1319.93 636.118C1320.95 635.445 1322.19 635.108 1323.65 635.108C1325.01 635.108 1326.2 635.406 1327.21 636.003C1328.23 636.599 1329.02 637.452 1329.58 638.56C1330.14 639.659 1330.42 640.972 1330.42 642.497V655H1324.98V643.469C1324.99 642.267 1324.68 641.33 1324.06 640.656C1323.43 639.974 1322.58 639.634 1321.49 639.634C1320.75 639.634 1320.11 639.791 1319.54 640.107C1318.99 640.422 1318.55 640.882 1318.24 641.487C1317.93 642.084 1317.78 642.804 1317.77 643.648ZM1342.87 655.384C1340.86 655.384 1339.13 654.957 1337.68 654.105C1336.24 653.244 1335.13 652.051 1334.35 650.526C1333.59 649 1333.2 647.244 1333.2 645.259C1333.2 643.247 1333.59 641.483 1334.37 639.966C1335.15 638.44 1336.26 637.251 1337.7 636.399C1339.14 635.538 1340.86 635.108 1342.84 635.108C1344.55 635.108 1346.05 635.419 1347.34 636.041C1348.63 636.663 1349.65 637.537 1350.4 638.662C1351.15 639.787 1351.56 641.108 1351.64 642.625H1346.5C1346.35 641.645 1345.97 640.857 1345.35 640.26C1344.73 639.655 1343.93 639.352 1342.93 639.352C1342.09 639.352 1341.35 639.582 1340.72 640.043C1340.1 640.494 1339.61 641.155 1339.26 642.024C1338.91 642.893 1338.74 643.946 1338.74 645.182C1338.74 646.435 1338.91 647.5 1339.25 648.378C1339.6 649.256 1340.09 649.925 1340.72 650.385C1341.35 650.845 1342.09 651.075 1342.93 651.075C1343.55 651.075 1344.11 650.947 1344.61 650.692C1345.11 650.436 1345.52 650.065 1345.85 649.58C1346.18 649.085 1346.4 648.493 1346.5 647.803H1351.64C1351.55 649.303 1351.14 650.624 1350.41 651.766C1349.69 652.899 1348.68 653.786 1347.41 654.425C1346.13 655.064 1344.61 655.384 1342.87 655.384ZM1363.35 655.384C1361.33 655.384 1359.59 654.974 1358.14 654.156C1356.69 653.33 1355.57 652.162 1354.79 650.653C1354 649.136 1353.61 647.342 1353.61 645.271C1353.61 643.251 1354 641.479 1354.79 639.953C1355.57 638.428 1356.68 637.239 1358.1 636.386C1359.53 635.534 1361.21 635.108 1363.14 635.108C1364.43 635.108 1365.64 635.317 1366.75 635.734C1367.88 636.143 1368.86 636.761 1369.69 637.588C1370.54 638.415 1371.19 639.455 1371.66 640.707C1372.13 641.952 1372.37 643.409 1372.37 645.08V646.575H1355.78V643.2H1367.24C1367.24 642.416 1367.07 641.722 1366.73 641.116C1366.39 640.511 1365.91 640.038 1365.31 639.697C1364.71 639.348 1364.02 639.173 1363.23 639.173C1362.4 639.173 1361.67 639.365 1361.03 639.749C1360.4 640.124 1359.9 640.631 1359.54 641.27C1359.19 641.901 1359 642.604 1358.99 643.379V646.588C1358.99 647.56 1359.17 648.399 1359.53 649.107C1359.9 649.814 1360.41 650.359 1361.08 650.743C1361.74 651.126 1362.53 651.318 1363.44 651.318C1364.05 651.318 1364.6 651.233 1365.1 651.062C1365.61 650.892 1366.04 650.636 1366.4 650.295C1366.75 649.955 1367.03 649.537 1367.21 649.043L1372.25 649.375C1371.99 650.585 1371.47 651.642 1370.68 652.545C1369.89 653.44 1368.88 654.139 1367.64 654.642C1366.4 655.136 1364.97 655.384 1363.35 655.384ZM1146.01 703.32C1144.52 703.32 1143.17 702.936 1141.96 702.169C1140.75 701.393 1139.8 700.256 1139.09 698.756C1138.39 697.247 1138.04 695.398 1138.04 693.207C1138.04 690.957 1138.41 689.087 1139.13 687.595C1139.86 686.095 1140.82 684.974 1142.02 684.233C1143.23 683.483 1144.56 683.108 1146 683.108C1147.1 683.108 1148.01 683.295 1148.74 683.67C1149.49 684.037 1150.08 684.497 1150.53 685.051C1150.99 685.597 1151.34 686.134 1151.58 686.662H1151.75V676.818H1157.18V703H1151.81V699.855H1151.58C1151.33 700.401 1150.96 700.942 1150.5 701.479C1150.04 702.007 1149.44 702.446 1148.69 702.795C1147.96 703.145 1147.07 703.32 1146.01 703.32ZM1147.73 698.986C1148.61 698.986 1149.35 698.747 1149.96 698.27C1150.57 697.784 1151.04 697.107 1151.37 696.237C1151.7 695.368 1151.86 694.349 1151.86 693.182C1151.86 692.014 1151.7 691 1151.38 690.139C1151.05 689.278 1150.59 688.614 1149.97 688.145C1149.36 687.676 1148.61 687.442 1147.73 687.442C1146.84 687.442 1146.09 687.685 1145.47 688.17C1144.86 688.656 1144.39 689.33 1144.08 690.19C1143.76 691.051 1143.61 692.048 1143.61 693.182C1143.61 694.324 1143.76 695.334 1144.08 696.212C1144.4 697.081 1144.87 697.763 1145.47 698.257C1146.09 698.743 1146.84 698.986 1147.73 698.986ZM1160.94 703V683.364H1166.39V703H1160.94ZM1163.68 680.832C1162.87 680.832 1162.17 680.564 1161.59 680.027C1161.02 679.482 1160.74 678.83 1160.74 678.071C1160.74 677.321 1161.02 676.678 1161.59 676.141C1162.17 675.595 1162.87 675.322 1163.68 675.322C1164.49 675.322 1165.18 675.595 1165.75 676.141C1166.33 676.678 1166.62 677.321 1166.62 678.071C1166.62 678.83 1166.33 679.482 1165.75 680.027C1165.18 680.564 1164.49 680.832 1163.68 680.832ZM1186.37 688.963L1181.38 689.27C1181.3 688.844 1181.11 688.46 1180.83 688.119C1180.55 687.77 1180.18 687.493 1179.72 687.288C1179.27 687.075 1178.73 686.969 1178.1 686.969C1177.25 686.969 1176.54 687.148 1175.96 687.506C1175.38 687.855 1175.09 688.324 1175.09 688.912C1175.09 689.381 1175.28 689.777 1175.65 690.101C1176.03 690.425 1176.67 690.685 1177.58 690.881L1181.14 691.597C1183.05 691.989 1184.47 692.619 1185.41 693.489C1186.35 694.358 1186.81 695.5 1186.81 696.915C1186.81 698.202 1186.43 699.331 1185.68 700.303C1184.93 701.274 1183.89 702.033 1182.58 702.578C1181.28 703.115 1179.77 703.384 1178.07 703.384C1175.47 703.384 1173.4 702.842 1171.86 701.76C1170.32 700.669 1169.42 699.186 1169.16 697.311L1174.52 697.03C1174.68 697.822 1175.07 698.428 1175.69 698.845C1176.31 699.254 1177.11 699.459 1178.08 699.459C1179.04 699.459 1179.8 699.276 1180.38 698.909C1180.97 698.534 1181.27 698.053 1181.28 697.464C1181.27 696.97 1181.06 696.565 1180.65 696.25C1180.24 695.926 1179.61 695.679 1178.76 695.509L1175.36 694.831C1173.44 694.447 1172.01 693.783 1171.08 692.837C1170.15 691.891 1169.68 690.685 1169.68 689.219C1169.68 687.957 1170.02 686.871 1170.71 685.959C1171.4 685.047 1172.36 684.344 1173.61 683.849C1174.86 683.355 1176.33 683.108 1178.01 683.108C1180.49 683.108 1182.44 683.632 1183.86 684.68C1185.29 685.729 1186.13 687.156 1186.37 688.963ZM1199.97 683.364V687.455H1188.14V683.364H1199.97ZM1190.83 678.659H1196.27V696.966C1196.27 697.469 1196.35 697.861 1196.5 698.142C1196.66 698.415 1196.87 698.607 1197.14 698.717C1197.42 698.828 1197.75 698.884 1198.11 698.884C1198.37 698.884 1198.63 698.862 1198.88 698.82C1199.14 698.768 1199.33 698.73 1199.47 698.705L1200.33 702.757C1200.05 702.842 1199.67 702.94 1199.18 703.051C1198.68 703.17 1198.08 703.243 1197.37 703.268C1196.06 703.32 1194.91 703.145 1193.92 702.744C1192.94 702.344 1192.18 701.722 1191.63 700.878C1191.09 700.034 1190.82 698.969 1190.83 697.682V678.659ZM1202.8 703V683.364H1208.08V686.79H1208.28C1208.64 685.571 1209.24 684.651 1210.08 684.028C1210.93 683.398 1211.9 683.082 1213 683.082C1213.27 683.082 1213.56 683.099 1213.88 683.134C1214.19 683.168 1214.47 683.214 1214.71 683.274V688.107C1214.45 688.03 1214.1 687.962 1213.65 687.902C1213.2 687.842 1212.78 687.812 1212.41 687.812C1211.61 687.812 1210.89 687.987 1210.26 688.337C1209.64 688.678 1209.14 689.155 1208.78 689.768C1208.42 690.382 1208.24 691.089 1208.24 691.891V703H1202.8ZM1216.81 703V683.364H1222.25V703H1216.81ZM1219.54 680.832C1218.73 680.832 1218.04 680.564 1217.46 680.027C1216.89 679.482 1216.6 678.83 1216.6 678.071C1216.6 677.321 1216.89 676.678 1217.46 676.141C1218.04 675.595 1218.73 675.322 1219.54 675.322C1220.35 675.322 1221.04 675.595 1221.61 676.141C1222.19 676.678 1222.48 677.321 1222.48 678.071C1222.48 678.83 1222.19 679.482 1221.61 680.027C1221.04 680.564 1220.35 680.832 1219.54 680.832ZM1226 703V676.818H1231.44V686.662H1231.61C1231.85 686.134 1232.19 685.597 1232.64 685.051C1233.1 684.497 1233.7 684.037 1234.43 683.67C1235.18 683.295 1236.1 683.108 1237.2 683.108C1238.63 683.108 1239.95 683.483 1241.16 684.233C1242.37 684.974 1243.34 686.095 1244.06 687.595C1244.79 689.087 1245.15 690.957 1245.15 693.207C1245.15 695.398 1244.79 697.247 1244.09 698.756C1243.39 700.256 1242.43 701.393 1241.22 702.169C1240.02 702.936 1238.67 703.32 1237.18 703.32C1236.13 703.32 1235.23 703.145 1234.49 702.795C1233.75 702.446 1233.15 702.007 1232.68 701.479C1232.21 700.942 1231.86 700.401 1231.61 699.855H1231.37V703H1226ZM1231.33 693.182C1231.33 694.349 1231.49 695.368 1231.81 696.237C1232.14 697.107 1232.61 697.784 1233.22 698.27C1233.83 698.747 1234.58 698.986 1235.46 698.986C1236.34 698.986 1237.09 698.743 1237.71 698.257C1238.32 697.763 1238.79 697.081 1239.1 696.212C1239.42 695.334 1239.59 694.324 1239.59 693.182C1239.59 692.048 1239.43 691.051 1239.11 690.19C1238.8 689.33 1238.33 688.656 1237.72 688.17C1237.11 687.685 1236.35 687.442 1235.46 687.442C1234.57 687.442 1233.82 687.676 1233.21 688.145C1232.6 688.614 1232.14 689.278 1231.81 690.139C1231.49 691 1231.33 692.014 1231.33 693.182ZM1260.65 694.639V683.364H1266.1V703H1260.87V699.433H1260.67C1260.22 700.584 1259.49 701.509 1258.45 702.207C1257.43 702.906 1256.18 703.256 1254.71 703.256C1253.4 703.256 1252.24 702.957 1251.24 702.361C1250.25 701.764 1249.47 700.916 1248.91 699.817C1248.35 698.717 1248.07 697.401 1248.06 695.866V683.364H1253.51V694.895C1253.52 696.054 1253.83 696.97 1254.44 697.643C1255.05 698.317 1255.88 698.653 1256.91 698.653C1257.56 698.653 1258.18 698.504 1258.75 698.206C1259.32 697.899 1259.78 697.447 1260.13 696.851C1260.49 696.254 1260.66 695.517 1260.65 694.639ZM1280.18 683.364V687.455H1268.36V683.364H1280.18ZM1271.04 678.659H1276.49V696.966C1276.49 697.469 1276.56 697.861 1276.72 698.142C1276.87 698.415 1277.08 698.607 1277.36 698.717C1277.64 698.828 1277.96 698.884 1278.33 698.884C1278.58 698.884 1278.84 698.862 1279.09 698.82C1279.35 698.768 1279.55 698.73 1279.68 698.705L1280.54 702.757C1280.27 702.842 1279.88 702.94 1279.39 703.051C1278.89 703.17 1278.29 703.243 1277.59 703.268C1276.27 703.32 1275.12 703.145 1274.13 702.744C1273.15 702.344 1272.39 701.722 1271.85 700.878C1271.3 700.034 1271.03 698.969 1271.04 697.682V678.659ZM1283.01 703V683.364H1288.45V703H1283.01ZM1285.74 680.832C1284.93 680.832 1284.24 680.564 1283.66 680.027C1283.09 679.482 1282.8 678.83 1282.8 678.071C1282.8 677.321 1283.09 676.678 1283.66 676.141C1284.24 675.595 1284.93 675.322 1285.74 675.322C1286.55 675.322 1287.24 675.595 1287.81 676.141C1288.39 676.678 1288.68 677.321 1288.68 678.071C1288.68 678.83 1288.39 679.482 1287.81 680.027C1287.24 680.564 1286.55 680.832 1285.74 680.832ZM1300.97 703.384C1298.98 703.384 1297.27 702.962 1295.82 702.118C1294.38 701.266 1293.26 700.081 1292.48 698.564C1291.7 697.038 1291.3 695.27 1291.3 693.259C1291.3 691.23 1291.7 689.457 1292.48 687.94C1293.26 686.415 1294.38 685.23 1295.82 684.386C1297.27 683.534 1298.98 683.108 1300.97 683.108C1302.95 683.108 1304.67 683.534 1306.11 684.386C1307.56 685.23 1308.67 686.415 1309.46 687.94C1310.24 689.457 1310.63 691.23 1310.63 693.259C1310.63 695.27 1310.24 697.038 1309.46 698.564C1308.67 700.081 1307.56 701.266 1306.11 702.118C1304.67 702.962 1302.95 703.384 1300.97 703.384ZM1300.99 699.165C1301.9 699.165 1302.65 698.909 1303.26 698.398C1303.86 697.878 1304.32 697.17 1304.62 696.276C1304.94 695.381 1305.1 694.362 1305.1 693.22C1305.1 692.078 1304.94 691.06 1304.62 690.165C1304.32 689.27 1303.86 688.562 1303.26 688.043C1302.65 687.523 1301.9 687.263 1300.99 687.263C1300.08 687.263 1299.32 687.523 1298.69 688.043C1298.08 688.562 1297.62 689.27 1297.3 690.165C1296.99 691.06 1296.84 692.078 1296.84 693.22C1296.84 694.362 1296.99 695.381 1297.3 696.276C1297.62 697.17 1298.08 697.878 1298.69 698.398C1299.32 698.909 1300.08 699.165 1300.99 699.165ZM1318.9 691.648V703H1313.45V683.364H1318.65V686.828H1318.88C1319.31 685.686 1320.04 684.783 1321.06 684.118C1322.08 683.445 1323.32 683.108 1324.78 683.108C1326.15 683.108 1327.33 683.406 1328.35 684.003C1329.36 684.599 1330.15 685.452 1330.71 686.56C1331.28 687.659 1331.56 688.972 1331.56 690.497V703H1326.11V691.469C1326.12 690.267 1325.81 689.33 1325.19 688.656C1324.57 687.974 1323.71 687.634 1322.62 687.634C1321.89 687.634 1321.24 687.791 1320.68 688.107C1320.12 688.422 1319.69 688.882 1319.37 689.487C1319.07 690.084 1318.91 690.804 1318.9 691.648ZM1353.3 683.364V687.455H1341.18V683.364H1353.3ZM1343.96 703V681.945C1343.96 680.521 1344.23 679.341 1344.79 678.403C1345.35 677.466 1346.12 676.763 1347.09 676.294C1348.06 675.825 1349.16 675.591 1350.4 675.591C1351.23 675.591 1352 675.655 1352.69 675.783C1353.39 675.911 1353.91 676.026 1354.25 676.128L1353.28 680.219C1353.06 680.151 1352.8 680.087 1352.48 680.027C1352.18 679.967 1351.86 679.938 1351.54 679.938C1350.74 679.938 1350.18 680.125 1349.86 680.5C1349.55 680.866 1349.39 681.382 1349.39 682.047V703H1343.96ZM1364.08 703.384C1362.09 703.384 1360.37 702.962 1358.93 702.118C1357.48 701.266 1356.37 700.081 1355.59 698.564C1354.8 697.038 1354.41 695.27 1354.41 693.259C1354.41 691.23 1354.8 689.457 1355.59 687.94C1356.37 686.415 1357.48 685.23 1358.93 684.386C1360.37 683.534 1362.09 683.108 1364.08 683.108C1366.06 683.108 1367.78 683.534 1369.22 684.386C1370.67 685.23 1371.78 686.415 1372.57 687.94C1373.35 689.457 1373.74 691.23 1373.74 693.259C1373.74 695.27 1373.35 697.038 1372.57 698.564C1371.78 700.081 1370.67 701.266 1369.22 702.118C1367.78 702.962 1366.06 703.384 1364.08 703.384ZM1364.1 699.165C1365.01 699.165 1365.76 698.909 1366.37 698.398C1366.97 697.878 1367.43 697.17 1367.73 696.276C1368.05 695.381 1368.21 694.362 1368.21 693.22C1368.21 692.078 1368.05 691.06 1367.73 690.165C1367.43 689.27 1366.97 688.562 1366.37 688.043C1365.76 687.523 1365.01 687.263 1364.1 687.263C1363.19 687.263 1362.42 687.523 1361.8 688.043C1361.19 688.562 1360.72 689.27 1360.41 690.165C1360.1 691.06 1359.95 692.078 1359.95 693.22C1359.95 694.362 1360.1 695.381 1360.41 696.276C1360.72 697.17 1361.19 697.878 1361.8 698.398C1362.42 698.909 1363.19 699.165 1364.1 699.165ZM1376.56 703V683.364H1381.84V686.79H1382.05C1382.41 685.571 1383.01 684.651 1383.85 684.028C1384.69 683.398 1385.67 683.082 1386.76 683.082C1387.04 683.082 1387.33 683.099 1387.65 683.134C1387.96 683.168 1388.24 683.214 1388.48 683.274V688.107C1388.22 688.03 1387.87 687.962 1387.42 687.902C1386.96 687.842 1386.55 687.812 1386.18 687.812C1385.38 687.812 1384.66 687.987 1384.03 688.337C1383.41 688.678 1382.91 689.155 1382.55 689.768C1382.19 690.382 1382.01 691.089 1382.01 691.891V703H1376.56Z" fill="black"/>
+<path d="M1140.14 758.364V731.364H1145.51V734.662H1145.75C1145.99 734.134 1146.33 733.597 1146.78 733.051C1147.24 732.497 1147.84 732.037 1148.57 731.67C1149.32 731.295 1150.24 731.108 1151.34 731.108C1152.77 731.108 1154.09 731.483 1155.3 732.233C1156.51 732.974 1157.48 734.095 1158.2 735.595C1158.92 737.087 1159.29 738.957 1159.29 741.207C1159.29 743.398 1158.93 745.247 1158.23 746.756C1157.53 748.256 1156.57 749.393 1155.36 750.169C1154.16 750.936 1152.81 751.32 1151.32 751.32C1150.27 751.32 1149.37 751.145 1148.63 750.795C1147.89 750.446 1147.29 750.007 1146.82 749.479C1146.35 748.942 1146 748.401 1145.75 747.855H1145.58V758.364H1140.14ZM1145.47 741.182C1145.47 742.349 1145.63 743.368 1145.95 744.237C1146.28 745.107 1146.75 745.784 1147.36 746.27C1147.97 746.747 1148.72 746.986 1149.6 746.986C1150.48 746.986 1151.23 746.743 1151.85 746.257C1152.46 745.763 1152.92 745.081 1153.24 744.212C1153.56 743.334 1153.73 742.324 1153.73 741.182C1153.73 740.048 1153.57 739.051 1153.25 738.19C1152.94 737.33 1152.47 736.656 1151.86 736.17C1151.25 735.685 1150.49 735.442 1149.6 735.442C1148.71 735.442 1147.96 735.676 1147.35 736.145C1146.74 736.614 1146.28 737.278 1145.95 738.139C1145.63 739 1145.47 740.014 1145.47 741.182ZM1171.15 751.384C1169.13 751.384 1167.39 750.974 1165.93 750.156C1164.48 749.33 1163.37 748.162 1162.58 746.653C1161.8 745.136 1161.41 743.342 1161.41 741.271C1161.41 739.251 1161.8 737.479 1162.58 735.953C1163.37 734.428 1164.47 733.239 1165.89 732.386C1167.32 731.534 1169 731.108 1170.93 731.108C1172.22 731.108 1173.43 731.317 1174.55 731.734C1175.67 732.143 1176.65 732.761 1177.49 733.588C1178.33 734.415 1178.99 735.455 1179.46 736.707C1179.93 737.952 1180.16 739.409 1180.16 741.08V742.575H1163.58V739.2H1175.03C1175.03 738.416 1174.86 737.722 1174.52 737.116C1174.18 736.511 1173.71 736.038 1173.1 735.697C1172.51 735.348 1171.81 735.173 1171.02 735.173C1170.19 735.173 1169.46 735.365 1168.82 735.749C1168.19 736.124 1167.69 736.631 1167.34 737.27C1166.98 737.901 1166.8 738.604 1166.79 739.379V742.588C1166.79 743.56 1166.97 744.399 1167.32 745.107C1167.69 745.814 1168.21 746.359 1168.87 746.743C1169.54 747.126 1170.32 747.318 1171.24 747.318C1171.84 747.318 1172.4 747.233 1172.9 747.062C1173.4 746.892 1173.83 746.636 1174.19 746.295C1174.55 745.955 1174.82 745.537 1175.01 745.043L1180.04 745.375C1179.79 746.585 1179.26 747.642 1178.47 748.545C1177.69 749.44 1176.67 750.139 1175.43 750.642C1174.19 751.136 1172.77 751.384 1171.15 751.384ZM1182.99 751V731.364H1188.27V734.79H1188.48C1188.84 733.571 1189.44 732.651 1190.28 732.028C1191.12 731.398 1192.1 731.082 1193.2 731.082C1193.47 731.082 1193.76 731.099 1194.08 731.134C1194.39 731.168 1194.67 731.214 1194.91 731.274V736.107C1194.65 736.03 1194.3 735.962 1193.85 735.902C1193.4 735.842 1192.98 735.812 1192.61 735.812C1191.81 735.812 1191.09 735.987 1190.46 736.337C1189.84 736.678 1189.34 737.155 1188.98 737.768C1188.62 738.382 1188.44 739.089 1188.44 739.891V751H1182.99ZM1208.43 731.364V735.455H1196.61V731.364H1208.43ZM1199.29 726.659H1204.74V744.966C1204.74 745.469 1204.81 745.861 1204.97 746.142C1205.12 746.415 1205.33 746.607 1205.61 746.717C1205.89 746.828 1206.21 746.884 1206.58 746.884C1206.83 746.884 1207.09 746.862 1207.35 746.82C1207.6 746.768 1207.8 746.73 1207.93 746.705L1208.79 750.757C1208.52 750.842 1208.13 750.94 1207.64 751.051C1207.15 751.17 1206.55 751.243 1205.84 751.268C1204.53 751.32 1203.37 751.145 1202.39 750.744C1201.41 750.344 1200.64 749.722 1200.1 748.878C1199.55 748.034 1199.28 746.969 1199.29 745.682V726.659ZM1223.85 742.639V731.364H1229.3V751H1224.07V747.433H1223.87C1223.42 748.584 1222.69 749.509 1221.65 750.207C1220.63 750.906 1219.38 751.256 1217.91 751.256C1216.6 751.256 1215.44 750.957 1214.44 750.361C1213.45 749.764 1212.67 748.916 1212.1 747.817C1211.55 746.717 1211.27 745.401 1211.26 743.866V731.364H1216.71V742.895C1216.71 744.054 1217.03 744.97 1217.64 745.643C1218.25 746.317 1219.08 746.653 1220.11 746.653C1220.76 746.653 1221.38 746.504 1221.95 746.206C1222.52 745.899 1222.98 745.447 1223.33 744.851C1223.69 744.254 1223.86 743.517 1223.85 742.639ZM1232.93 751V731.364H1238.21V734.79H1238.42C1238.78 733.571 1239.38 732.651 1240.22 732.028C1241.07 731.398 1242.04 731.082 1243.14 731.082C1243.41 731.082 1243.7 731.099 1244.02 731.134C1244.33 731.168 1244.61 731.214 1244.85 731.274V736.107C1244.59 736.03 1244.24 735.962 1243.79 735.902C1243.34 735.842 1242.92 735.812 1242.55 735.812C1241.75 735.812 1241.03 735.987 1240.4 736.337C1239.78 736.678 1239.28 737.155 1238.92 737.768C1238.56 738.382 1238.38 739.089 1238.38 739.891V751H1232.93ZM1247.05 751V724.818H1252.49V734.662H1252.66C1252.9 734.134 1253.24 733.597 1253.7 733.051C1254.16 732.497 1254.75 732.037 1255.49 731.67C1256.23 731.295 1257.15 731.108 1258.25 731.108C1259.68 731.108 1261 731.483 1262.21 732.233C1263.42 732.974 1264.39 734.095 1265.11 735.595C1265.84 737.087 1266.2 738.957 1266.2 741.207C1266.2 743.398 1265.84 745.247 1265.14 746.756C1264.44 748.256 1263.48 749.393 1262.27 750.169C1261.07 750.936 1259.73 751.32 1258.23 751.32C1257.18 751.32 1256.28 751.145 1255.54 750.795C1254.8 750.446 1254.2 750.007 1253.73 749.479C1253.27 748.942 1252.91 748.401 1252.66 747.855H1252.42V751H1247.05ZM1252.38 741.182C1252.38 742.349 1252.54 743.368 1252.86 744.237C1253.19 745.107 1253.66 745.784 1254.27 746.27C1254.88 746.747 1255.63 746.986 1256.51 746.986C1257.39 746.986 1258.14 746.743 1258.76 746.257C1259.37 745.763 1259.84 745.081 1260.15 744.212C1260.48 743.334 1260.64 742.324 1260.64 741.182C1260.64 740.048 1260.48 739.051 1260.16 738.19C1259.85 737.33 1259.38 736.656 1258.77 736.17C1258.16 735.685 1257.4 735.442 1256.51 735.442C1255.62 735.442 1254.87 735.676 1254.26 736.145C1253.65 736.614 1253.19 737.278 1252.86 738.139C1252.54 739 1252.38 740.014 1252.38 741.182ZM1274.71 751.371C1273.46 751.371 1272.34 751.153 1271.36 750.719C1270.38 750.276 1269.61 749.624 1269.04 748.763C1268.47 747.893 1268.19 746.811 1268.19 745.516C1268.19 744.425 1268.39 743.509 1268.79 742.767C1269.19 742.026 1269.74 741.429 1270.43 740.977C1271.12 740.526 1271.9 740.185 1272.78 739.955C1273.67 739.724 1274.6 739.562 1275.57 739.469C1276.71 739.349 1277.63 739.239 1278.33 739.136C1279.03 739.026 1279.54 738.864 1279.85 738.651C1280.17 738.437 1280.32 738.122 1280.32 737.705V737.628C1280.32 736.818 1280.07 736.192 1279.56 735.749C1279.05 735.305 1278.34 735.084 1277.41 735.084C1276.43 735.084 1275.65 735.301 1275.07 735.736C1274.49 736.162 1274.11 736.699 1273.92 737.347L1268.88 736.938C1269.14 735.744 1269.64 734.713 1270.39 733.844C1271.14 732.966 1272.11 732.293 1273.29 731.824C1274.49 731.347 1275.87 731.108 1277.43 731.108C1278.53 731.108 1279.57 731.236 1280.57 731.491C1281.57 731.747 1282.46 732.143 1283.24 732.68C1284.02 733.217 1284.64 733.908 1285.09 734.751C1285.54 735.587 1285.77 736.588 1285.77 737.756V751H1280.61V748.277H1280.45C1280.14 748.891 1279.71 749.432 1279.19 749.901C1278.66 750.361 1278.02 750.723 1277.28 750.987C1276.54 751.243 1275.68 751.371 1274.71 751.371ZM1276.27 747.612C1277.07 747.612 1277.78 747.455 1278.39 747.139C1279.01 746.815 1279.49 746.381 1279.84 745.835C1280.19 745.29 1280.36 744.672 1280.36 743.982V741.898C1280.19 742.009 1279.96 742.111 1279.66 742.205C1279.37 742.29 1279.04 742.371 1278.67 742.447C1278.31 742.516 1277.94 742.58 1277.58 742.639C1277.21 742.69 1276.88 742.737 1276.58 742.78C1275.94 742.874 1275.38 743.023 1274.9 743.227C1274.43 743.432 1274.06 743.709 1273.79 744.058C1273.53 744.399 1273.39 744.825 1273.39 745.337C1273.39 746.078 1273.66 746.645 1274.2 747.037C1274.75 747.42 1275.44 747.612 1276.27 747.612ZM1299.72 731.364V735.455H1287.89V731.364H1299.72ZM1290.58 726.659H1296.02V744.966C1296.02 745.469 1296.1 745.861 1296.26 746.142C1296.41 746.415 1296.62 746.607 1296.89 746.717C1297.18 746.828 1297.5 746.884 1297.87 746.884C1298.12 746.884 1298.38 746.862 1298.63 746.82C1298.89 746.768 1299.08 746.73 1299.22 746.705L1300.08 750.757C1299.8 750.842 1299.42 750.94 1298.93 751.051C1298.43 751.17 1297.83 751.243 1297.12 751.268C1295.81 751.32 1294.66 751.145 1293.67 750.744C1292.69 750.344 1291.93 749.722 1291.38 748.878C1290.84 748.034 1290.57 746.969 1290.58 745.682V726.659ZM1302.55 751V731.364H1307.99V751H1302.55ZM1305.28 728.832C1304.47 728.832 1303.78 728.564 1303.2 728.027C1302.63 727.482 1302.34 726.83 1302.34 726.071C1302.34 725.321 1302.63 724.678 1303.2 724.141C1303.78 723.595 1304.47 723.322 1305.28 723.322C1306.09 723.322 1306.78 723.595 1307.35 724.141C1307.93 724.678 1308.22 725.321 1308.22 726.071C1308.22 726.83 1307.93 727.482 1307.35 728.027C1306.78 728.564 1306.09 728.832 1305.28 728.832ZM1320.51 751.384C1318.52 751.384 1316.8 750.962 1315.36 750.118C1313.92 749.266 1312.8 748.081 1312.02 746.564C1311.24 745.038 1310.84 743.27 1310.84 741.259C1310.84 739.23 1311.24 737.457 1312.02 735.94C1312.8 734.415 1313.92 733.23 1315.36 732.386C1316.8 731.534 1318.52 731.108 1320.51 731.108C1322.49 731.108 1324.21 731.534 1325.65 732.386C1327.1 733.23 1328.21 734.415 1329 735.94C1329.78 737.457 1330.17 739.23 1330.17 741.259C1330.17 743.27 1329.78 745.038 1329 746.564C1328.21 748.081 1327.1 749.266 1325.65 750.118C1324.21 750.962 1322.49 751.384 1320.51 751.384ZM1320.53 747.165C1321.44 747.165 1322.19 746.909 1322.8 746.398C1323.4 745.878 1323.86 745.17 1324.16 744.276C1324.48 743.381 1324.64 742.362 1324.64 741.22C1324.64 740.078 1324.48 739.06 1324.16 738.165C1323.86 737.27 1323.4 736.562 1322.8 736.043C1322.19 735.523 1321.44 735.263 1320.53 735.263C1319.62 735.263 1318.85 735.523 1318.23 736.043C1317.62 736.562 1317.15 737.27 1316.84 738.165C1316.53 739.06 1316.38 740.078 1316.38 741.22C1316.38 742.362 1316.53 743.381 1316.84 744.276C1317.15 745.17 1317.62 745.878 1318.23 746.398C1318.85 746.909 1319.62 747.165 1320.53 747.165ZM1338.44 739.648V751H1332.99V731.364H1338.18V734.828H1338.41C1338.85 733.686 1339.58 732.783 1340.6 732.118C1341.62 731.445 1342.86 731.108 1344.32 731.108C1345.68 731.108 1346.87 731.406 1347.89 732.003C1348.9 732.599 1349.69 733.452 1350.25 734.56C1350.81 735.659 1351.1 736.972 1351.1 738.497V751H1345.65V739.469C1345.66 738.267 1345.35 737.33 1344.73 736.656C1344.11 735.974 1343.25 735.634 1342.16 735.634C1341.43 735.634 1340.78 735.791 1340.22 736.107C1339.66 736.422 1339.23 736.882 1338.91 737.487C1338.61 738.084 1338.45 738.804 1338.44 739.648ZM1366.9 751H1360.96L1370 724.818H1377.14L1386.16 751H1380.23L1373.67 730.801H1373.47L1366.9 751ZM1366.52 740.709H1380.54V745.03H1366.52V740.709Z" fill="#E6711C"/>
+<path d="M1673.25 655V628.818H1683.58C1685.56 628.818 1687.26 629.197 1688.65 629.956C1690.05 630.706 1691.12 631.75 1691.85 633.088C1692.59 634.418 1692.96 635.952 1692.96 637.69C1692.96 639.429 1692.59 640.963 1691.84 642.293C1691.09 643.622 1690 644.658 1688.58 645.399C1687.16 646.141 1685.45 646.511 1683.44 646.511H1676.85V642.075H1682.54C1683.61 642.075 1684.49 641.892 1685.18 641.526C1685.88 641.151 1686.4 640.635 1686.74 639.979C1687.09 639.314 1687.26 638.551 1687.26 637.69C1687.26 636.821 1687.09 636.062 1686.74 635.415C1686.4 634.759 1685.88 634.251 1685.18 633.893C1684.48 633.527 1683.59 633.344 1682.52 633.344H1678.78V655H1673.25ZM1704.37 655.384C1702.35 655.384 1700.61 654.974 1699.15 654.156C1697.7 653.33 1696.59 652.162 1695.8 650.653C1695.02 649.136 1694.63 647.342 1694.63 645.271C1694.63 643.251 1695.02 641.479 1695.8 639.953C1696.59 638.428 1697.69 637.239 1699.11 636.386C1700.55 635.534 1702.22 635.108 1704.15 635.108C1705.45 635.108 1706.65 635.317 1707.77 635.734C1708.89 636.143 1709.87 636.761 1710.71 637.588C1711.55 638.415 1712.21 639.455 1712.68 640.707C1713.15 641.952 1713.38 643.409 1713.38 645.08V646.575H1696.8V643.2H1708.25C1708.25 642.416 1708.08 641.722 1707.74 641.116C1707.4 640.511 1706.93 640.038 1706.32 639.697C1705.73 639.348 1705.03 639.173 1704.24 639.173C1703.41 639.173 1702.68 639.365 1702.04 639.749C1701.41 640.124 1700.92 640.631 1700.56 641.27C1700.2 641.901 1700.02 642.604 1700.01 643.379V646.588C1700.01 647.56 1700.19 648.399 1700.55 649.107C1700.91 649.814 1701.43 650.359 1702.09 650.743C1702.76 651.126 1703.55 651.318 1704.46 651.318C1705.06 651.318 1705.62 651.233 1706.12 651.062C1706.62 650.892 1707.05 650.636 1707.41 650.295C1707.77 649.955 1708.04 649.537 1708.23 649.043L1713.27 649.375C1713.01 650.585 1712.49 651.642 1711.69 652.545C1710.91 653.44 1709.9 654.139 1708.65 654.642C1707.41 655.136 1705.99 655.384 1704.37 655.384ZM1716.21 655V635.364H1721.49V638.79H1721.7C1722.06 637.571 1722.66 636.651 1723.5 636.028C1724.35 635.398 1725.32 635.082 1726.42 635.082C1726.69 635.082 1726.98 635.099 1727.3 635.134C1727.61 635.168 1727.89 635.214 1728.13 635.274V640.107C1727.87 640.03 1727.52 639.962 1727.07 639.902C1726.62 639.842 1726.2 639.812 1725.83 639.812C1725.03 639.812 1724.31 639.987 1723.68 640.337C1723.06 640.678 1722.56 641.155 1722.2 641.768C1721.84 642.382 1721.66 643.089 1721.66 643.891V655H1716.21ZM1741.77 635.364V639.455H1729.65V635.364H1741.77ZM1732.42 655V633.945C1732.42 632.521 1732.7 631.341 1733.26 630.403C1733.82 629.466 1734.58 628.763 1735.56 628.294C1736.53 627.825 1737.63 627.591 1738.87 627.591C1739.7 627.591 1740.47 627.655 1741.16 627.783C1741.85 627.911 1742.37 628.026 1742.72 628.128L1741.74 632.219C1741.53 632.151 1741.27 632.087 1740.95 632.027C1740.64 631.967 1740.33 631.938 1740.01 631.938C1739.2 631.938 1738.65 632.125 1738.33 632.5C1738.02 632.866 1737.86 633.382 1737.86 634.047V655H1732.42ZM1752.55 655.384C1750.56 655.384 1748.84 654.962 1747.39 654.118C1745.95 653.266 1744.84 652.081 1744.06 650.564C1743.27 649.038 1742.88 647.27 1742.88 645.259C1742.88 643.23 1743.27 641.457 1744.06 639.94C1744.84 638.415 1745.95 637.23 1747.39 636.386C1748.84 635.534 1750.56 635.108 1752.55 635.108C1754.53 635.108 1756.24 635.534 1757.68 636.386C1759.13 637.23 1760.25 638.415 1761.03 639.94C1761.82 641.457 1762.21 643.23 1762.21 645.259C1762.21 647.27 1761.82 649.038 1761.03 650.564C1760.25 652.081 1759.13 653.266 1757.68 654.118C1756.24 654.962 1754.53 655.384 1752.55 655.384ZM1752.57 651.165C1753.47 651.165 1754.23 650.909 1754.83 650.398C1755.44 649.878 1755.89 649.17 1756.2 648.276C1756.52 647.381 1756.67 646.362 1756.67 645.22C1756.67 644.078 1756.52 643.06 1756.2 642.165C1755.89 641.27 1755.44 640.562 1754.83 640.043C1754.23 639.523 1753.47 639.263 1752.57 639.263C1751.66 639.263 1750.89 639.523 1750.27 640.043C1749.66 640.562 1749.19 641.27 1748.88 642.165C1748.57 643.06 1748.42 644.078 1748.42 645.22C1748.42 646.362 1748.57 647.381 1748.88 648.276C1749.19 649.17 1749.66 649.878 1750.27 650.398C1750.89 650.909 1751.66 651.165 1752.57 651.165ZM1765.03 655V635.364H1770.31V638.79H1770.52C1770.87 637.571 1771.47 636.651 1772.32 636.028C1773.16 635.398 1774.13 635.082 1775.23 635.082C1775.51 635.082 1775.8 635.099 1776.12 635.134C1776.43 635.168 1776.71 635.214 1776.95 635.274V640.107C1776.69 640.03 1776.34 639.962 1775.89 639.902C1775.43 639.842 1775.02 639.812 1774.64 639.812C1773.84 639.812 1773.13 639.987 1772.5 640.337C1771.88 640.678 1771.38 641.155 1771.01 641.768C1770.66 642.382 1770.48 643.089 1770.48 643.891V655H1765.03ZM1779.04 655V635.364H1784.23V638.828H1784.46C1784.87 637.678 1785.55 636.77 1786.51 636.105C1787.46 635.44 1788.6 635.108 1789.93 635.108C1791.28 635.108 1792.43 635.445 1793.37 636.118C1794.32 636.783 1794.95 637.686 1795.26 638.828H1795.47C1795.87 637.703 1796.59 636.804 1797.64 636.131C1798.7 635.449 1799.95 635.108 1801.39 635.108C1803.22 635.108 1804.71 635.692 1805.85 636.859C1807 638.018 1807.58 639.663 1807.58 641.794V655H1802.14V642.868C1802.14 641.777 1801.85 640.959 1801.27 640.413C1800.69 639.868 1799.97 639.595 1799.1 639.595C1798.11 639.595 1797.34 639.911 1796.79 640.541C1796.23 641.163 1795.96 641.986 1795.96 643.009V655H1790.68V642.753C1790.68 641.79 1790.4 641.023 1789.84 640.452C1789.3 639.881 1788.58 639.595 1787.68 639.595C1787.08 639.595 1786.53 639.749 1786.05 640.055C1785.57 640.354 1785.19 640.776 1784.91 641.321C1784.63 641.858 1784.49 642.489 1784.49 643.213V655H1779.04ZM1816.76 655.371C1815.5 655.371 1814.39 655.153 1813.41 654.719C1812.43 654.276 1811.65 653.624 1811.08 652.763C1810.52 651.893 1810.24 650.811 1810.24 649.516C1810.24 648.425 1810.44 647.509 1810.84 646.767C1811.24 646.026 1811.78 645.429 1812.47 644.977C1813.16 644.526 1813.95 644.185 1814.83 643.955C1815.71 643.724 1816.64 643.562 1817.61 643.469C1818.76 643.349 1819.68 643.239 1820.38 643.136C1821.07 643.026 1821.58 642.864 1821.9 642.651C1822.21 642.437 1822.37 642.122 1822.37 641.705V641.628C1822.37 640.818 1822.11 640.192 1821.6 639.749C1821.1 639.305 1820.38 639.084 1819.45 639.084C1818.47 639.084 1817.69 639.301 1817.12 639.736C1816.54 640.162 1816.15 640.699 1815.96 641.347L1810.93 640.938C1811.18 639.744 1811.69 638.713 1812.44 637.844C1813.19 636.966 1814.15 636.293 1815.34 635.824C1816.53 635.347 1817.91 635.108 1819.48 635.108C1820.57 635.108 1821.62 635.236 1822.61 635.491C1823.62 635.747 1824.51 636.143 1825.28 636.68C1826.07 637.217 1826.69 637.908 1827.14 638.751C1827.59 639.587 1827.82 640.588 1827.82 641.756V655H1822.65V652.277H1822.5C1822.18 652.891 1821.76 653.432 1821.23 653.901C1820.7 654.361 1820.07 654.723 1819.33 654.987C1818.59 655.243 1817.73 655.371 1816.76 655.371ZM1818.32 651.612C1819.12 651.612 1819.83 651.455 1820.44 651.139C1821.05 650.815 1821.53 650.381 1821.88 649.835C1822.23 649.29 1822.41 648.672 1822.41 647.982V645.898C1822.24 646.009 1822 646.111 1821.7 646.205C1821.41 646.29 1821.09 646.371 1820.72 646.447C1820.35 646.516 1819.99 646.58 1819.62 646.639C1819.25 646.69 1818.92 646.737 1818.62 646.78C1817.98 646.874 1817.43 647.023 1816.95 647.227C1816.47 647.432 1816.1 647.709 1815.84 648.058C1815.57 648.399 1815.44 648.825 1815.44 649.337C1815.44 650.078 1815.71 650.645 1816.25 651.037C1816.79 651.42 1817.48 651.612 1818.32 651.612ZM1836.77 643.648V655H1831.32V635.364H1836.51V638.828H1836.74C1837.18 637.686 1837.9 636.783 1838.93 636.118C1839.95 635.445 1841.19 635.108 1842.65 635.108C1844.01 635.108 1845.2 635.406 1846.21 636.003C1847.23 636.599 1848.02 637.452 1848.58 638.56C1849.14 639.659 1849.42 640.972 1849.42 642.497V655H1843.98V643.469C1843.99 642.267 1843.68 641.33 1843.06 640.656C1842.43 639.974 1841.58 639.634 1840.49 639.634C1839.75 639.634 1839.11 639.791 1838.54 640.107C1837.99 640.422 1837.55 640.882 1837.24 641.487C1836.93 642.084 1836.78 642.804 1836.77 643.648ZM1861.87 655.384C1859.86 655.384 1858.13 654.957 1856.68 654.105C1855.24 653.244 1854.13 652.051 1853.35 650.526C1852.59 649 1852.2 647.244 1852.2 645.259C1852.2 643.247 1852.59 641.483 1853.37 639.966C1854.15 638.44 1855.26 637.251 1856.7 636.399C1858.14 635.538 1859.86 635.108 1861.84 635.108C1863.55 635.108 1865.05 635.419 1866.34 636.041C1867.63 636.663 1868.65 637.537 1869.4 638.662C1870.15 639.787 1870.56 641.108 1870.64 642.625H1865.5C1865.35 641.645 1864.97 640.857 1864.35 640.26C1863.73 639.655 1862.93 639.352 1861.93 639.352C1861.09 639.352 1860.35 639.582 1859.72 640.043C1859.1 640.494 1858.61 641.155 1858.26 642.024C1857.91 642.893 1857.74 643.946 1857.74 645.182C1857.74 646.435 1857.91 647.5 1858.25 648.378C1858.6 649.256 1859.09 649.925 1859.72 650.385C1860.35 650.845 1861.09 651.075 1861.93 651.075C1862.55 651.075 1863.11 650.947 1863.61 650.692C1864.11 650.436 1864.52 650.065 1864.85 649.58C1865.18 649.085 1865.4 648.493 1865.5 647.803H1870.64C1870.55 649.303 1870.14 650.624 1869.41 651.766C1868.69 652.899 1867.68 653.786 1866.41 654.425C1865.13 655.064 1863.61 655.384 1861.87 655.384ZM1882.35 655.384C1880.33 655.384 1878.59 654.974 1877.14 654.156C1875.69 653.33 1874.57 652.162 1873.79 650.653C1873 649.136 1872.61 647.342 1872.61 645.271C1872.61 643.251 1873 641.479 1873.79 639.953C1874.57 638.428 1875.68 637.239 1877.1 636.386C1878.53 635.534 1880.21 635.108 1882.14 635.108C1883.43 635.108 1884.64 635.317 1885.75 635.734C1886.88 636.143 1887.86 636.761 1888.69 637.588C1889.54 638.415 1890.19 639.455 1890.66 640.707C1891.13 641.952 1891.37 643.409 1891.37 645.08V646.575H1874.78V643.2H1886.24C1886.24 642.416 1886.07 641.722 1885.73 641.116C1885.39 640.511 1884.91 640.038 1884.31 639.697C1883.71 639.348 1883.02 639.173 1882.23 639.173C1881.4 639.173 1880.67 639.365 1880.03 639.749C1879.4 640.124 1878.9 640.631 1878.54 641.27C1878.19 641.901 1878 642.604 1877.99 643.379V646.588C1877.99 647.56 1878.17 648.399 1878.53 649.107C1878.9 649.814 1879.41 650.359 1880.08 650.743C1880.74 651.126 1881.53 651.318 1882.44 651.318C1883.05 651.318 1883.6 651.233 1884.1 651.062C1884.61 650.892 1885.04 650.636 1885.4 650.295C1885.75 649.955 1886.03 649.537 1886.21 649.043L1891.25 649.375C1890.99 650.585 1890.47 651.642 1889.68 652.545C1888.89 653.44 1887.88 654.139 1886.64 654.642C1885.4 655.136 1883.97 655.384 1882.35 655.384ZM1665.01 703.32C1663.52 703.32 1662.17 702.936 1660.96 702.169C1659.75 701.393 1658.8 700.256 1658.09 698.756C1657.39 697.247 1657.04 695.398 1657.04 693.207C1657.04 690.957 1657.41 689.087 1658.13 687.595C1658.86 686.095 1659.82 684.974 1661.02 684.233C1662.23 683.483 1663.56 683.108 1665 683.108C1666.1 683.108 1667.01 683.295 1667.74 683.67C1668.49 684.037 1669.08 684.497 1669.53 685.051C1669.99 685.597 1670.34 686.134 1670.58 686.662H1670.75V676.818H1676.18V703H1670.81V699.855H1670.58C1670.33 700.401 1669.96 700.942 1669.5 701.479C1669.04 702.007 1668.44 702.446 1667.69 702.795C1666.96 703.145 1666.07 703.32 1665.01 703.32ZM1666.73 698.986C1667.61 698.986 1668.35 698.747 1668.96 698.27C1669.57 697.784 1670.04 697.107 1670.37 696.237C1670.7 695.368 1670.86 694.349 1670.86 693.182C1670.86 692.014 1670.7 691 1670.38 690.139C1670.05 689.278 1669.59 688.614 1668.97 688.145C1668.36 687.676 1667.61 687.442 1666.73 687.442C1665.84 687.442 1665.09 687.685 1664.47 688.17C1663.86 688.656 1663.39 689.33 1663.08 690.19C1662.76 691.051 1662.61 692.048 1662.61 693.182C1662.61 694.324 1662.76 695.334 1663.08 696.212C1663.4 697.081 1663.87 697.763 1664.47 698.257C1665.09 698.743 1665.84 698.986 1666.73 698.986ZM1679.94 703V683.364H1685.39V703H1679.94ZM1682.68 680.832C1681.87 680.832 1681.17 680.564 1680.59 680.027C1680.02 679.482 1679.74 678.83 1679.74 678.071C1679.74 677.321 1680.02 676.678 1680.59 676.141C1681.17 675.595 1681.87 675.322 1682.68 675.322C1683.49 675.322 1684.18 675.595 1684.75 676.141C1685.33 676.678 1685.62 677.321 1685.62 678.071C1685.62 678.83 1685.33 679.482 1684.75 680.027C1684.18 680.564 1683.49 680.832 1682.68 680.832ZM1705.37 688.963L1700.38 689.27C1700.3 688.844 1700.11 688.46 1699.83 688.119C1699.55 687.77 1699.18 687.493 1698.72 687.288C1698.27 687.075 1697.73 686.969 1697.1 686.969C1696.25 686.969 1695.54 687.148 1694.96 687.506C1694.38 687.855 1694.09 688.324 1694.09 688.912C1694.09 689.381 1694.28 689.777 1694.65 690.101C1695.03 690.425 1695.67 690.685 1696.58 690.881L1700.14 691.597C1702.05 691.989 1703.47 692.619 1704.41 693.489C1705.35 694.358 1705.81 695.5 1705.81 696.915C1705.81 698.202 1705.43 699.331 1704.68 700.303C1703.93 701.274 1702.89 702.033 1701.58 702.578C1700.28 703.115 1698.77 703.384 1697.07 703.384C1694.47 703.384 1692.4 702.842 1690.86 701.76C1689.32 700.669 1688.42 699.186 1688.16 697.311L1693.52 697.03C1693.68 697.822 1694.07 698.428 1694.69 698.845C1695.31 699.254 1696.11 699.459 1697.08 699.459C1698.04 699.459 1698.8 699.276 1699.38 698.909C1699.97 698.534 1700.27 698.053 1700.28 697.464C1700.27 696.97 1700.06 696.565 1699.65 696.25C1699.24 695.926 1698.61 695.679 1697.76 695.509L1694.36 694.831C1692.44 694.447 1691.01 693.783 1690.08 692.837C1689.15 691.891 1688.68 690.685 1688.68 689.219C1688.68 687.957 1689.02 686.871 1689.71 685.959C1690.4 685.047 1691.36 684.344 1692.61 683.849C1693.86 683.355 1695.33 683.108 1697.01 683.108C1699.49 683.108 1701.44 683.632 1702.86 684.68C1704.29 685.729 1705.13 687.156 1705.37 688.963ZM1718.97 683.364V687.455H1707.14V683.364H1718.97ZM1709.83 678.659H1715.27V696.966C1715.27 697.469 1715.35 697.861 1715.5 698.142C1715.66 698.415 1715.87 698.607 1716.14 698.717C1716.42 698.828 1716.75 698.884 1717.11 698.884C1717.37 698.884 1717.63 698.862 1717.88 698.82C1718.14 698.768 1718.33 698.73 1718.47 698.705L1719.33 702.757C1719.05 702.842 1718.67 702.94 1718.18 703.051C1717.68 703.17 1717.08 703.243 1716.37 703.268C1715.06 703.32 1713.91 703.145 1712.92 702.744C1711.94 702.344 1711.18 701.722 1710.63 700.878C1710.09 700.034 1709.82 698.969 1709.83 697.682V678.659ZM1721.8 703V683.364H1727.08V686.79H1727.28C1727.64 685.571 1728.24 684.651 1729.08 684.028C1729.93 683.398 1730.9 683.082 1732 683.082C1732.27 683.082 1732.56 683.099 1732.88 683.134C1733.19 683.168 1733.47 683.214 1733.71 683.274V688.107C1733.45 688.03 1733.1 687.962 1732.65 687.902C1732.2 687.842 1731.78 687.812 1731.41 687.812C1730.61 687.812 1729.89 687.987 1729.26 688.337C1728.64 688.678 1728.14 689.155 1727.78 689.768C1727.42 690.382 1727.24 691.089 1727.24 691.891V703H1721.8ZM1735.81 703V683.364H1741.25V703H1735.81ZM1738.54 680.832C1737.73 680.832 1737.04 680.564 1736.46 680.027C1735.89 679.482 1735.6 678.83 1735.6 678.071C1735.6 677.321 1735.89 676.678 1736.46 676.141C1737.04 675.595 1737.73 675.322 1738.54 675.322C1739.35 675.322 1740.04 675.595 1740.61 676.141C1741.19 676.678 1741.48 677.321 1741.48 678.071C1741.48 678.83 1741.19 679.482 1740.61 680.027C1740.04 680.564 1739.35 680.832 1738.54 680.832ZM1745 703V676.818H1750.44V686.662H1750.61C1750.85 686.134 1751.19 685.597 1751.64 685.051C1752.1 684.497 1752.7 684.037 1753.43 683.67C1754.18 683.295 1755.1 683.108 1756.2 683.108C1757.63 683.108 1758.95 683.483 1760.16 684.233C1761.37 684.974 1762.34 686.095 1763.06 687.595C1763.79 689.087 1764.15 690.957 1764.15 693.207C1764.15 695.398 1763.79 697.247 1763.09 698.756C1762.39 700.256 1761.43 701.393 1760.22 702.169C1759.02 702.936 1757.67 703.32 1756.18 703.32C1755.13 703.32 1754.23 703.145 1753.49 702.795C1752.75 702.446 1752.15 702.007 1751.68 701.479C1751.21 700.942 1750.86 700.401 1750.61 699.855H1750.37V703H1745ZM1750.33 693.182C1750.33 694.349 1750.49 695.368 1750.81 696.237C1751.14 697.107 1751.61 697.784 1752.22 698.27C1752.83 698.747 1753.58 698.986 1754.46 698.986C1755.34 698.986 1756.09 698.743 1756.71 698.257C1757.32 697.763 1757.79 697.081 1758.1 696.212C1758.42 695.334 1758.59 694.324 1758.59 693.182C1758.59 692.048 1758.43 691.051 1758.11 690.19C1757.8 689.33 1757.33 688.656 1756.72 688.17C1756.11 687.685 1755.35 687.442 1754.46 687.442C1753.57 687.442 1752.82 687.676 1752.21 688.145C1751.6 688.614 1751.14 689.278 1750.81 690.139C1750.49 691 1750.33 692.014 1750.33 693.182ZM1779.65 694.639V683.364H1785.1V703H1779.87V699.433H1779.67C1779.22 700.584 1778.49 701.509 1777.45 702.207C1776.43 702.906 1775.18 703.256 1773.71 703.256C1772.4 703.256 1771.24 702.957 1770.24 702.361C1769.25 701.764 1768.47 700.916 1767.91 699.817C1767.35 698.717 1767.07 697.401 1767.06 695.866V683.364H1772.51V694.895C1772.52 696.054 1772.83 696.97 1773.44 697.643C1774.05 698.317 1774.88 698.653 1775.91 698.653C1776.56 698.653 1777.18 698.504 1777.75 698.206C1778.32 697.899 1778.78 697.447 1779.13 696.851C1779.49 696.254 1779.66 695.517 1779.65 694.639ZM1799.18 683.364V687.455H1787.36V683.364H1799.18ZM1790.04 678.659H1795.49V696.966C1795.49 697.469 1795.56 697.861 1795.72 698.142C1795.87 698.415 1796.08 698.607 1796.36 698.717C1796.64 698.828 1796.96 698.884 1797.33 698.884C1797.58 698.884 1797.84 698.862 1798.09 698.82C1798.35 698.768 1798.55 698.73 1798.68 698.705L1799.54 702.757C1799.27 702.842 1798.88 702.94 1798.39 703.051C1797.89 703.17 1797.29 703.243 1796.59 703.268C1795.27 703.32 1794.12 703.145 1793.13 702.744C1792.15 702.344 1791.39 701.722 1790.85 700.878C1790.3 700.034 1790.03 698.969 1790.04 697.682V678.659ZM1802.01 703V683.364H1807.45V703H1802.01ZM1804.74 680.832C1803.93 680.832 1803.24 680.564 1802.66 680.027C1802.09 679.482 1801.8 678.83 1801.8 678.071C1801.8 677.321 1802.09 676.678 1802.66 676.141C1803.24 675.595 1803.93 675.322 1804.74 675.322C1805.55 675.322 1806.24 675.595 1806.81 676.141C1807.39 676.678 1807.68 677.321 1807.68 678.071C1807.68 678.83 1807.39 679.482 1806.81 680.027C1806.24 680.564 1805.55 680.832 1804.74 680.832ZM1819.97 703.384C1817.98 703.384 1816.27 702.962 1814.82 702.118C1813.38 701.266 1812.26 700.081 1811.48 698.564C1810.7 697.038 1810.3 695.27 1810.3 693.259C1810.3 691.23 1810.7 689.457 1811.48 687.94C1812.26 686.415 1813.38 685.23 1814.82 684.386C1816.27 683.534 1817.98 683.108 1819.97 683.108C1821.95 683.108 1823.67 683.534 1825.11 684.386C1826.56 685.23 1827.67 686.415 1828.46 687.94C1829.24 689.457 1829.63 691.23 1829.63 693.259C1829.63 695.27 1829.24 697.038 1828.46 698.564C1827.67 700.081 1826.56 701.266 1825.11 702.118C1823.67 702.962 1821.95 703.384 1819.97 703.384ZM1819.99 699.165C1820.9 699.165 1821.65 698.909 1822.26 698.398C1822.86 697.878 1823.32 697.17 1823.62 696.276C1823.94 695.381 1824.1 694.362 1824.1 693.22C1824.1 692.078 1823.94 691.06 1823.62 690.165C1823.32 689.27 1822.86 688.562 1822.26 688.043C1821.65 687.523 1820.9 687.263 1819.99 687.263C1819.08 687.263 1818.32 687.523 1817.69 688.043C1817.08 688.562 1816.62 689.27 1816.3 690.165C1815.99 691.06 1815.84 692.078 1815.84 693.22C1815.84 694.362 1815.99 695.381 1816.3 696.276C1816.62 697.17 1817.08 697.878 1817.69 698.398C1818.32 698.909 1819.08 699.165 1819.99 699.165ZM1837.9 691.648V703H1832.45V683.364H1837.65V686.828H1837.88C1838.31 685.686 1839.04 684.783 1840.06 684.118C1841.08 683.445 1842.32 683.108 1843.78 683.108C1845.15 683.108 1846.33 683.406 1847.35 684.003C1848.36 684.599 1849.15 685.452 1849.71 686.56C1850.28 687.659 1850.56 688.972 1850.56 690.497V703H1845.11V691.469C1845.12 690.267 1844.81 689.33 1844.19 688.656C1843.57 687.974 1842.71 687.634 1841.62 687.634C1840.89 687.634 1840.24 687.791 1839.68 688.107C1839.12 688.422 1838.69 688.882 1838.37 689.487C1838.07 690.084 1837.91 690.804 1837.9 691.648ZM1872.3 683.364V687.455H1860.18V683.364H1872.3ZM1862.96 703V681.945C1862.96 680.521 1863.23 679.341 1863.79 678.403C1864.35 677.466 1865.12 676.763 1866.09 676.294C1867.06 675.825 1868.16 675.591 1869.4 675.591C1870.23 675.591 1871 675.655 1871.69 675.783C1872.39 675.911 1872.91 676.026 1873.25 676.128L1872.28 680.219C1872.06 680.151 1871.8 680.087 1871.48 680.027C1871.18 679.967 1870.86 679.938 1870.54 679.938C1869.74 679.938 1869.18 680.125 1868.86 680.5C1868.55 680.866 1868.39 681.382 1868.39 682.047V703H1862.96ZM1883.08 703.384C1881.09 703.384 1879.37 702.962 1877.93 702.118C1876.48 701.266 1875.37 700.081 1874.59 698.564C1873.8 697.038 1873.41 695.27 1873.41 693.259C1873.41 691.23 1873.8 689.457 1874.59 687.94C1875.37 686.415 1876.48 685.23 1877.93 684.386C1879.37 683.534 1881.09 683.108 1883.08 683.108C1885.06 683.108 1886.78 683.534 1888.22 684.386C1889.67 685.23 1890.78 686.415 1891.57 687.94C1892.35 689.457 1892.74 691.23 1892.74 693.259C1892.74 695.27 1892.35 697.038 1891.57 698.564C1890.78 700.081 1889.67 701.266 1888.22 702.118C1886.78 702.962 1885.06 703.384 1883.08 703.384ZM1883.1 699.165C1884.01 699.165 1884.76 698.909 1885.37 698.398C1885.97 697.878 1886.43 697.17 1886.73 696.276C1887.05 695.381 1887.21 694.362 1887.21 693.22C1887.21 692.078 1887.05 691.06 1886.73 690.165C1886.43 689.27 1885.97 688.562 1885.37 688.043C1884.76 687.523 1884.01 687.263 1883.1 687.263C1882.19 687.263 1881.42 687.523 1880.8 688.043C1880.19 688.562 1879.72 689.27 1879.41 690.165C1879.1 691.06 1878.95 692.078 1878.95 693.22C1878.95 694.362 1879.1 695.381 1879.41 696.276C1879.72 697.17 1880.19 697.878 1880.8 698.398C1881.42 698.909 1882.19 699.165 1883.1 699.165ZM1895.56 703V683.364H1900.84V686.79H1901.05C1901.41 685.571 1902.01 684.651 1902.85 684.028C1903.69 683.398 1904.67 683.082 1905.76 683.082C1906.04 683.082 1906.33 683.099 1906.65 683.134C1906.96 683.168 1907.24 683.214 1907.48 683.274V688.107C1907.22 688.03 1906.87 687.962 1906.42 687.902C1905.96 687.842 1905.55 687.812 1905.18 687.812C1904.38 687.812 1903.66 687.987 1903.03 688.337C1902.41 688.678 1901.91 689.155 1901.55 689.768C1901.19 690.382 1901.01 691.089 1901.01 691.891V703H1895.56Z" fill="black"/>
+<path d="M1660.7 758.364V731.364H1666.07V734.662H1666.31C1666.55 734.134 1666.9 733.597 1667.35 733.051C1667.81 732.497 1668.41 732.037 1669.14 731.67C1669.88 731.295 1670.8 731.108 1671.9 731.108C1673.33 731.108 1674.65 731.483 1675.86 732.233C1677.07 732.974 1678.04 734.095 1678.76 735.595C1679.49 737.087 1679.85 738.957 1679.85 741.207C1679.85 743.398 1679.5 745.247 1678.79 746.756C1678.09 748.256 1677.14 749.393 1675.93 750.169C1674.73 750.936 1673.38 751.32 1671.89 751.32C1670.83 751.32 1669.93 751.145 1669.19 750.795C1668.46 750.446 1667.86 750.007 1667.39 749.479C1666.92 748.942 1666.56 748.401 1666.31 747.855H1666.15V758.364H1660.7ZM1666.03 741.182C1666.03 742.349 1666.19 743.368 1666.52 744.237C1666.84 745.107 1667.31 745.784 1667.92 746.27C1668.54 746.747 1669.28 746.986 1670.16 746.986C1671.05 746.986 1671.8 746.743 1672.41 746.257C1673.02 745.763 1673.49 745.081 1673.8 744.212C1674.13 743.334 1674.29 742.324 1674.29 741.182C1674.29 740.048 1674.13 739.051 1673.82 738.19C1673.5 737.33 1673.04 736.656 1672.42 736.17C1671.81 735.685 1671.06 735.442 1670.16 735.442C1669.27 735.442 1668.52 735.676 1667.91 736.145C1667.31 736.614 1666.84 737.278 1666.52 738.139C1666.19 739 1666.03 740.014 1666.03 741.182ZM1691.71 751.384C1689.69 751.384 1687.95 750.974 1686.5 750.156C1685.05 749.33 1683.93 748.162 1683.15 746.653C1682.36 745.136 1681.97 743.342 1681.97 741.271C1681.97 739.251 1682.36 737.479 1683.15 735.953C1683.93 734.428 1685.03 733.239 1686.46 732.386C1687.89 731.534 1689.57 731.108 1691.49 731.108C1692.79 731.108 1694 731.317 1695.11 731.734C1696.24 732.143 1697.22 732.761 1698.05 733.588C1698.9 734.415 1699.55 735.455 1700.02 736.707C1700.49 737.952 1700.72 739.409 1700.72 741.08V742.575H1684.14V739.2H1695.6C1695.6 738.416 1695.43 737.722 1695.09 737.116C1694.75 736.511 1694.27 736.038 1693.67 735.697C1693.07 735.348 1692.38 735.173 1691.58 735.173C1690.76 735.173 1690.02 735.365 1689.38 735.749C1688.75 736.124 1688.26 736.631 1687.9 737.27C1687.54 737.901 1687.36 738.604 1687.35 739.379V742.588C1687.35 743.56 1687.53 744.399 1687.89 745.107C1688.26 745.814 1688.77 746.359 1689.44 746.743C1690.1 747.126 1690.89 747.318 1691.8 747.318C1692.41 747.318 1692.96 747.233 1693.46 747.062C1693.97 746.892 1694.4 746.636 1694.75 746.295C1695.11 745.955 1695.38 745.537 1695.57 745.043L1700.61 745.375C1700.35 746.585 1699.83 747.642 1699.04 748.545C1698.25 749.44 1697.24 750.139 1695.99 750.642C1694.76 751.136 1693.33 751.384 1691.71 751.384ZM1703.56 751V731.364H1708.84V734.79H1709.04C1709.4 733.571 1710 732.651 1710.84 732.028C1711.69 731.398 1712.66 731.082 1713.76 731.082C1714.03 731.082 1714.33 731.099 1714.64 731.134C1714.96 731.168 1715.23 731.214 1715.47 731.274V736.107C1715.22 736.03 1714.86 735.962 1714.41 735.902C1713.96 735.842 1713.55 735.812 1713.17 735.812C1712.37 735.812 1711.65 735.987 1711.02 736.337C1710.4 736.678 1709.91 737.155 1709.54 737.768C1709.18 738.382 1709 739.089 1709 739.891V751H1703.56ZM1729 731.364V735.455H1717.17V731.364H1729ZM1719.86 726.659H1725.3V744.966C1725.3 745.469 1725.38 745.861 1725.53 746.142C1725.69 746.415 1725.9 746.607 1726.17 746.717C1726.45 746.828 1726.78 746.884 1727.14 746.884C1727.4 746.884 1727.65 746.862 1727.91 746.82C1728.17 746.768 1728.36 746.73 1728.5 746.705L1729.36 750.757C1729.08 750.842 1728.7 750.94 1728.2 751.051C1727.71 751.17 1727.11 751.243 1726.4 751.268C1725.09 751.32 1723.94 751.145 1722.95 750.744C1721.97 750.344 1721.21 749.722 1720.66 748.878C1720.12 748.034 1719.85 746.969 1719.86 745.682V726.659ZM1744.42 742.639V731.364H1749.86V751H1744.63V747.433H1744.43C1743.99 748.584 1743.25 749.509 1742.22 750.207C1741.2 750.906 1739.95 751.256 1738.47 751.256C1737.16 751.256 1736.01 750.957 1735.01 750.361C1734.01 749.764 1733.23 748.916 1732.67 747.817C1732.11 746.717 1731.83 745.401 1731.82 743.866V731.364H1737.27V742.895C1737.28 744.054 1737.59 744.97 1738.2 745.643C1738.82 746.317 1739.64 746.653 1740.67 746.653C1741.33 746.653 1741.94 746.504 1742.51 746.206C1743.08 745.899 1743.54 745.447 1743.89 744.851C1744.25 744.254 1744.43 743.517 1744.42 742.639ZM1753.5 751V731.364H1758.78V734.79H1758.98C1759.34 733.571 1759.94 732.651 1760.79 732.028C1761.63 731.398 1762.6 731.082 1763.7 731.082C1763.97 731.082 1764.27 731.099 1764.58 731.134C1764.9 731.168 1765.18 731.214 1765.41 731.274V736.107C1765.16 736.03 1764.8 735.962 1764.35 735.902C1763.9 735.842 1763.49 735.812 1763.11 735.812C1762.31 735.812 1761.6 735.987 1760.97 736.337C1760.34 736.678 1759.85 737.155 1759.48 737.768C1759.12 738.382 1758.95 739.089 1758.95 739.891V751H1753.5ZM1767.61 751V724.818H1773.06V734.662H1773.22C1773.46 734.134 1773.81 733.597 1774.26 733.051C1774.72 732.497 1775.32 732.037 1776.05 731.67C1776.79 731.295 1777.71 731.108 1778.81 731.108C1780.24 731.108 1781.56 731.483 1782.77 732.233C1783.98 732.974 1784.95 734.095 1785.68 735.595C1786.4 737.087 1786.76 738.957 1786.76 741.207C1786.76 743.398 1786.41 745.247 1785.7 746.756C1785 748.256 1784.05 749.393 1782.84 750.169C1781.64 750.936 1780.29 751.32 1778.8 751.32C1777.74 751.32 1776.84 751.145 1776.1 750.795C1775.37 750.446 1774.77 750.007 1774.3 749.479C1773.83 748.942 1773.47 748.401 1773.22 747.855H1772.98V751H1767.61ZM1772.94 741.182C1772.94 742.349 1773.11 743.368 1773.43 744.237C1773.75 745.107 1774.22 745.784 1774.84 746.27C1775.45 746.747 1776.19 746.986 1777.07 746.986C1777.96 746.986 1778.71 746.743 1779.32 746.257C1779.94 745.763 1780.4 745.081 1780.72 744.212C1781.04 743.334 1781.2 742.324 1781.2 741.182C1781.2 740.048 1781.04 739.051 1780.73 738.19C1780.41 737.33 1779.95 736.656 1779.34 736.17C1778.72 735.685 1777.97 735.442 1777.07 735.442C1776.19 735.442 1775.44 735.676 1774.82 736.145C1774.22 736.614 1773.75 737.278 1773.43 738.139C1773.11 739 1772.94 740.014 1772.94 741.182ZM1795.28 751.371C1794.02 751.371 1792.91 751.153 1791.93 750.719C1790.95 750.276 1790.17 749.624 1789.6 748.763C1789.04 747.893 1788.76 746.811 1788.76 745.516C1788.76 744.425 1788.96 743.509 1789.36 742.767C1789.76 742.026 1790.3 741.429 1790.99 740.977C1791.68 740.526 1792.47 740.185 1793.35 739.955C1794.23 739.724 1795.16 739.562 1796.13 739.469C1797.27 739.349 1798.2 739.239 1798.89 739.136C1799.59 739.026 1800.1 738.864 1800.42 738.651C1800.73 738.437 1800.89 738.122 1800.89 737.705V737.628C1800.89 736.818 1800.63 736.192 1800.12 735.749C1799.62 735.305 1798.9 735.084 1797.97 735.084C1796.99 735.084 1796.21 735.301 1795.63 735.736C1795.05 736.162 1794.67 736.699 1794.48 737.347L1789.45 736.938C1789.7 735.744 1790.21 734.713 1790.96 733.844C1791.71 732.966 1792.67 732.293 1793.86 731.824C1795.05 731.347 1796.43 731.108 1798 731.108C1799.09 731.108 1800.13 731.236 1801.13 731.491C1802.14 731.747 1803.03 732.143 1803.8 732.68C1804.59 733.217 1805.21 733.908 1805.66 734.751C1806.11 735.587 1806.33 736.588 1806.33 737.756V751H1801.17V748.277H1801.02C1800.7 748.891 1800.28 749.432 1799.75 749.901C1799.22 750.361 1798.59 750.723 1797.85 750.987C1797.1 751.243 1796.25 751.371 1795.28 751.371ZM1796.84 747.612C1797.64 747.612 1798.34 747.455 1798.96 747.139C1799.57 746.815 1800.05 746.381 1800.4 745.835C1800.75 745.29 1800.93 744.672 1800.93 743.982V741.898C1800.76 742.009 1800.52 742.111 1800.22 742.205C1799.93 742.29 1799.61 742.371 1799.24 742.447C1798.87 742.516 1798.51 742.58 1798.14 742.639C1797.77 742.69 1797.44 742.737 1797.14 742.78C1796.5 742.874 1795.95 743.023 1795.47 743.227C1794.99 743.432 1794.62 743.709 1794.36 744.058C1794.09 744.399 1793.96 744.825 1793.96 745.337C1793.96 746.078 1794.23 746.645 1794.76 747.037C1795.31 747.42 1796 747.612 1796.84 747.612ZM1820.28 731.364V735.455H1808.46V731.364H1820.28ZM1811.14 726.659H1816.59V744.966C1816.59 745.469 1816.67 745.861 1816.82 746.142C1816.97 746.415 1817.19 746.607 1817.46 746.717C1817.74 746.828 1818.06 746.884 1818.43 746.884C1818.69 746.884 1818.94 746.862 1819.2 746.82C1819.45 746.768 1819.65 746.73 1819.79 746.705L1820.64 750.757C1820.37 750.842 1819.99 750.94 1819.49 751.051C1819 751.17 1818.4 751.243 1817.69 751.268C1816.38 751.32 1815.23 751.145 1814.24 750.744C1813.26 750.344 1812.49 749.722 1811.95 748.878C1811.4 748.034 1811.13 746.969 1811.14 745.682V726.659ZM1823.11 751V731.364H1828.56V751H1823.11ZM1825.85 728.832C1825.04 728.832 1824.34 728.564 1823.76 728.027C1823.19 727.482 1822.91 726.83 1822.91 726.071C1822.91 725.321 1823.19 724.678 1823.76 724.141C1824.34 723.595 1825.04 723.322 1825.85 723.322C1826.66 723.322 1827.35 723.595 1827.92 724.141C1828.5 724.678 1828.79 725.321 1828.79 726.071C1828.79 726.83 1828.5 727.482 1827.92 728.027C1827.35 728.564 1826.66 728.832 1825.85 728.832ZM1841.07 751.384C1839.09 751.384 1837.37 750.962 1835.92 750.118C1834.48 749.266 1833.37 748.081 1832.58 746.564C1831.8 745.038 1831.41 743.27 1831.41 741.259C1831.41 739.23 1831.8 737.457 1832.58 735.94C1833.37 734.415 1834.48 733.23 1835.92 732.386C1837.37 731.534 1839.09 731.108 1841.07 731.108C1843.06 731.108 1844.77 731.534 1846.21 732.386C1847.66 733.23 1848.78 734.415 1849.56 735.94C1850.35 737.457 1850.74 739.23 1850.74 741.259C1850.74 743.27 1850.35 745.038 1849.56 746.564C1848.78 748.081 1847.66 749.266 1846.21 750.118C1844.77 750.962 1843.06 751.384 1841.07 751.384ZM1841.1 747.165C1842 747.165 1842.76 746.909 1843.36 746.398C1843.97 745.878 1844.42 745.17 1844.73 744.276C1845.04 743.381 1845.2 742.362 1845.2 741.22C1845.2 740.078 1845.04 739.06 1844.73 738.165C1844.42 737.27 1843.97 736.562 1843.36 736.043C1842.76 735.523 1842 735.263 1841.1 735.263C1840.19 735.263 1839.42 735.523 1838.8 736.043C1838.18 736.562 1837.72 737.27 1837.4 738.165C1837.1 739.06 1836.94 740.078 1836.94 741.22C1836.94 742.362 1837.1 743.381 1837.4 744.276C1837.72 745.17 1838.18 745.878 1838.8 746.398C1839.42 746.909 1840.19 747.165 1841.1 747.165ZM1859 739.648V751H1853.56V731.364H1858.75V734.828H1858.98C1859.41 733.686 1860.14 732.783 1861.16 732.118C1862.19 731.445 1863.43 731.108 1864.89 731.108C1866.25 731.108 1867.44 731.406 1868.45 732.003C1869.47 732.599 1870.25 733.452 1870.82 734.56C1871.38 735.659 1871.66 736.972 1871.66 738.497V751H1866.21V739.469C1866.22 738.267 1865.92 737.33 1865.29 736.656C1864.67 735.974 1863.82 735.634 1862.72 735.634C1861.99 735.634 1861.34 735.791 1860.78 736.107C1860.23 736.422 1859.79 736.882 1859.48 737.487C1859.17 738.084 1859.01 738.804 1859 739.648ZM1882.95 751V724.818H1893.43C1895.36 724.818 1896.96 725.104 1898.25 725.675C1899.54 726.246 1900.5 727.038 1901.15 728.053C1901.8 729.058 1902.12 730.217 1902.12 731.53C1902.12 732.553 1901.92 733.452 1901.51 734.227C1901.1 734.994 1900.54 735.625 1899.82 736.119C1899.11 736.605 1898.31 736.95 1897.39 737.155V737.411C1898.39 737.453 1899.32 737.734 1900.19 738.254C1901.07 738.774 1901.78 739.503 1902.33 740.44C1902.87 741.369 1903.15 742.477 1903.15 743.764C1903.15 745.153 1902.8 746.393 1902.11 747.484C1901.43 748.567 1900.42 749.423 1899.08 750.054C1897.74 750.685 1896.09 751 1894.13 751H1882.95ZM1888.48 746.474H1893C1894.54 746.474 1895.66 746.18 1896.37 745.592C1897.08 744.996 1897.43 744.203 1897.43 743.214C1897.43 742.49 1897.26 741.851 1896.91 741.297C1896.56 740.743 1896.06 740.308 1895.41 739.993C1894.77 739.678 1894.01 739.52 1893.12 739.52H1888.48V746.474ZM1888.48 735.774H1892.59C1893.34 735.774 1894.02 735.642 1894.61 735.378C1895.2 735.105 1895.67 734.722 1896.01 734.227C1896.36 733.733 1896.54 733.141 1896.54 732.45C1896.54 731.504 1896.2 730.741 1895.53 730.162C1894.86 729.582 1893.92 729.293 1892.69 729.293H1888.48V735.774Z" fill="#5C0B4D"/>
+<rect x="1069" y="268" width="285.028" height="61.8182" rx="22" fill="#E6711C" stroke="black" stroke-width="4"/>
+<path d="M1098.35 312.384C1096.34 312.384 1094.61 311.957 1093.16 311.105C1091.72 310.244 1090.61 309.051 1089.83 307.526C1089.07 306 1088.68 304.244 1088.68 302.259C1088.68 300.247 1089.07 298.483 1089.85 296.966C1090.63 295.44 1091.74 294.251 1093.18 293.399C1094.62 292.538 1096.34 292.108 1098.32 292.108C1100.04 292.108 1101.54 292.419 1102.82 293.041C1104.11 293.663 1105.13 294.537 1105.88 295.662C1106.63 296.787 1107.04 298.108 1107.12 299.625H1101.98C1101.83 298.645 1101.45 297.857 1100.83 297.26C1100.21 296.655 1099.41 296.352 1098.41 296.352C1097.57 296.352 1096.83 296.582 1096.2 297.043C1095.58 297.494 1095.09 298.155 1094.74 299.024C1094.39 299.893 1094.22 300.946 1094.22 302.182C1094.22 303.435 1094.39 304.5 1094.73 305.378C1095.08 306.256 1095.57 306.925 1096.2 307.385C1096.83 307.845 1097.57 308.075 1098.41 308.075C1099.03 308.075 1099.59 307.947 1100.09 307.692C1100.59 307.436 1101 307.065 1101.33 306.58C1101.66 306.085 1101.88 305.493 1101.98 304.803H1107.12C1107.03 306.303 1106.62 307.624 1105.89 308.766C1105.17 309.899 1104.16 310.786 1102.89 311.425C1101.61 312.064 1100.1 312.384 1098.35 312.384ZM1118.76 312.384C1116.77 312.384 1115.05 311.962 1113.61 311.118C1112.16 310.266 1111.05 309.081 1110.27 307.564C1109.48 306.038 1109.09 304.27 1109.09 302.259C1109.09 300.23 1109.48 298.457 1110.27 296.94C1111.05 295.415 1112.16 294.23 1113.61 293.386C1115.05 292.534 1116.77 292.108 1118.76 292.108C1120.74 292.108 1122.46 292.534 1123.9 293.386C1125.35 294.23 1126.46 295.415 1127.25 296.94C1128.03 298.457 1128.42 300.23 1128.42 302.259C1128.42 304.27 1128.03 306.038 1127.25 307.564C1126.46 309.081 1125.35 310.266 1123.9 311.118C1122.46 311.962 1120.74 312.384 1118.76 312.384ZM1118.78 308.165C1119.69 308.165 1120.44 307.909 1121.05 307.398C1121.65 306.878 1122.11 306.17 1122.41 305.276C1122.73 304.381 1122.89 303.362 1122.89 302.22C1122.89 301.078 1122.73 300.06 1122.41 299.165C1122.11 298.27 1121.65 297.562 1121.05 297.043C1120.44 296.523 1119.69 296.263 1118.78 296.263C1117.87 296.263 1117.1 296.523 1116.48 297.043C1115.87 297.562 1115.4 298.27 1115.09 299.165C1114.78 300.06 1114.63 301.078 1114.63 302.22C1114.63 303.362 1114.78 304.381 1115.09 305.276C1115.4 306.17 1115.87 306.878 1116.48 307.398C1117.1 307.909 1117.87 308.165 1118.78 308.165ZM1131.24 312V292.364H1136.43V295.828H1136.66C1137.07 294.678 1137.75 293.77 1138.71 293.105C1139.66 292.44 1140.81 292.108 1142.14 292.108C1143.48 292.108 1144.63 292.445 1145.57 293.118C1146.52 293.783 1147.15 294.686 1147.47 295.828H1147.67C1148.07 294.703 1148.8 293.804 1149.84 293.131C1150.9 292.449 1152.15 292.108 1153.59 292.108C1155.42 292.108 1156.91 292.692 1158.05 293.859C1159.2 295.018 1159.78 296.663 1159.78 298.794V312H1154.34V299.868C1154.34 298.777 1154.05 297.959 1153.47 297.413C1152.9 296.868 1152.17 296.595 1151.3 296.595C1150.31 296.595 1149.54 296.911 1148.99 297.541C1148.43 298.163 1148.16 298.986 1148.16 300.009V312H1142.88V299.753C1142.88 298.79 1142.6 298.023 1142.05 297.452C1141.5 296.881 1140.78 296.595 1139.89 296.595C1139.28 296.595 1138.73 296.749 1138.25 297.055C1137.77 297.354 1137.39 297.776 1137.11 298.321C1136.83 298.858 1136.69 299.489 1136.69 300.213V312H1131.24ZM1163.36 319.364V292.364H1168.73V295.662H1168.97C1169.21 295.134 1169.55 294.597 1170.01 294.051C1170.47 293.497 1171.06 293.037 1171.8 292.67C1172.54 292.295 1173.46 292.108 1174.56 292.108C1175.99 292.108 1177.31 292.483 1178.52 293.233C1179.73 293.974 1180.7 295.095 1181.42 296.595C1182.15 298.087 1182.51 299.957 1182.51 302.207C1182.51 304.398 1182.16 306.247 1181.45 307.756C1180.75 309.256 1179.8 310.393 1178.58 311.169C1177.38 311.936 1176.04 312.32 1174.55 312.32C1173.49 312.32 1172.59 312.145 1171.85 311.795C1171.11 311.446 1170.51 311.007 1170.05 310.479C1169.58 309.942 1169.22 309.401 1168.97 308.855H1168.8V319.364H1163.36ZM1168.69 302.182C1168.69 303.349 1168.85 304.368 1169.18 305.237C1169.5 306.107 1169.97 306.784 1170.58 307.27C1171.2 307.747 1171.94 307.986 1172.82 307.986C1173.71 307.986 1174.46 307.743 1175.07 307.257C1175.68 306.763 1176.15 306.081 1176.46 305.212C1176.79 304.334 1176.95 303.324 1176.95 302.182C1176.95 301.048 1176.79 300.051 1176.48 299.19C1176.16 298.33 1175.7 297.656 1175.08 297.17C1174.47 296.685 1173.71 296.442 1172.82 296.442C1171.93 296.442 1171.18 296.676 1170.57 297.145C1169.96 297.614 1169.5 298.278 1169.18 299.139C1168.85 300 1168.69 301.014 1168.69 302.182ZM1191.02 312.371C1189.77 312.371 1188.65 312.153 1187.67 311.719C1186.69 311.276 1185.91 310.624 1185.34 309.763C1184.78 308.893 1184.5 307.811 1184.5 306.516C1184.5 305.425 1184.7 304.509 1185.1 303.767C1185.5 303.026 1186.05 302.429 1186.74 301.977C1187.43 301.526 1188.21 301.185 1189.09 300.955C1189.98 300.724 1190.9 300.562 1191.88 300.469C1193.02 300.349 1193.94 300.239 1194.64 300.136C1195.34 300.026 1195.84 299.864 1196.16 299.651C1196.47 299.437 1196.63 299.122 1196.63 298.705V298.628C1196.63 297.818 1196.38 297.192 1195.86 296.749C1195.36 296.305 1194.65 296.084 1193.72 296.084C1192.74 296.084 1191.96 296.301 1191.38 296.736C1190.8 297.162 1190.41 297.699 1190.23 298.347L1185.19 297.938C1185.45 296.744 1185.95 295.713 1186.7 294.844C1187.45 293.966 1188.42 293.293 1189.6 292.824C1190.79 292.347 1192.17 292.108 1193.74 292.108C1194.83 292.108 1195.88 292.236 1196.87 292.491C1197.88 292.747 1198.77 293.143 1199.55 293.68C1200.33 294.217 1200.95 294.908 1201.4 295.751C1201.85 296.587 1202.08 297.588 1202.08 298.756V312H1196.91V309.277H1196.76C1196.44 309.891 1196.02 310.432 1195.49 310.901C1194.97 311.361 1194.33 311.723 1193.59 311.987C1192.85 312.243 1191.99 312.371 1191.02 312.371ZM1192.58 308.612C1193.38 308.612 1194.09 308.455 1194.7 308.139C1195.32 307.815 1195.8 307.381 1196.15 306.835C1196.5 306.29 1196.67 305.672 1196.67 304.982V302.898C1196.5 303.009 1196.27 303.111 1195.97 303.205C1195.68 303.29 1195.35 303.371 1194.98 303.447C1194.62 303.516 1194.25 303.58 1193.88 303.639C1193.52 303.69 1193.18 303.737 1192.89 303.78C1192.25 303.874 1191.69 304.023 1191.21 304.227C1190.73 304.432 1190.36 304.709 1190.1 305.058C1189.83 305.399 1189.7 305.825 1189.7 306.337C1189.7 307.078 1189.97 307.645 1190.51 308.037C1191.05 308.42 1191.74 308.612 1192.58 308.612ZM1205.58 312V292.364H1210.86V295.79H1211.07C1211.43 294.571 1212.03 293.651 1212.87 293.028C1213.71 292.398 1214.69 292.082 1215.78 292.082C1216.06 292.082 1216.35 292.099 1216.67 292.134C1216.98 292.168 1217.26 292.214 1217.5 292.274V297.107C1217.24 297.03 1216.89 296.962 1216.44 296.902C1215.99 296.842 1215.57 296.812 1215.2 296.812C1214.4 296.812 1213.68 296.987 1213.05 297.337C1212.43 297.678 1211.93 298.155 1211.57 298.768C1211.21 299.382 1211.03 300.089 1211.03 300.891V312H1205.58ZM1224.63 312.371C1223.38 312.371 1222.26 312.153 1221.28 311.719C1220.3 311.276 1219.53 310.624 1218.95 309.763C1218.39 308.893 1218.11 307.811 1218.11 306.516C1218.11 305.425 1218.31 304.509 1218.71 303.767C1219.11 303.026 1219.66 302.429 1220.35 301.977C1221.04 301.526 1221.82 301.185 1222.7 300.955C1223.59 300.724 1224.52 300.562 1225.49 300.469C1226.63 300.349 1227.55 300.239 1228.25 300.136C1228.95 300.026 1229.45 299.864 1229.77 299.651C1230.08 299.437 1230.24 299.122 1230.24 298.705V298.628C1230.24 297.818 1229.99 297.192 1229.48 296.749C1228.97 296.305 1228.26 296.084 1227.33 296.084C1226.35 296.084 1225.57 296.301 1224.99 296.736C1224.41 297.162 1224.03 297.699 1223.84 298.347L1218.8 297.938C1219.06 296.744 1219.56 295.713 1220.31 294.844C1221.06 293.966 1222.03 293.293 1223.21 292.824C1224.4 292.347 1225.79 292.108 1227.35 292.108C1228.44 292.108 1229.49 292.236 1230.49 292.491C1231.49 292.747 1232.38 293.143 1233.16 293.68C1233.94 294.217 1234.56 294.908 1235.01 295.751C1235.46 296.587 1235.69 297.588 1235.69 298.756V312H1230.52V309.277H1230.37C1230.06 309.891 1229.63 310.432 1229.1 310.901C1228.58 311.361 1227.94 311.723 1227.2 311.987C1226.46 312.243 1225.6 312.371 1224.63 312.371ZM1226.19 308.612C1226.99 308.612 1227.7 308.455 1228.31 308.139C1228.93 307.815 1229.41 307.381 1229.76 306.835C1230.11 306.29 1230.28 305.672 1230.28 304.982V302.898C1230.11 303.009 1229.88 303.111 1229.58 303.205C1229.29 303.29 1228.96 303.371 1228.59 303.447C1228.23 303.516 1227.86 303.58 1227.49 303.639C1227.13 303.69 1226.8 303.737 1226.5 303.78C1225.86 303.874 1225.3 304.023 1224.82 304.227C1224.34 304.432 1223.97 304.709 1223.71 305.058C1223.45 305.399 1223.31 305.825 1223.31 306.337C1223.31 307.078 1223.58 307.645 1224.12 308.037C1224.66 308.42 1225.35 308.612 1226.19 308.612ZM1249.64 292.364V296.455H1237.81V292.364H1249.64ZM1240.5 287.659H1245.94V305.966C1245.94 306.469 1246.02 306.861 1246.17 307.142C1246.33 307.415 1246.54 307.607 1246.81 307.717C1247.09 307.828 1247.42 307.884 1247.78 307.884C1248.04 307.884 1248.3 307.862 1248.55 307.82C1248.81 307.768 1249 307.73 1249.14 307.705L1250 311.757C1249.72 311.842 1249.34 311.94 1248.85 312.051C1248.35 312.17 1247.75 312.243 1247.04 312.268C1245.73 312.32 1244.58 312.145 1243.59 311.744C1242.61 311.344 1241.85 310.722 1241.3 309.878C1240.76 309.034 1240.49 307.969 1240.5 306.682V287.659ZM1261.13 312.384C1259.14 312.384 1257.42 311.962 1255.98 311.118C1254.53 310.266 1253.42 309.081 1252.64 307.564C1251.85 306.038 1251.46 304.27 1251.46 302.259C1251.46 300.23 1251.85 298.457 1252.64 296.94C1253.42 295.415 1254.53 294.23 1255.98 293.386C1257.42 292.534 1259.14 292.108 1261.13 292.108C1263.11 292.108 1264.83 292.534 1266.27 293.386C1267.72 294.23 1268.83 295.415 1269.62 296.94C1270.4 298.457 1270.79 300.23 1270.79 302.259C1270.79 304.27 1270.4 306.038 1269.62 307.564C1268.83 309.081 1267.72 310.266 1266.27 311.118C1264.83 311.962 1263.11 312.384 1261.13 312.384ZM1261.15 308.165C1262.06 308.165 1262.81 307.909 1263.42 307.398C1264.02 306.878 1264.48 306.17 1264.78 305.276C1265.1 304.381 1265.26 303.362 1265.26 302.22C1265.26 301.078 1265.1 300.06 1264.78 299.165C1264.48 298.27 1264.02 297.562 1263.42 297.043C1262.81 296.523 1262.06 296.263 1261.15 296.263C1260.24 296.263 1259.47 296.523 1258.85 297.043C1258.24 297.562 1257.77 298.27 1257.46 299.165C1257.15 300.06 1257 301.078 1257 302.22C1257 303.362 1257.15 304.381 1257.46 305.276C1257.77 306.17 1258.24 306.878 1258.85 307.398C1259.47 307.909 1260.24 308.165 1261.15 308.165ZM1273.61 312V292.364H1278.89V295.79H1279.1C1279.46 294.571 1280.06 293.651 1280.9 293.028C1281.74 292.398 1282.72 292.082 1283.81 292.082C1284.09 292.082 1284.38 292.099 1284.7 292.134C1285.01 292.168 1285.29 292.214 1285.53 292.274V297.107C1285.27 297.03 1284.92 296.962 1284.47 296.902C1284.02 296.842 1283.6 296.812 1283.23 296.812C1282.43 296.812 1281.71 296.987 1281.08 297.337C1280.46 297.678 1279.96 298.155 1279.6 298.768C1279.24 299.382 1279.06 300.089 1279.06 300.891V312H1273.61ZM1288.56 312.332C1287.71 312.332 1286.99 312.034 1286.38 311.438C1285.79 310.832 1285.49 310.108 1285.49 309.264C1285.49 308.429 1285.79 307.713 1286.38 307.116C1286.99 306.52 1287.71 306.222 1288.56 306.222C1289.38 306.222 1290.09 306.52 1290.7 307.116C1291.32 307.713 1291.63 308.429 1291.63 309.264C1291.63 309.827 1291.48 310.342 1291.19 310.811C1290.91 311.271 1290.54 311.642 1290.08 311.923C1289.62 312.196 1289.11 312.332 1288.56 312.332ZM1295.38 319.364V292.364H1300.75V295.662H1300.99C1301.23 295.134 1301.57 294.597 1302.02 294.051C1302.48 293.497 1303.08 293.037 1303.81 292.67C1304.56 292.295 1305.48 292.108 1306.58 292.108C1308.01 292.108 1309.33 292.483 1310.54 293.233C1311.75 293.974 1312.72 295.095 1313.44 296.595C1314.16 298.087 1314.53 299.957 1314.53 302.207C1314.53 304.398 1314.17 306.247 1313.47 307.756C1312.77 309.256 1311.81 310.393 1310.6 311.169C1309.4 311.936 1308.05 312.32 1306.56 312.32C1305.51 312.32 1304.61 312.145 1303.86 311.795C1303.13 311.446 1302.53 311.007 1302.06 310.479C1301.59 309.942 1301.24 309.401 1300.99 308.855H1300.82V319.364H1295.38ZM1300.71 302.182C1300.71 303.349 1300.87 304.368 1301.19 305.237C1301.52 306.107 1301.99 306.784 1302.6 307.27C1303.21 307.747 1303.96 307.986 1304.84 307.986C1305.72 307.986 1306.47 307.743 1307.09 307.257C1307.7 306.763 1308.16 306.081 1308.48 305.212C1308.8 304.334 1308.97 303.324 1308.97 302.182C1308.97 301.048 1308.81 300.051 1308.49 299.19C1308.18 298.33 1307.71 297.656 1307.1 297.17C1306.49 296.685 1305.73 296.442 1304.84 296.442C1303.95 296.442 1303.2 296.676 1302.59 297.145C1301.98 297.614 1301.52 298.278 1301.19 299.139C1300.87 300 1300.71 301.014 1300.71 302.182ZM1320.17 319.364C1319.48 319.364 1318.83 319.308 1318.22 319.197C1317.63 319.095 1317.13 318.963 1316.74 318.801L1317.97 314.736C1318.61 314.932 1319.18 315.038 1319.69 315.055C1320.21 315.072 1320.66 314.953 1321.04 314.697C1321.42 314.442 1321.73 314.007 1321.97 313.393L1322.29 312.562L1315.25 292.364H1320.97L1325.04 306.784H1325.24L1329.35 292.364H1335.11L1327.48 314.122C1327.11 315.179 1326.61 316.099 1325.98 316.884C1325.36 317.676 1324.57 318.286 1323.62 318.712C1322.66 319.146 1321.51 319.364 1320.17 319.364Z" fill="white"/>
+<rect x="46" y="113" width="241.149" height="61.8182" rx="22" fill="white" stroke="black" stroke-width="4"/>
+<path d="M91.4928 137.364V141.455H79.3735V137.364H91.4928ZM82.1476 157V135.945C82.1476 134.521 82.4246 133.341 82.9786 132.403C83.5411 131.466 84.3081 130.763 85.2797 130.294C86.2513 129.825 87.355 129.591 88.5908 129.591C89.426 129.591 90.1888 129.655 90.8792 129.783C91.578 129.911 92.0979 130.026 92.4388 130.128L91.4672 134.219C91.2542 134.151 90.99 134.087 90.6746 134.027C90.3678 133.967 90.0525 133.938 89.7286 133.938C88.9275 133.938 88.3692 134.125 88.0539 134.5C87.7385 134.866 87.5809 135.382 87.5809 136.047V157H82.1476ZM106.692 148.639V137.364H112.138V157H106.91V153.433H106.705C106.262 154.584 105.525 155.509 104.493 156.207C103.471 156.906 102.222 157.256 100.748 157.256C99.4351 157.256 98.2803 156.957 97.2831 156.361C96.2859 155.764 95.5061 154.916 94.9436 153.817C94.3896 152.717 94.1084 151.401 94.0999 149.866V137.364H99.5459V148.895C99.5544 150.054 99.8655 150.97 100.479 151.643C101.093 152.317 101.915 152.653 102.946 152.653C103.603 152.653 104.216 152.504 104.787 152.206C105.358 151.899 105.819 151.447 106.168 150.851C106.526 150.254 106.701 149.517 106.692 148.639ZM121.22 145.648V157H115.774V137.364H120.965V140.828H121.195C121.63 139.686 122.358 138.783 123.381 138.118C124.404 137.445 125.644 137.108 127.101 137.108C128.465 137.108 129.654 137.406 130.668 138.003C131.682 138.599 132.47 139.452 133.033 140.56C133.595 141.659 133.877 142.972 133.877 144.497V157H128.431V145.469C128.439 144.267 128.132 143.33 127.51 142.656C126.888 141.974 126.031 141.634 124.941 141.634C124.208 141.634 123.56 141.791 122.997 142.107C122.443 142.422 122.009 142.882 121.693 143.487C121.387 144.084 121.229 144.804 121.22 145.648ZM146.321 157.384C144.31 157.384 142.58 156.957 141.131 156.105C139.69 155.244 138.582 154.051 137.807 152.526C137.04 151 136.656 149.244 136.656 147.259C136.656 145.247 137.044 143.483 137.82 141.966C138.604 140.44 139.716 139.251 141.156 138.399C142.597 137.538 144.31 137.108 146.296 137.108C148.009 137.108 149.509 137.419 150.796 138.041C152.082 138.663 153.101 139.537 153.851 140.662C154.601 141.787 155.014 143.108 155.091 144.625H149.952C149.807 143.645 149.423 142.857 148.801 142.26C148.188 141.655 147.382 141.352 146.385 141.352C145.541 141.352 144.804 141.582 144.173 142.043C143.551 142.494 143.065 143.155 142.716 144.024C142.367 144.893 142.192 145.946 142.192 147.182C142.192 148.435 142.362 149.5 142.703 150.378C143.053 151.256 143.543 151.925 144.173 152.385C144.804 152.845 145.541 153.075 146.385 153.075C147.007 153.075 147.565 152.947 148.06 152.692C148.563 152.436 148.976 152.065 149.3 151.58C149.632 151.085 149.849 150.493 149.952 149.803H155.091C155.006 151.303 154.597 152.624 153.864 153.766C153.139 154.899 152.138 155.786 150.859 156.425C149.581 157.064 148.068 157.384 146.321 157.384ZM168.302 137.364V141.455H156.477V137.364H168.302ZM159.162 132.659H164.608V150.966C164.608 151.469 164.685 151.861 164.838 152.142C164.991 152.415 165.204 152.607 165.477 152.717C165.758 152.828 166.082 152.884 166.449 152.884C166.704 152.884 166.96 152.862 167.216 152.82C167.471 152.768 167.667 152.73 167.804 152.705L168.66 156.757C168.388 156.842 168.004 156.94 167.51 157.051C167.015 157.17 166.415 157.243 165.707 157.268C164.395 157.32 163.244 157.145 162.256 156.744C161.275 156.344 160.513 155.722 159.967 154.878C159.422 154.034 159.153 152.969 159.162 151.682V132.659ZM179.791 157.384C177.805 157.384 176.088 156.962 174.639 156.118C173.199 155.266 172.087 154.081 171.303 152.564C170.519 151.038 170.126 149.27 170.126 147.259C170.126 145.23 170.519 143.457 171.303 141.94C172.087 140.415 173.199 139.23 174.639 138.386C176.088 137.534 177.805 137.108 179.791 137.108C181.777 137.108 183.49 137.534 184.93 138.386C186.379 139.23 187.496 140.415 188.28 141.94C189.064 143.457 189.456 145.23 189.456 147.259C189.456 149.27 189.064 151.038 188.28 152.564C187.496 154.081 186.379 155.266 184.93 156.118C183.49 156.962 181.777 157.384 179.791 157.384ZM179.817 153.165C180.72 153.165 181.474 152.909 182.08 152.398C182.685 151.878 183.141 151.17 183.447 150.276C183.763 149.381 183.92 148.362 183.92 147.22C183.92 146.078 183.763 145.06 183.447 144.165C183.141 143.27 182.685 142.562 182.08 142.043C181.474 141.523 180.72 141.263 179.817 141.263C178.905 141.263 178.138 141.523 177.516 142.043C176.902 142.562 176.438 143.27 176.122 144.165C175.815 145.06 175.662 146.078 175.662 147.22C175.662 148.362 175.815 149.381 176.122 150.276C176.438 151.17 176.902 151.878 177.516 152.398C178.138 152.909 178.905 153.165 179.817 153.165ZM192.277 157V137.364H197.557V140.79H197.762C198.12 139.571 198.72 138.651 199.564 138.028C200.408 137.398 201.379 137.082 202.479 137.082C202.752 137.082 203.046 137.099 203.361 137.134C203.676 137.168 203.953 137.214 204.192 137.274V142.107C203.936 142.03 203.583 141.962 203.131 141.902C202.679 141.842 202.266 141.812 201.891 141.812C201.09 141.812 200.374 141.987 199.743 142.337C199.121 142.678 198.627 143.155 198.26 143.768C197.902 144.382 197.723 145.089 197.723 145.891V157H192.277ZM207.221 157.332C206.377 157.332 205.653 157.034 205.048 156.438C204.451 155.832 204.153 155.108 204.153 154.264C204.153 153.429 204.451 152.713 205.048 152.116C205.653 151.52 206.377 151.222 207.221 151.222C208.039 151.222 208.755 151.52 209.369 152.116C209.982 152.713 210.289 153.429 210.289 154.264C210.289 154.827 210.144 155.342 209.854 155.811C209.573 156.271 209.202 156.642 208.742 156.923C208.282 157.196 207.775 157.332 207.221 157.332ZM214.04 164.364V137.364H219.41V140.662H219.653C219.891 140.134 220.236 139.597 220.688 139.051C221.148 138.497 221.745 138.037 222.478 137.67C223.219 137.295 224.14 137.108 225.239 137.108C226.671 137.108 227.992 137.483 229.202 138.233C230.412 138.974 231.38 140.095 232.104 141.595C232.829 143.087 233.191 144.957 233.191 147.207C233.191 149.398 232.837 151.247 232.13 152.756C231.431 154.256 230.476 155.393 229.266 156.169C228.064 156.936 226.718 157.32 225.226 157.32C224.17 157.32 223.27 157.145 222.529 156.795C221.796 156.446 221.195 156.007 220.726 155.479C220.258 154.942 219.9 154.401 219.653 153.855H219.486V164.364H214.04ZM219.371 147.182C219.371 148.349 219.533 149.368 219.857 150.237C220.181 151.107 220.65 151.784 221.263 152.27C221.877 152.747 222.623 152.986 223.501 152.986C224.387 152.986 225.137 152.743 225.751 152.257C226.364 151.763 226.829 151.081 227.144 150.212C227.468 149.334 227.63 148.324 227.63 147.182C227.63 146.048 227.472 145.051 227.157 144.19C226.841 143.33 226.377 142.656 225.763 142.17C225.15 141.685 224.395 141.442 223.501 141.442C222.614 141.442 221.864 141.676 221.251 142.145C220.645 142.614 220.181 143.278 219.857 144.139C219.533 145 219.371 146.014 219.371 147.182ZM238.831 164.364C238.141 164.364 237.493 164.308 236.888 164.197C236.291 164.095 235.797 163.963 235.405 163.801L236.632 159.736C237.271 159.932 237.847 160.038 238.358 160.055C238.878 160.072 239.325 159.953 239.7 159.697C240.084 159.442 240.395 159.007 240.634 158.393L240.953 157.562L233.909 137.364H239.636L243.702 151.784H243.906L248.01 137.364H253.776L246.143 159.122C245.777 160.179 245.278 161.099 244.648 161.884C244.026 162.676 243.237 163.286 242.283 163.712C241.328 164.146 240.178 164.364 238.831 164.364Z" fill="black"/>
+<rect x="4" y="2" width="456" height="62" rx="22" fill="#E6711C" stroke="black" stroke-width="4"/>
+<path d="M84.3929 46V26.3636H89.6727V29.7898H89.8773C90.2352 28.571 90.8361 27.6506 91.6798 27.0284C92.5236 26.3977 93.4952 26.0824 94.5946 26.0824C94.8673 26.0824 95.1614 26.0994 95.4767 26.1335C95.792 26.1676 96.069 26.2145 96.3077 26.2741V31.1065C96.052 31.0298 95.6983 30.9616 95.2466 30.902C94.7949 30.8423 94.3815 30.8125 94.0065 30.8125C93.2054 30.8125 92.4895 30.9872 91.8588 31.3366C91.2367 31.6776 90.7423 32.1548 90.3759 32.7685C90.0179 33.3821 89.8389 34.0895 89.8389 34.8906V46H84.3929ZM98.4034 46V26.3636H103.849V46H98.4034ZM101.139 23.8324C100.33 23.8324 99.6349 23.5639 99.0554 23.027C98.4843 22.4815 98.1988 21.8295 98.1988 21.071C98.1988 20.321 98.4843 19.6776 99.0554 19.1406C99.6349 18.5952 100.33 18.3224 101.139 18.3224C101.949 18.3224 102.639 18.5952 103.21 19.1406C103.79 19.6776 104.08 20.321 104.08 21.071C104.08 21.8295 103.79 22.4815 103.21 23.027C102.639 23.5639 101.949 23.8324 101.139 23.8324ZM112.938 34.6477V46H107.492V26.3636H112.682V29.8281H112.912C113.347 28.6861 114.076 27.7827 115.098 27.1179C116.121 26.4446 117.361 26.108 118.819 26.108C120.182 26.108 121.371 26.4062 122.385 27.0028C123.4 27.5994 124.188 28.4517 124.75 29.5597C125.313 30.6591 125.594 31.9716 125.594 33.4972V46H120.148V34.4688C120.157 33.267 119.85 32.3295 119.228 31.6562C118.606 30.9744 117.749 30.6335 116.658 30.6335C115.925 30.6335 115.277 30.7912 114.715 31.1065C114.161 31.4219 113.726 31.8821 113.411 32.4872C113.104 33.0838 112.947 33.804 112.938 34.6477ZM138.013 53.7727C136.249 53.7727 134.736 53.5298 133.475 53.044C132.222 52.5668 131.225 51.9148 130.483 51.0881C129.742 50.2614 129.26 49.3324 129.039 48.3011L134.076 47.6236C134.229 48.0156 134.472 48.3821 134.804 48.723C135.137 49.0639 135.576 49.3366 136.121 49.5412C136.675 49.7543 137.348 49.8608 138.141 49.8608C139.326 49.8608 140.301 49.571 141.068 48.9915C141.844 48.4205 142.232 47.4616 142.232 46.1151V42.5227H142.002C141.763 43.0682 141.405 43.5838 140.928 44.0696C140.451 44.5554 139.837 44.9517 139.087 45.2585C138.337 45.5653 137.442 45.7188 136.402 45.7188C134.928 45.7188 133.586 45.3778 132.375 44.696C131.174 44.0057 130.215 42.9531 129.499 41.5384C128.791 40.1151 128.438 38.3168 128.438 36.1435C128.438 33.919 128.8 32.0611 129.524 30.5696C130.249 29.0781 131.212 27.9616 132.414 27.2202C133.624 26.4787 134.949 26.108 136.39 26.108C137.489 26.108 138.409 26.2955 139.151 26.6705C139.892 27.0369 140.489 27.4972 140.941 28.0511C141.401 28.5966 141.755 29.1335 142.002 29.6619H142.206V26.3636H147.614V46.1918C147.614 47.8622 147.205 49.2599 146.387 50.3849C145.568 51.5099 144.435 52.3537 142.986 52.9162C141.546 53.4872 139.888 53.7727 138.013 53.7727ZM138.128 41.6278C139.006 41.6278 139.747 41.4105 140.353 40.9759C140.966 40.5327 141.435 39.902 141.759 39.0838C142.091 38.2571 142.257 37.2685 142.257 36.1179C142.257 34.9673 142.095 33.9702 141.772 33.1264C141.448 32.2741 140.979 31.6136 140.365 31.1449C139.752 30.6761 139.006 30.4418 138.128 30.4418C137.233 30.4418 136.479 30.6847 135.865 31.1705C135.252 31.6477 134.787 32.3125 134.472 33.1648C134.157 34.017 133.999 35.0014 133.999 36.1179C133.999 37.2514 134.157 38.2315 134.472 39.0582C134.796 39.8764 135.26 40.5114 135.865 40.9631C136.479 41.4062 137.233 41.6278 138.128 41.6278ZM167.566 31.9631L162.58 32.2699C162.495 31.8437 162.312 31.4602 162.03 31.1193C161.749 30.7699 161.378 30.4929 160.918 30.2884C160.466 30.0753 159.925 29.9688 159.295 29.9688C158.451 29.9688 157.739 30.1477 157.16 30.5057C156.58 30.8551 156.29 31.3239 156.29 31.9119C156.29 32.3807 156.478 32.777 156.853 33.1009C157.228 33.4247 157.871 33.6847 158.783 33.8807L162.337 34.5966C164.246 34.9886 165.67 35.6193 166.607 36.4886C167.545 37.358 168.013 38.5 168.013 39.9148C168.013 41.2017 167.634 42.331 166.875 43.3026C166.125 44.2741 165.094 45.0327 163.782 45.5781C162.478 46.1151 160.973 46.3835 159.269 46.3835C156.67 46.3835 154.598 45.8423 153.056 44.7599C151.522 43.669 150.623 42.1861 150.358 40.3111L155.715 40.0298C155.877 40.8224 156.269 41.4276 156.891 41.8452C157.513 42.2543 158.31 42.4588 159.282 42.4588C160.236 42.4588 161.003 42.2756 161.583 41.9091C162.171 41.5341 162.469 41.0526 162.478 40.4645C162.469 39.9702 162.26 39.5653 161.851 39.25C161.442 38.9261 160.812 38.679 159.959 38.5085L156.559 37.831C154.641 37.4474 153.214 36.7827 152.276 35.8366C151.347 34.8906 150.883 33.6847 150.883 32.2188C150.883 30.9574 151.223 29.8707 151.905 28.9588C152.596 28.0469 153.563 27.3438 154.807 26.8494C156.06 26.3551 157.526 26.108 159.205 26.108C161.685 26.108 163.637 26.6321 165.06 27.6804C166.492 28.7287 167.327 30.1562 167.566 31.9631ZM182.126 18.5909L173.688 49.9375H168.997L177.434 18.5909H182.126ZM200.368 31.9631L195.382 32.2699C195.297 31.8437 195.114 31.4602 194.832 31.1193C194.551 30.7699 194.18 30.4929 193.72 30.2884C193.269 30.0753 192.727 29.9688 192.097 29.9688C191.253 29.9688 190.541 30.1477 189.962 30.5057C189.382 30.8551 189.092 31.3239 189.092 31.9119C189.092 32.3807 189.28 32.777 189.655 33.1009C190.03 33.4247 190.673 33.6847 191.585 33.8807L195.139 34.5966C197.048 34.9886 198.472 35.6193 199.409 36.4886C200.347 37.358 200.815 38.5 200.815 39.9148C200.815 41.2017 200.436 42.331 199.678 43.3026C198.928 44.2741 197.896 45.0327 196.584 45.5781C195.28 46.1151 193.776 46.3835 192.071 46.3835C189.472 46.3835 187.401 45.8423 185.858 44.7599C184.324 43.669 183.425 42.1861 183.161 40.3111L188.517 40.0298C188.679 40.8224 189.071 41.4276 189.693 41.8452C190.315 42.2543 191.112 42.4588 192.084 42.4588C193.038 42.4588 193.805 42.2756 194.385 41.9091C194.973 41.5341 195.271 41.0526 195.28 40.4645C195.271 39.9702 195.063 39.5653 194.654 39.25C194.244 38.9261 193.614 38.679 192.761 38.5085L189.361 37.831C187.443 37.4474 186.016 36.7827 185.078 35.8366C184.149 34.8906 183.685 33.6847 183.685 32.2188C183.685 30.9574 184.026 29.8707 184.707 28.9588C185.398 28.0469 186.365 27.3438 187.609 26.8494C188.862 26.3551 190.328 26.108 192.007 26.108C194.487 26.108 196.439 26.6321 197.862 27.6804C199.294 28.7287 200.129 30.1562 200.368 31.9631ZM212.474 46.3835C210.454 46.3835 208.715 45.9744 207.258 45.1562C205.809 44.3295 204.692 43.1619 203.908 41.6534C203.124 40.1364 202.732 38.3423 202.732 36.2713C202.732 34.2514 203.124 32.4787 203.908 30.9531C204.692 29.4276 205.796 28.2386 207.219 27.3864C208.651 26.5341 210.33 26.108 212.256 26.108C213.552 26.108 214.758 26.3168 215.874 26.7344C216.999 27.1435 217.979 27.7614 218.815 28.5881C219.658 29.4148 220.315 30.4545 220.783 31.7074C221.252 32.9517 221.486 34.4091 221.486 36.0795V37.5753H204.905V34.2003H216.36C216.36 33.4162 216.19 32.7216 215.849 32.1165C215.508 31.5114 215.035 31.0384 214.43 30.6974C213.833 30.348 213.138 30.1733 212.346 30.1733C211.519 30.1733 210.786 30.3651 210.147 30.7486C209.516 31.1236 209.022 31.6307 208.664 32.2699C208.306 32.9006 208.123 33.6037 208.114 34.3793V37.5881C208.114 38.5597 208.293 39.3991 208.651 40.1065C209.018 40.8139 209.533 41.3594 210.198 41.7429C210.863 42.1264 211.651 42.3182 212.563 42.3182C213.168 42.3182 213.722 42.233 214.225 42.0625C214.728 41.892 215.158 41.6364 215.516 41.2955C215.874 40.9545 216.147 40.5369 216.334 40.0426L221.371 40.375C221.116 41.5852 220.592 42.642 219.799 43.5455C219.015 44.4403 218.001 45.1392 216.756 45.642C215.521 46.1364 214.093 46.3835 212.474 46.3835ZM224.32 53.3636V26.3636H229.69V29.6619H229.933C230.171 29.1335 230.516 28.5966 230.968 28.0511C231.428 27.4972 232.025 27.0369 232.758 26.6705C233.499 26.2955 234.42 26.108 235.519 26.108C236.951 26.108 238.272 26.483 239.482 27.233C240.693 27.9744 241.66 29.0952 242.384 30.5952C243.109 32.0866 243.471 33.9574 243.471 36.2074C243.471 38.3977 243.117 40.2472 242.41 41.7557C241.711 43.2557 240.756 44.3935 239.546 45.169C238.345 45.9361 236.998 46.3196 235.506 46.3196C234.45 46.3196 233.551 46.1449 232.809 45.7955C232.076 45.446 231.475 45.0071 231.006 44.4787C230.538 43.9418 230.18 43.4006 229.933 42.8551H229.766V53.3636H224.32ZM229.651 36.1818C229.651 37.3494 229.813 38.3679 230.137 39.2372C230.461 40.1065 230.93 40.7841 231.543 41.2699C232.157 41.7472 232.903 41.9858 233.781 41.9858C234.667 41.9858 235.417 41.7429 236.031 41.2571C236.644 40.7628 237.109 40.081 237.424 39.2116C237.748 38.3338 237.91 37.3239 237.91 36.1818C237.91 35.0483 237.752 34.0511 237.437 33.1903C237.122 32.3295 236.657 31.6562 236.043 31.1705C235.43 30.6847 234.676 30.4418 233.781 30.4418C232.894 30.4418 232.144 30.6761 231.531 31.1449C230.926 31.6136 230.461 32.2784 230.137 33.1392C229.813 34 229.651 35.0142 229.651 36.1818ZM251.981 46.3707C250.728 46.3707 249.612 46.1534 248.632 45.7188C247.652 45.2756 246.876 44.6236 246.305 43.7628C245.742 42.8935 245.461 41.8111 245.461 40.5156C245.461 39.4247 245.661 38.5085 246.062 37.767C246.463 37.0256 247.008 36.429 247.698 35.9773C248.389 35.5256 249.173 35.1847 250.051 34.9545C250.937 34.7244 251.866 34.5625 252.838 34.4688C253.98 34.3494 254.9 34.2386 255.599 34.1364C256.298 34.0256 256.805 33.8636 257.12 33.6506C257.436 33.4375 257.593 33.1222 257.593 32.7045V32.6278C257.593 31.8182 257.338 31.1918 256.826 30.7486C256.323 30.3054 255.608 30.0838 254.679 30.0838C253.698 30.0838 252.919 30.3011 252.339 30.7358C251.759 31.1619 251.376 31.6989 251.188 32.3466L246.152 31.9375C246.407 30.7443 246.91 29.7131 247.66 28.8438C248.41 27.9659 249.377 27.2926 250.562 26.8239C251.755 26.3466 253.136 26.108 254.704 26.108C255.795 26.108 256.839 26.2358 257.836 26.4915C258.842 26.7472 259.733 27.1435 260.508 27.6804C261.292 28.2173 261.91 28.9077 262.362 29.7514C262.813 30.5866 263.039 31.5881 263.039 32.7557V46H257.875V43.277H257.721C257.406 43.8906 256.984 44.4318 256.456 44.9006C255.927 45.3608 255.292 45.723 254.551 45.9872C253.809 46.2429 252.953 46.3707 251.981 46.3707ZM253.541 42.6122C254.342 42.6122 255.049 42.4545 255.663 42.1392C256.277 41.8153 256.758 41.3807 257.108 40.8352C257.457 40.2898 257.632 39.6719 257.632 38.9815V36.8977C257.461 37.0085 257.227 37.1108 256.929 37.2045C256.639 37.2898 256.311 37.3707 255.944 37.4474C255.578 37.5156 255.211 37.5795 254.845 37.6392C254.478 37.6903 254.146 37.7372 253.848 37.7798C253.208 37.8736 252.65 38.0227 252.173 38.2273C251.696 38.4318 251.325 38.7088 251.061 39.0582C250.796 39.3991 250.664 39.8253 250.664 40.3366C250.664 41.0781 250.933 41.6449 251.47 42.0369C252.015 42.4205 252.706 42.6122 253.541 42.6122ZM266.544 46V26.3636H271.824V29.7898H272.029C272.387 28.571 272.988 27.6506 273.831 27.0284C274.675 26.3977 275.647 26.0824 276.746 26.0824C277.019 26.0824 277.313 26.0994 277.628 26.1335C277.944 26.1676 278.221 26.2145 278.459 26.2741V31.1065C278.204 31.0298 277.85 30.9616 277.398 30.902C276.946 30.8423 276.533 30.8125 276.158 30.8125C275.357 30.8125 274.641 30.9872 274.01 31.3366C273.388 31.6776 272.894 32.1548 272.527 32.7685C272.169 33.3821 271.99 34.0895 271.99 34.8906V46H266.544ZM285.592 46.3707C284.339 46.3707 283.223 46.1534 282.242 45.7188C281.262 45.2756 280.487 44.6236 279.916 43.7628C279.353 42.8935 279.072 41.8111 279.072 40.5156C279.072 39.4247 279.272 38.5085 279.673 37.767C280.073 37.0256 280.619 36.429 281.309 35.9773C282 35.5256 282.784 35.1847 283.661 34.9545C284.548 34.7244 285.477 34.5625 286.448 34.4688C287.59 34.3494 288.511 34.2386 289.21 34.1364C289.909 34.0256 290.416 33.8636 290.731 33.6506C291.046 33.4375 291.204 33.1222 291.204 32.7045V32.6278C291.204 31.8182 290.948 31.1918 290.437 30.7486C289.934 30.3054 289.218 30.0838 288.289 30.0838C287.309 30.0838 286.529 30.3011 285.95 30.7358C285.37 31.1619 284.987 31.6989 284.799 32.3466L279.762 31.9375C280.018 30.7443 280.521 29.7131 281.271 28.8438C282.021 27.9659 282.988 27.2926 284.173 26.8239C285.366 26.3466 286.747 26.108 288.315 26.108C289.406 26.108 290.45 26.2358 291.447 26.4915C292.453 26.7472 293.343 27.1435 294.119 27.6804C294.903 28.2173 295.521 28.9077 295.973 29.7514C296.424 30.5866 296.65 31.5881 296.65 32.7557V46H291.485V43.277H291.332C291.017 43.8906 290.595 44.4318 290.066 44.9006C289.538 45.3608 288.903 45.723 288.161 45.9872C287.42 46.2429 286.563 46.3707 285.592 46.3707ZM287.152 42.6122C287.953 42.6122 288.66 42.4545 289.274 42.1392C289.887 41.8153 290.369 41.3807 290.718 40.8352C291.068 40.2898 291.242 39.6719 291.242 38.9815V36.8977C291.072 37.0085 290.838 37.1108 290.539 37.2045C290.25 37.2898 289.921 37.3707 289.555 37.4474C289.188 37.5156 288.822 37.5795 288.456 37.6392C288.089 37.6903 287.757 37.7372 287.458 37.7798C286.819 37.8736 286.261 38.0227 285.784 38.2273C285.306 38.4318 284.936 38.7088 284.671 39.0582C284.407 39.3991 284.275 39.8253 284.275 40.3366C284.275 41.0781 284.544 41.6449 285.081 42.0369C285.626 42.4205 286.316 42.6122 287.152 42.6122ZM300.258 46V19.8182H305.704V29.6619H305.87C306.108 29.1335 306.454 28.5966 306.905 28.0511C307.365 27.4972 307.962 27.0369 308.695 26.6705C309.436 26.2955 310.357 26.108 311.456 26.108C312.888 26.108 314.209 26.483 315.419 27.233C316.63 27.9744 317.597 29.0952 318.321 30.5952C319.046 32.0866 319.408 33.9574 319.408 36.2074C319.408 38.3977 319.054 40.2472 318.347 41.7557C317.648 43.2557 316.694 44.3935 315.483 45.169C314.282 45.9361 312.935 46.3196 311.444 46.3196C310.387 46.3196 309.488 46.1449 308.746 45.7955C308.013 45.446 307.412 45.0071 306.944 44.4787C306.475 43.9418 306.117 43.4006 305.87 42.8551H305.627V46H300.258ZM305.588 36.1818C305.588 37.3494 305.75 38.3679 306.074 39.2372C306.398 40.1065 306.867 40.7841 307.481 41.2699C308.094 41.7472 308.84 41.9858 309.718 41.9858C310.604 41.9858 311.354 41.7429 311.968 41.2571C312.581 40.7628 313.046 40.081 313.361 39.2116C313.685 38.3338 313.847 37.3239 313.847 36.1818C313.847 35.0483 313.689 34.0511 313.374 33.1903C313.059 32.3295 312.594 31.6562 311.981 31.1705C311.367 30.6847 310.613 30.4418 309.718 30.4418C308.831 30.4418 308.081 30.6761 307.468 31.1449C306.863 31.6136 306.398 32.2784 306.074 33.1392C305.75 34 305.588 35.0142 305.588 36.1818ZM322.322 46V26.3636H327.768V46H322.322ZM325.058 23.8324C324.248 23.8324 323.554 23.5639 322.974 23.027C322.403 22.4815 322.117 21.8295 322.117 21.071C322.117 20.321 322.403 19.6776 322.974 19.1406C323.554 18.5952 324.248 18.3224 325.058 18.3224C325.867 18.3224 326.558 18.5952 327.129 19.1406C327.708 19.6776 327.998 20.321 327.998 21.071C327.998 21.8295 327.708 22.4815 327.129 23.027C326.558 23.5639 325.867 23.8324 325.058 23.8324ZM336.857 19.8182V46H331.411V19.8182H336.857ZM340.499 46V26.3636H345.945V46H340.499ZM343.235 23.8324C342.425 23.8324 341.731 23.5639 341.151 23.027C340.58 22.4815 340.295 21.8295 340.295 21.071C340.295 20.321 340.58 19.6776 341.151 19.1406C341.731 18.5952 342.425 18.3224 343.235 18.3224C344.045 18.3224 344.735 18.5952 345.306 19.1406C345.886 19.6776 346.175 20.321 346.175 21.071C346.175 21.8295 345.886 22.4815 345.306 23.027C344.735 23.5639 344.045 23.8324 343.235 23.8324ZM360.032 26.3636V30.4545H348.207V26.3636H360.032ZM350.892 21.6591H356.338V39.9659C356.338 40.4687 356.414 40.8608 356.568 41.142C356.721 41.4148 356.934 41.6065 357.207 41.7173C357.488 41.8281 357.812 41.8835 358.179 41.8835C358.434 41.8835 358.69 41.8622 358.946 41.8196C359.201 41.7685 359.397 41.7301 359.534 41.7045L360.39 45.7571C360.118 45.8423 359.734 45.9403 359.24 46.0511C358.745 46.1705 358.145 46.2429 357.437 46.2685C356.125 46.3196 354.974 46.1449 353.985 45.7443C353.005 45.3437 352.243 44.7216 351.697 43.8778C351.152 43.0341 350.883 41.9687 350.892 40.6818V21.6591ZM366.222 53.3636C365.532 53.3636 364.884 53.3082 364.279 53.1974C363.682 53.0952 363.188 52.9631 362.796 52.8011L364.023 48.7358C364.662 48.9318 365.238 49.0384 365.749 49.0554C366.269 49.0724 366.716 48.9531 367.091 48.6974C367.475 48.4418 367.786 48.0071 368.025 47.3935L368.344 46.5625L361.3 26.3636H367.028L371.093 40.7841H371.297L375.401 26.3636H381.167L373.535 48.1222C373.168 49.179 372.67 50.0994 372.039 50.8835C371.417 51.6761 370.628 52.2855 369.674 52.7116C368.719 53.1463 367.569 53.3636 366.222 53.3636Z" fill="white"/>
+<rect x="1451" y="528" width="144" height="156" rx="6" fill="#D9D9D9" stroke="black" stroke-width="4"/>
+<path d="M1531.5 554.78L1513.5 562.706V557.528L1525.82 552.581L1525.66 552.849V552.21L1525.82 552.479L1513.5 547.531V542.354L1531.5 550.28V554.78ZM1529.06 583.591L1520.63 614.938H1515.93L1524.37 583.591H1529.06ZM1513.5 650.78V646.28L1531.5 638.354V643.531L1519.18 648.479L1519.34 648.21V648.849L1519.18 648.581L1531.5 653.528V658.706L1513.5 650.78Z" fill="black"/>
+<path d="M1526.19 465.375H1514.56C1514.6 461.375 1514.96 458.104 1515.62 455.562C1516.33 452.979 1517.48 450.625 1519.06 448.5C1520.65 446.375 1522.75 443.958 1525.38 441.25C1527.29 439.292 1529.04 437.458 1530.62 435.75C1532.25 434 1533.56 432.125 1534.56 430.125C1535.56 428.083 1536.06 425.646 1536.06 422.812C1536.06 419.938 1535.54 417.458 1534.5 415.375C1533.5 413.292 1532 411.688 1530 410.562C1528.04 409.438 1525.6 408.875 1522.69 408.875C1520.27 408.875 1517.98 409.312 1515.81 410.188C1513.65 411.062 1511.9 412.417 1510.56 414.25C1509.23 416.042 1508.54 418.396 1508.5 421.312H1496.94C1497.02 416.604 1498.19 412.562 1500.44 409.188C1502.73 405.812 1505.81 403.229 1509.69 401.438C1513.56 399.646 1517.9 398.75 1522.69 398.75C1527.98 398.75 1532.48 399.708 1536.19 401.625C1539.94 403.542 1542.79 406.292 1544.75 409.875C1546.71 413.417 1547.69 417.625 1547.69 422.5C1547.69 426.25 1546.92 429.708 1545.38 432.875C1543.88 436 1541.94 438.938 1539.56 441.688C1537.19 444.438 1534.67 447.062 1532 449.562C1529.71 451.688 1528.17 454.083 1527.38 456.75C1526.58 459.417 1526.19 462.292 1526.19 465.375ZM1514.06 485.188C1514.06 483.312 1514.65 481.729 1515.81 480.438C1516.98 479.146 1518.67 478.5 1520.88 478.5C1523.12 478.5 1524.83 479.146 1526 480.438C1527.17 481.729 1527.75 483.312 1527.75 485.188C1527.75 486.979 1527.17 488.521 1526 489.812C1524.83 491.104 1523.12 491.75 1520.88 491.75C1518.67 491.75 1516.98 491.104 1515.81 489.812C1514.65 488.521 1514.06 486.979 1514.06 485.188Z" fill="black"/>
+<mask id="mask103_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="536" y="854" width="112" height="114">
+<path d="M536 967.037H647.004V854H536V967.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask103_13_16079)">
+<mask id="mask104_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask104_13_16079)">
+<path d="M632.723 910.52L627.2 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask105_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask105_13_16079)">
+<path d="M632.723 910.52L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask106_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask106_13_16079)">
+<path d="M632.723 910.52L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask107_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask107_13_16079)">
+<path d="M632.723 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask108_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask108_13_16079)">
+<path d="M627.2 889.532L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask109_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask109_13_16079)">
+<path d="M627.2 889.532L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask110_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask110_13_16079)">
+<path d="M627.2 889.532L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask111_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask111_13_16079)">
+<path d="M612.112 874.168L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask112_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask112_13_16079)">
+<path d="M570.89 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask113_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask113_13_16079)">
+<path d="M570.891 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask114_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask114_13_16079)">
+<path d="M570.89 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask115_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask115_13_16079)">
+<path d="M555.802 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask116_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask116_13_16079)">
+<path d="M555.802 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask117_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask117_13_16079)">
+<path d="M555.802 889.532L570.89 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask118_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask118_13_16079)">
+<path d="M550.28 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask119_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask119_13_16079)">
+<path d="M570.891 946.872L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask120_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask120_13_16079)">
+<path d="M570.891 946.872H612.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask121_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask121_13_16079)">
+<path d="M570.891 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask122_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask122_13_16079)">
+<path d="M591.501 952.495L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask123_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask123_13_16079)">
+<path d="M591.501 952.495L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask124_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask124_13_16079)">
+<path d="M612.112 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask125_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask125_13_16079)">
+<path d="M632.723 910.52L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask126_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask126_13_16079)">
+<path d="M632.723 910.52L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask127_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask127_13_16079)">
+<path d="M632.723 910.52L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask128_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask128_13_16079)">
+<path d="M632.723 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask129_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask129_13_16079)">
+<path d="M632.723 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask130_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask130_13_16079)">
+<path d="M632.723 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask131_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask131_13_16079)">
+<path d="M632.723 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask132_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask132_13_16079)">
+<path d="M627.2 889.532H555.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask133_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask133_13_16079)">
+<path d="M627.2 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask134_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask134_13_16079)">
+<path d="M627.2 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask135_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask135_13_16079)">
+<path d="M627.2 889.532L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask136_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask136_13_16079)">
+<path d="M627.2 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask137_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask137_13_16079)">
+<path d="M627.2 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask138_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask138_13_16079)">
+<path d="M627.2 889.532V931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask139_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask139_13_16079)">
+<path d="M612.112 874.168H570.891" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask140_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask140_13_16079)">
+<path d="M612.112 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask141_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask141_13_16079)">
+<path d="M612.112 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask142_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask142_13_16079)">
+<path d="M612.112 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask143_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask143_13_16079)">
+<path d="M612.112 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask144_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask144_13_16079)">
+<path d="M612.112 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask145_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask145_13_16079)">
+<path d="M612.112 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask146_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask146_13_16079)">
+<path d="M612.112 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask147_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask147_13_16079)">
+<path d="M591.501 868.544L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask148_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask148_13_16079)">
+<path d="M591.501 868.544L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask149_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask149_13_16079)">
+<path d="M591.501 868.544L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask150_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask150_13_16079)">
+<path d="M591.501 868.544L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask151_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask151_13_16079)">
+<path d="M591.501 868.544L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask152_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask152_13_16079)">
+<path d="M591.501 868.544V952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask153_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask153_13_16079)">
+<path d="M591.501 868.544L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask154_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask154_13_16079)">
+<path d="M591.501 868.544L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask155_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask155_13_16079)">
+<path d="M570.891 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask156_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask156_13_16079)">
+<path d="M570.891 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask157_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask157_13_16079)">
+<path d="M570.891 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask158_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask158_13_16079)">
+<path d="M570.891 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask159_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask159_13_16079)">
+<path d="M555.802 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask160_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask160_13_16079)">
+<path d="M555.802 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask161_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask161_13_16079)">
+<path d="M555.802 889.532L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask162_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask162_13_16079)">
+<path d="M550.28 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask163_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask163_13_16079)">
+<path d="M550.28 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask164_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask164_13_16079)">
+<path d="M550.28 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask165_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask165_13_16079)">
+<path d="M550.28 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask166_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask166_13_16079)">
+<path d="M555.802 931.508L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask167_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask167_13_16079)">
+<path d="M555.802 931.508L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask168_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask168_13_16079)">
+<path d="M555.802 931.508L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask169_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask169_13_16079)">
+<path d="M555.802 931.508L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask170_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask170_13_16079)">
+<mask id="mask171_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="627" y="905" width="11" height="11">
+<path d="M627.766 915.568H637.68V905.472H627.766V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask171_13_16079)">
+<path d="M632.723 915.045C633.901 915.045 635.032 914.568 635.865 913.72C636.699 912.871 637.167 911.72 637.167 910.52C637.167 909.32 636.699 908.168 635.865 907.32C635.032 906.471 633.901 905.994 632.723 905.994C631.544 905.994 630.414 906.471 629.58 907.32C628.747 908.168 628.279 909.32 628.279 910.52C628.279 911.72 628.747 912.871 629.58 913.72C630.414 914.568 631.544 915.045 632.723 915.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask172_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask172_13_16079)">
+<mask id="mask173_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="884" width="11" height="11">
+<path d="M622.243 894.58H632.157V884.484H622.243V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask173_13_16079)">
+<path d="M627.2 894.057C628.379 894.057 629.509 893.58 630.343 892.732C631.176 891.883 631.644 890.732 631.644 889.532C631.644 888.332 631.176 887.181 630.343 886.332C629.509 885.483 628.379 885.007 627.2 885.007C626.022 885.007 624.891 885.483 624.058 886.332C623.224 887.181 622.756 888.332 622.756 889.532C622.756 890.732 623.224 891.883 624.058 892.732C624.891 893.58 626.022 894.057 627.2 894.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask174_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask174_13_16079)">
+<mask id="mask175_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="869" width="11" height="11">
+<path d="M607.155 879.215H617.069V869.12H607.155V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask175_13_16079)">
+<path d="M612.112 878.693C613.291 878.693 614.421 878.216 615.254 877.367C616.088 876.519 616.556 875.368 616.556 874.168C616.556 872.967 616.088 871.816 615.254 870.968C614.421 870.119 613.291 869.642 612.112 869.642C610.933 869.642 609.803 870.119 608.97 870.968C608.136 871.816 607.668 872.967 607.668 874.168C607.668 875.368 608.136 876.519 608.97 877.367C609.803 878.216 610.933 878.693 612.112 878.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask176_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask176_13_16079)">
+<mask id="mask177_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="863" width="11" height="11">
+<path d="M586.544 873.592H596.458V863.496H586.544V873.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask177_13_16079)">
+<path d="M591.501 873.069C592.68 873.069 593.81 872.592 594.644 871.744C595.477 870.895 595.945 869.744 595.945 868.544C595.945 867.344 595.477 866.193 594.644 865.344C593.81 864.495 592.68 864.019 591.501 864.019C590.323 864.019 589.192 864.495 588.359 865.344C587.526 866.193 587.057 867.344 587.057 868.544C587.057 869.744 587.526 870.895 588.359 871.744C589.192 872.592 590.323 873.069 591.501 873.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask178_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask178_13_16079)">
+<mask id="mask179_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="869" width="11" height="11">
+<path d="M565.933 879.215H575.848V869.12H565.933V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask179_13_16079)">
+<path d="M570.891 878.693C572.069 878.693 573.2 878.216 574.033 877.367C574.866 876.519 575.334 875.368 575.334 874.168C575.334 872.967 574.866 871.816 574.033 870.968C573.2 870.119 572.069 869.642 570.891 869.642C569.712 869.642 568.581 870.119 567.748 870.968C566.915 871.816 566.447 872.967 566.447 874.168C566.447 875.368 566.915 876.519 567.748 877.367C568.581 878.216 569.712 878.693 570.891 878.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask180_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask180_13_16079)">
+<mask id="mask181_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="884" width="11" height="11">
+<path d="M550.845 894.58H560.76V884.484H550.845V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask181_13_16079)">
+<path d="M555.802 894.057C556.981 894.057 558.111 893.58 558.945 892.732C559.778 891.883 560.246 890.732 560.246 889.532C560.246 888.332 559.778 887.181 558.945 886.332C558.111 885.483 556.981 885.007 555.802 885.007C554.624 885.007 553.493 885.483 552.66 886.332C551.827 887.181 551.358 888.332 551.358 889.532C551.358 890.732 551.827 891.883 552.66 892.732C553.493 893.58 554.624 894.057 555.802 894.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask182_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask182_13_16079)">
+<mask id="mask183_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="545" y="905" width="11" height="11">
+<path d="M545.323 915.568H555.237V905.472H545.323V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask183_13_16079)">
+<path d="M550.28 915.045C551.458 915.045 552.589 914.568 553.422 913.72C554.255 912.871 554.724 911.72 554.724 910.52C554.724 909.32 554.255 908.168 553.422 907.32C552.589 906.471 551.458 905.994 550.28 905.994C549.101 905.994 547.971 906.471 547.137 907.32C546.304 908.168 545.836 909.32 545.836 910.52C545.836 911.72 546.304 912.871 547.137 913.72C547.971 914.568 549.101 915.045 550.28 915.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask184_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask184_13_16079)">
+<mask id="mask185_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="926" width="11" height="11">
+<path d="M550.845 936.555H560.76V926.46H550.845V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask185_13_16079)">
+<path d="M555.802 936.033C556.981 936.033 558.111 935.556 558.945 934.708C559.778 933.859 560.246 932.708 560.246 931.508C560.246 930.308 559.778 929.156 558.945 928.308C558.111 927.459 556.981 926.982 555.802 926.982C554.624 926.982 553.493 927.459 552.66 928.308C551.827 929.156 551.358 930.308 551.358 931.508C551.358 932.708 551.827 933.859 552.66 934.708C553.493 935.556 554.624 936.033 555.802 936.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask186_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask186_13_16079)">
+<mask id="mask187_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="941" width="11" height="11">
+<path d="M565.933 951.92H575.848V941.824H565.933V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask187_13_16079)">
+<path d="M570.891 951.397C572.069 951.397 573.2 950.92 574.033 950.072C574.866 949.223 575.334 948.072 575.334 946.872C575.334 945.672 574.866 944.521 574.033 943.672C573.2 942.823 572.069 942.347 570.891 942.347C569.712 942.347 568.581 942.823 567.748 943.672C566.915 944.521 566.447 945.672 566.447 946.872C566.447 948.072 566.915 949.223 567.748 950.072C568.581 950.92 569.712 951.397 570.891 951.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask188_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask188_13_16079)">
+<mask id="mask189_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="947" width="11" height="11">
+<path d="M586.544 957.543H596.458V947.448H586.544V957.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask189_13_16079)">
+<path d="M591.501 957.021C592.68 957.021 593.81 956.544 594.644 955.695C595.477 954.847 595.945 953.696 595.945 952.496C595.945 951.295 595.477 950.144 594.644 949.296C593.81 948.447 592.68 947.97 591.501 947.97C590.323 947.97 589.192 948.447 588.359 949.296C587.526 950.144 587.057 951.295 587.057 952.496C587.057 953.696 587.526 954.847 588.359 955.695C589.192 956.544 590.323 957.021 591.501 957.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask190_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask190_13_16079)">
+<mask id="mask191_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="941" width="11" height="11">
+<path d="M607.155 951.92H617.069V941.824H607.155V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask191_13_16079)">
+<path d="M612.112 951.397C613.291 951.397 614.421 950.92 615.254 950.072C616.088 949.223 616.556 948.072 616.556 946.872C616.556 945.672 616.088 944.521 615.254 943.672C614.421 942.823 613.291 942.347 612.112 942.347C610.933 942.347 609.803 942.823 608.97 943.672C608.136 944.521 607.668 945.672 607.668 946.872C607.668 948.072 608.136 949.223 608.97 950.072C609.803 950.92 610.933 951.397 612.112 951.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask192_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask192_13_16079)">
+<mask id="mask193_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="926" width="11" height="11">
+<path d="M622.243 936.555H632.157V926.46H622.243V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask193_13_16079)">
+<path d="M627.2 936.033C628.379 936.033 629.509 935.556 630.343 934.708C631.176 933.859 631.644 932.708 631.644 931.508C631.644 930.308 631.176 929.156 630.343 928.308C629.509 927.459 628.379 926.982 627.2 926.982C626.022 926.982 624.891 927.459 624.058 928.308C623.224 929.156 622.756 930.308 622.756 931.508C622.756 932.708 623.224 933.859 624.058 934.708C624.891 935.556 626.022 936.033 627.2 936.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask194_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask194_13_16079)">
+<path d="M632.767 907.274C632.36 907.274 632.066 907.389 631.795 907.642C631.388 908.057 631.117 908.885 631.117 909.737C631.117 910.542 631.343 911.394 631.682 911.808C631.953 912.13 632.315 912.291 632.721 912.291C633.083 912.291 633.399 912.176 633.648 911.923C634.077 911.532 634.349 910.68 634.349 909.783C634.349 908.287 633.693 907.274 632.767 907.274ZM632.744 907.458C633.332 907.458 633.648 908.287 633.648 909.806C633.648 911.325 633.354 912.107 632.721 912.107C632.111 912.107 631.795 911.325 631.795 909.806C631.795 908.264 632.111 907.458 632.744 907.458Z" fill="white"/>
+</g>
+<mask id="mask195_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask195_13_16079)">
+<path d="M627.489 886.291L626.201 886.959V887.051C626.292 887.005 626.359 886.982 626.405 886.982C626.518 886.913 626.653 886.89 626.721 886.89C626.879 886.89 626.947 887.005 626.947 887.235V890.549C626.947 890.779 626.879 890.94 626.766 891.009C626.653 891.078 626.563 891.101 626.246 891.101V891.216H628.235V891.101C627.67 891.101 627.557 891.032 627.557 890.687V886.291H627.489Z" fill="white"/>
+</g>
+<mask id="mask196_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask196_13_16079)">
+<path d="M613.737 874.859L613.624 874.813C613.376 875.228 613.285 875.297 612.946 875.297H611.251L612.449 874.008C613.082 873.34 613.353 872.788 613.353 872.213C613.353 871.476 612.788 870.924 612.042 870.924C611.635 870.924 611.274 871.085 611.003 871.361C610.777 871.614 610.664 871.844 610.551 872.374L610.686 872.397C610.98 871.683 611.251 871.453 611.726 871.453C612.336 871.453 612.743 871.868 612.743 872.489C612.743 873.064 612.426 873.732 611.816 874.376L610.551 875.757V875.849H613.33L613.737 874.859Z" fill="white"/>
+</g>
+<mask id="mask197_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask197_13_16079)">
+<path d="M590.821 867.811C591.227 867.811 591.386 867.834 591.566 867.903C592.018 868.065 592.29 868.479 592.29 868.985C592.29 869.583 591.883 870.067 591.363 870.067C591.16 870.067 591.024 870.021 590.753 869.837C590.527 869.698 590.414 869.652 590.301 869.652C590.12 869.652 590.03 869.768 590.03 869.906C590.03 870.159 590.323 870.32 590.821 870.32C591.386 870.32 591.951 870.136 592.29 869.837C592.629 869.537 592.809 869.123 592.809 868.64C592.809 868.249 592.696 867.926 592.493 867.696C592.335 867.535 592.199 867.443 591.883 867.305C592.38 866.96 592.561 866.684 592.561 866.292C592.561 865.694 592.109 865.303 591.453 865.303C591.092 865.303 590.775 865.418 590.527 865.648C590.301 865.855 590.188 866.039 590.03 866.477L590.143 866.5C590.436 865.97 590.753 865.74 591.205 865.74C591.679 865.74 591.996 866.062 591.996 866.523C591.996 866.776 591.883 867.029 591.702 867.213C591.499 867.443 591.295 867.558 590.821 867.719V867.811Z" fill="white"/>
+</g>
+<mask id="mask198_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask198_13_16079)">
+<path d="M572.492 874.169H571.746V870.924H571.43L569.192 874.169V874.629H571.204V875.849H571.746V874.629H572.492V874.169ZM571.204 874.169H569.463L571.204 871.66V874.169Z" fill="white"/>
+</g>
+<mask id="mask199_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask199_13_16079)">
+<path d="M555.299 886.959H556.722C556.835 886.959 556.858 886.959 556.881 886.89L557.152 886.245L557.084 886.199C556.971 886.36 556.903 886.383 556.745 886.383H555.253L554.485 888.109C554.462 888.132 554.462 888.132 554.462 888.156C554.462 888.179 554.508 888.202 554.553 888.202C554.779 888.202 555.073 888.271 555.366 888.363C556.18 888.616 556.564 889.076 556.564 889.812C556.564 890.503 556.135 891.055 555.57 891.055C555.434 891.055 555.299 890.986 555.095 890.848C554.869 890.664 554.688 890.595 554.553 890.595C554.349 890.595 554.236 890.687 554.236 890.871C554.236 891.147 554.575 891.308 555.118 891.308C555.705 891.308 556.225 891.124 556.587 890.756C556.926 890.411 557.061 889.997 557.061 889.444C557.061 888.915 556.926 888.593 556.564 888.225C556.27 887.902 555.841 887.741 555.005 887.58L555.299 886.959Z" fill="white"/>
+</g>
+<mask id="mask200_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask200_13_16079)">
+<path d="M551.677 907.205C550.863 907.274 550.457 907.412 549.937 907.803C549.146 908.356 548.739 909.184 548.739 910.174C548.739 910.795 548.92 911.44 549.236 911.808C549.507 912.13 549.892 912.291 550.344 912.291C551.225 912.291 551.835 911.601 551.835 910.611C551.835 909.668 551.315 909.069 550.502 909.069C550.185 909.069 550.027 909.138 549.575 909.414C549.779 908.31 550.57 907.504 551.7 907.32L551.677 907.205ZM550.231 909.414C550.841 909.414 551.202 909.944 551.202 910.841C551.202 911.647 550.909 912.107 550.411 912.107C549.779 912.107 549.394 911.417 549.394 910.289C549.394 909.898 549.462 909.714 549.598 909.599C549.756 909.483 549.982 909.414 550.231 909.414Z" fill="white"/>
+</g>
+<mask id="mask201_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask201_13_16079)">
+<path d="M557.22 928.355H554.575L554.146 929.436L554.282 929.482C554.575 928.999 554.711 928.907 555.118 928.907H556.655L555.253 933.257H555.705L557.22 928.47V928.355Z" fill="white"/>
+</g>
+<mask id="mask202_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask202_13_16079)">
+<path d="M571.181 945.839C571.882 945.471 572.13 945.149 572.13 944.666C572.13 944.067 571.633 943.63 570.91 943.63C570.119 943.63 569.554 944.113 569.554 944.781C569.554 945.241 569.689 945.471 570.435 946.139C569.667 946.737 569.509 946.967 569.509 947.45C569.509 948.164 570.074 948.647 570.887 948.647C571.746 948.647 572.288 948.187 572.288 947.427C572.288 946.852 572.04 946.507 571.181 945.839ZM571.045 946.599C571.565 946.99 571.746 947.243 571.746 947.657C571.746 948.118 571.43 948.463 570.955 948.463C570.413 948.463 570.051 948.026 570.051 947.404C570.051 946.921 570.209 946.622 570.616 946.277L571.045 946.599ZM570.978 945.724C570.345 945.287 570.074 944.965 570.074 944.551C570.074 944.136 570.39 943.837 570.842 943.837C571.339 943.837 571.656 944.159 571.656 944.643C571.656 945.057 571.452 945.402 571.045 945.678C571 945.701 571 945.701 570.978 945.724Z" fill="white"/>
+</g>
+<mask id="mask203_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask203_13_16079)">
+<path d="M590.143 954.337C590.934 954.245 591.34 954.107 591.815 953.739C592.561 953.187 593.013 952.289 593.013 951.299C593.013 950.103 592.335 949.251 591.408 949.251C590.572 949.251 589.939 949.988 589.939 950.977C589.939 951.852 590.436 952.45 591.227 952.45C591.612 952.45 591.905 952.335 592.29 952.036C591.996 953.21 591.205 953.992 590.12 954.199L590.143 954.337ZM592.312 951.576C592.312 951.737 592.267 951.806 592.199 951.875C591.996 952.036 591.725 952.128 591.476 952.128C590.934 952.128 590.595 951.576 590.595 950.724C590.595 950.31 590.708 949.873 590.843 949.665C590.979 949.527 591.16 949.458 591.363 949.458C591.973 949.458 592.312 950.08 592.312 951.299V951.576Z" fill="white"/>
+</g>
+<mask id="mask204_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask204_13_16079)">
+<path d="M610.613 943.63L609.324 944.297V944.39C609.415 944.343 609.483 944.32 609.528 944.32C609.641 944.251 609.776 944.228 609.844 944.228C610.002 944.228 610.07 944.343 610.07 944.574V947.888C610.07 948.118 610.002 948.279 609.889 948.348C609.776 948.417 609.686 948.44 609.37 948.44V948.555H611.358V948.44C610.793 948.44 610.68 948.371 610.68 948.026V943.63H610.613ZM613.941 943.63C613.534 943.63 613.24 943.745 612.969 943.998C612.562 944.413 612.291 945.241 612.291 946.093C612.291 946.898 612.517 947.75 612.856 948.164C613.127 948.486 613.489 948.647 613.895 948.647C614.257 948.647 614.573 948.532 614.822 948.279C615.251 947.888 615.523 947.036 615.523 946.139C615.523 944.643 614.867 943.63 613.941 943.63ZM613.918 943.814C614.506 943.814 614.822 944.643 614.822 946.162C614.822 947.68 614.528 948.463 613.895 948.463C613.285 948.463 612.969 947.68 612.969 946.162C612.969 944.62 613.285 943.814 613.918 943.814Z" fill="white"/>
+</g>
+<mask id="mask205_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask205_13_16079)">
+<path d="M625.698 928.263L624.41 928.93V929.022C624.5 928.976 624.568 928.953 624.613 928.953C624.726 928.884 624.862 928.861 624.93 928.861C625.088 928.861 625.156 928.976 625.156 929.206V932.52C625.156 932.75 625.088 932.911 624.975 932.981C624.862 933.05 624.772 933.073 624.455 933.073V933.188H626.444V933.073C625.879 933.073 625.766 933.004 625.766 932.658V928.263H625.698ZM629.28 928.263L627.992 928.93V929.022C628.083 928.976 628.15 928.953 628.196 928.953C628.309 928.884 628.444 928.861 628.512 928.861C628.67 928.861 628.738 928.976 628.738 929.206V932.52C628.738 932.75 628.67 932.911 628.557 932.981C628.444 933.05 628.354 933.073 628.037 933.073V933.188H630.026V933.073C629.461 933.073 629.348 933.004 629.348 932.658V928.263H629.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask206_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="476" width="112" height="114">
+<path d="M303 589.037H414.004V476H303V589.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask206_13_16079)">
+<mask id="mask207_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask207_13_16079)">
+<path d="M399.723 532.52L394.2 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask208_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask208_13_16079)">
+<path d="M399.723 532.52L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask209_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask209_13_16079)">
+<path d="M399.723 532.52L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask210_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask210_13_16079)">
+<path d="M399.723 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask211_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask211_13_16079)">
+<path d="M394.2 511.532L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask212_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask212_13_16079)">
+<path d="M394.2 511.532L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask213_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask213_13_16079)">
+<path d="M394.2 511.532L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask214_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask214_13_16079)">
+<path d="M379.112 496.168L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask215_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask215_13_16079)">
+<path d="M337.89 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask216_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask216_13_16079)">
+<path d="M337.89 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask217_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask217_13_16079)">
+<path d="M337.891 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask218_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask218_13_16079)">
+<path d="M322.802 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask219_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask219_13_16079)">
+<path d="M322.802 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask220_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask220_13_16079)">
+<path d="M322.802 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask221_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask221_13_16079)">
+<path d="M317.28 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask222_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask222_13_16079)">
+<path d="M337.891 568.872L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask223_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask223_13_16079)">
+<path d="M337.891 568.872H379.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask224_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask224_13_16079)">
+<path d="M337.891 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask225_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask225_13_16079)">
+<path d="M358.501 574.495L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask226_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask226_13_16079)">
+<path d="M358.501 574.495L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask227_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask227_13_16079)">
+<path d="M379.112 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask228_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask228_13_16079)">
+<path d="M399.723 532.52L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask229_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask229_13_16079)">
+<path d="M399.723 532.52L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask230_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask230_13_16079)">
+<path d="M399.723 532.52L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask231_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask231_13_16079)">
+<path d="M399.723 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask232_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask232_13_16079)">
+<path d="M399.723 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask233_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask233_13_16079)">
+<path d="M399.723 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask234_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask234_13_16079)">
+<path d="M399.723 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask235_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask235_13_16079)">
+<path d="M394.2 511.532H322.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask236_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask236_13_16079)">
+<path d="M394.2 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask237_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask237_13_16079)">
+<path d="M394.2 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask238_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask238_13_16079)">
+<path d="M394.2 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask239_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask239_13_16079)">
+<path d="M394.2 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask240_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask240_13_16079)">
+<path d="M394.2 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask241_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask241_13_16079)">
+<path d="M394.2 511.532V553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask242_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask242_13_16079)">
+<path d="M379.112 496.168H337.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask243_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask243_13_16079)">
+<path d="M379.112 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask244_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask244_13_16079)">
+<path d="M379.112 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask245_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask245_13_16079)">
+<path d="M379.112 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask246_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask246_13_16079)">
+<path d="M379.112 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask247_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask247_13_16079)">
+<path d="M379.112 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask248_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask248_13_16079)">
+<path d="M379.112 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask249_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask249_13_16079)">
+<path d="M379.112 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask250_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask250_13_16079)">
+<path d="M358.501 490.544L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask251_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask251_13_16079)">
+<path d="M358.501 490.544L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask252_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask252_13_16079)">
+<path d="M358.501 490.544L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask253_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask253_13_16079)">
+<path d="M358.501 490.544L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask254_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask254_13_16079)">
+<path d="M358.501 490.544L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask255_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask255_13_16079)">
+<path d="M358.501 490.544V574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask256_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask256_13_16079)">
+<path d="M358.501 490.544L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask257_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask257_13_16079)">
+<path d="M358.501 490.544L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask258_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask258_13_16079)">
+<path d="M337.89 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask259_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask259_13_16079)">
+<path d="M337.89 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask260_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask260_13_16079)">
+<path d="M337.89 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask261_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask261_13_16079)">
+<path d="M337.89 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask262_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask262_13_16079)">
+<path d="M322.802 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask263_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask263_13_16079)">
+<path d="M322.802 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask264_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask264_13_16079)">
+<path d="M322.802 511.532L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask265_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask265_13_16079)">
+<path d="M317.28 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask266_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask266_13_16079)">
+<path d="M317.28 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask267_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask267_13_16079)">
+<path d="M317.28 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask268_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask268_13_16079)">
+<path d="M317.28 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask269_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask269_13_16079)">
+<path d="M322.802 553.508L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask270_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask270_13_16079)">
+<path d="M322.802 553.508L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask271_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask271_13_16079)">
+<path d="M322.802 553.508L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask272_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask272_13_16079)">
+<path d="M322.802 553.508L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask273_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask273_13_16079)">
+<mask id="mask274_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="527" width="11" height="11">
+<path d="M394.766 537.568H404.68V527.472H394.766V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask274_13_16079)">
+<path d="M399.723 537.045C400.901 537.045 402.032 536.568 402.865 535.72C403.699 534.871 404.167 533.72 404.167 532.52C404.167 531.32 403.699 530.168 402.865 529.32C402.032 528.471 400.901 527.994 399.723 527.994C398.544 527.994 397.414 528.471 396.58 529.32C395.747 530.168 395.279 531.32 395.279 532.52C395.279 533.72 395.747 534.871 396.58 535.72C397.414 536.568 398.544 537.045 399.723 537.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask275_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask275_13_16079)">
+<mask id="mask276_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="506" width="11" height="11">
+<path d="M389.243 516.58H399.157V506.484H389.243V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask276_13_16079)">
+<path d="M394.2 516.057C395.379 516.057 396.509 515.58 397.343 514.732C398.176 513.883 398.644 512.732 398.644 511.532C398.644 510.332 398.176 509.181 397.343 508.332C396.509 507.483 395.379 507.007 394.2 507.007C393.022 507.007 391.891 507.483 391.058 508.332C390.224 509.181 389.756 510.332 389.756 511.532C389.756 512.732 390.224 513.883 391.058 514.732C391.891 515.58 393.022 516.057 394.2 516.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask277_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask277_13_16079)">
+<mask id="mask278_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="491" width="11" height="11">
+<path d="M374.155 501.215H384.069V491.12H374.155V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask278_13_16079)">
+<path d="M379.112 500.693C380.291 500.693 381.421 500.216 382.254 499.367C383.088 498.519 383.556 497.368 383.556 496.168C383.556 494.967 383.088 493.816 382.254 492.968C381.421 492.119 380.291 491.642 379.112 491.642C377.933 491.642 376.803 492.119 375.97 492.968C375.136 493.816 374.668 494.967 374.668 496.168C374.668 497.368 375.136 498.519 375.97 499.367C376.803 500.216 377.933 500.693 379.112 500.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask279_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask279_13_16079)">
+<mask id="mask280_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="485" width="11" height="11">
+<path d="M353.544 495.592H363.458V485.496H353.544V495.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask280_13_16079)">
+<path d="M358.501 495.069C359.68 495.069 360.81 494.592 361.644 493.744C362.477 492.895 362.945 491.744 362.945 490.544C362.945 489.344 362.477 488.193 361.644 487.344C360.81 486.495 359.68 486.019 358.501 486.019C357.323 486.019 356.192 486.495 355.359 487.344C354.526 488.193 354.057 489.344 354.057 490.544C354.057 491.744 354.526 492.895 355.359 493.744C356.192 494.592 357.323 495.069 358.501 495.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask281_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask281_13_16079)">
+<mask id="mask282_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="491" width="11" height="11">
+<path d="M332.933 501.215H342.848V491.12H332.933V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask282_13_16079)">
+<path d="M337.891 500.693C339.069 500.693 340.2 500.216 341.033 499.367C341.866 498.519 342.334 497.368 342.334 496.168C342.334 494.967 341.866 493.816 341.033 492.968C340.2 492.119 339.069 491.642 337.891 491.642C336.712 491.642 335.581 492.119 334.748 492.968C333.915 493.816 333.447 494.967 333.447 496.168C333.447 497.368 333.915 498.519 334.748 499.367C335.581 500.216 336.712 500.693 337.891 500.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask283_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask283_13_16079)">
+<mask id="mask284_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="506" width="11" height="11">
+<path d="M317.845 516.58H327.76V506.484H317.845V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask284_13_16079)">
+<path d="M322.802 516.057C323.981 516.057 325.111 515.58 325.945 514.732C326.778 513.883 327.246 512.732 327.246 511.532C327.246 510.332 326.778 509.181 325.945 508.332C325.111 507.483 323.981 507.007 322.802 507.007C321.624 507.007 320.493 507.483 319.66 508.332C318.827 509.181 318.358 510.332 318.358 511.532C318.358 512.732 318.827 513.883 319.66 514.732C320.493 515.58 321.624 516.057 322.802 516.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask285_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask285_13_16079)">
+<mask id="mask286_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="527" width="11" height="11">
+<path d="M312.323 537.568H322.237V527.472H312.323V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask286_13_16079)">
+<path d="M317.28 537.045C318.458 537.045 319.589 536.568 320.422 535.72C321.255 534.871 321.724 533.72 321.724 532.52C321.724 531.32 321.255 530.168 320.422 529.32C319.589 528.471 318.458 527.994 317.28 527.994C316.101 527.994 314.971 528.471 314.137 529.32C313.304 530.168 312.836 531.32 312.836 532.52C312.836 533.72 313.304 534.871 314.137 535.72C314.971 536.568 316.101 537.045 317.28 537.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask287_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask287_13_16079)">
+<mask id="mask288_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="548" width="11" height="11">
+<path d="M317.845 558.555H327.76V548.46H317.845V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask288_13_16079)">
+<path d="M322.802 558.033C323.981 558.033 325.111 557.556 325.945 556.708C326.778 555.859 327.246 554.708 327.246 553.508C327.246 552.308 326.778 551.156 325.945 550.308C325.111 549.459 323.981 548.982 322.802 548.982C321.624 548.982 320.493 549.459 319.66 550.308C318.827 551.156 318.358 552.308 318.358 553.508C318.358 554.708 318.827 555.859 319.66 556.708C320.493 557.556 321.624 558.033 322.802 558.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask289_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask289_13_16079)">
+<mask id="mask290_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="563" width="11" height="11">
+<path d="M332.933 573.92H342.848V563.824H332.933V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask290_13_16079)">
+<path d="M337.891 573.397C339.069 573.397 340.2 572.92 341.033 572.072C341.866 571.223 342.334 570.072 342.334 568.872C342.334 567.672 341.866 566.521 341.033 565.672C340.2 564.823 339.069 564.347 337.891 564.347C336.712 564.347 335.581 564.823 334.748 565.672C333.915 566.521 333.447 567.672 333.447 568.872C333.447 570.072 333.915 571.223 334.748 572.072C335.581 572.92 336.712 573.397 337.891 573.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask291_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask291_13_16079)">
+<mask id="mask292_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="569" width="11" height="11">
+<path d="M353.544 579.543H363.458V569.448H353.544V579.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask292_13_16079)">
+<path d="M358.501 579.021C359.68 579.021 360.81 578.544 361.644 577.695C362.477 576.847 362.945 575.696 362.945 574.496C362.945 573.295 362.477 572.144 361.644 571.296C360.81 570.447 359.68 569.97 358.501 569.97C357.323 569.97 356.192 570.447 355.359 571.296C354.526 572.144 354.057 573.295 354.057 574.496C354.057 575.696 354.526 576.847 355.359 577.695C356.192 578.544 357.323 579.021 358.501 579.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask293_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask293_13_16079)">
+<mask id="mask294_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="563" width="11" height="11">
+<path d="M374.155 573.92H384.069V563.824H374.155V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask294_13_16079)">
+<path d="M379.112 573.397C380.291 573.397 381.421 572.92 382.254 572.072C383.088 571.223 383.556 570.072 383.556 568.872C383.556 567.672 383.088 566.521 382.254 565.672C381.421 564.823 380.291 564.347 379.112 564.347C377.933 564.347 376.803 564.823 375.97 565.672C375.136 566.521 374.668 567.672 374.668 568.872C374.668 570.072 375.136 571.223 375.97 572.072C376.803 572.92 377.933 573.397 379.112 573.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask295_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask295_13_16079)">
+<mask id="mask296_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="548" width="11" height="11">
+<path d="M389.243 558.555H399.157V548.46H389.243V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask296_13_16079)">
+<path d="M394.2 558.033C395.379 558.033 396.509 557.556 397.343 556.708C398.176 555.859 398.644 554.708 398.644 553.508C398.644 552.308 398.176 551.156 397.343 550.308C396.509 549.459 395.379 548.982 394.2 548.982C393.022 548.982 391.891 549.459 391.058 550.308C390.224 551.156 389.756 552.308 389.756 553.508C389.756 554.708 390.224 555.859 391.058 556.708C391.891 557.556 393.022 558.033 394.2 558.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask297_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask297_13_16079)">
+<path d="M399.767 529.274C399.36 529.274 399.066 529.389 398.795 529.642C398.388 530.057 398.117 530.885 398.117 531.737C398.117 532.542 398.343 533.394 398.682 533.808C398.953 534.13 399.315 534.291 399.721 534.291C400.083 534.291 400.399 534.176 400.648 533.923C401.077 533.532 401.349 532.68 401.349 531.783C401.349 530.287 400.693 529.274 399.767 529.274ZM399.744 529.458C400.332 529.458 400.648 530.287 400.648 531.806C400.648 533.325 400.354 534.107 399.721 534.107C399.111 534.107 398.795 533.325 398.795 531.806C398.795 530.264 399.111 529.458 399.744 529.458Z" fill="white"/>
+</g>
+<mask id="mask298_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask298_13_16079)">
+<path d="M394.489 508.291L393.201 508.959V509.051C393.292 509.005 393.359 508.982 393.405 508.982C393.518 508.913 393.653 508.89 393.721 508.89C393.879 508.89 393.947 509.005 393.947 509.235V512.549C393.947 512.779 393.879 512.94 393.766 513.009C393.653 513.078 393.563 513.101 393.246 513.101V513.216H395.235V513.101C394.67 513.101 394.557 513.032 394.557 512.687V508.291H394.489Z" fill="white"/>
+</g>
+<mask id="mask299_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask299_13_16079)">
+<path d="M380.737 496.859L380.624 496.813C380.376 497.228 380.285 497.297 379.946 497.297H378.251L379.449 496.008C380.082 495.34 380.353 494.788 380.353 494.213C380.353 493.476 379.788 492.924 379.042 492.924C378.635 492.924 378.274 493.085 378.003 493.361C377.777 493.614 377.664 493.844 377.551 494.374L377.686 494.397C377.98 493.683 378.251 493.453 378.726 493.453C379.336 493.453 379.743 493.868 379.743 494.489C379.743 495.064 379.426 495.732 378.816 496.376L377.551 497.757V497.849H380.33L380.737 496.859Z" fill="white"/>
+</g>
+<mask id="mask300_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask300_13_16079)">
+<path d="M357.821 489.811C358.227 489.811 358.386 489.834 358.566 489.903C359.018 490.065 359.29 490.479 359.29 490.985C359.29 491.583 358.883 492.067 358.363 492.067C358.16 492.067 358.024 492.021 357.753 491.837C357.527 491.698 357.414 491.652 357.301 491.652C357.12 491.652 357.03 491.768 357.03 491.906C357.03 492.159 357.323 492.32 357.821 492.32C358.386 492.32 358.951 492.136 359.29 491.837C359.629 491.537 359.809 491.123 359.809 490.64C359.809 490.249 359.696 489.926 359.493 489.696C359.335 489.535 359.199 489.443 358.883 489.305C359.38 488.96 359.561 488.684 359.561 488.292C359.561 487.694 359.109 487.303 358.453 487.303C358.092 487.303 357.775 487.418 357.527 487.648C357.301 487.855 357.188 488.039 357.03 488.477L357.143 488.5C357.436 487.97 357.753 487.74 358.205 487.74C358.679 487.74 358.996 488.062 358.996 488.523C358.996 488.776 358.883 489.029 358.702 489.213C358.499 489.443 358.295 489.558 357.821 489.719V489.811Z" fill="white"/>
+</g>
+<mask id="mask301_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask301_13_16079)">
+<path d="M339.492 496.169H338.746V492.924H338.43L336.192 496.169V496.629H338.204V497.849H338.746V496.629H339.492V496.169ZM338.204 496.169H336.463L338.204 493.66V496.169Z" fill="white"/>
+</g>
+<mask id="mask302_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask302_13_16079)">
+<path d="M322.299 508.959H323.722C323.835 508.959 323.858 508.959 323.881 508.89L324.152 508.245L324.084 508.199C323.971 508.36 323.903 508.383 323.745 508.383H322.253L321.485 510.109C321.462 510.132 321.462 510.132 321.462 510.156C321.462 510.179 321.508 510.202 321.553 510.202C321.779 510.202 322.073 510.271 322.366 510.363C323.18 510.616 323.564 511.076 323.564 511.812C323.564 512.503 323.135 513.055 322.57 513.055C322.434 513.055 322.299 512.986 322.095 512.848C321.869 512.664 321.688 512.595 321.553 512.595C321.349 512.595 321.236 512.687 321.236 512.871C321.236 513.147 321.575 513.308 322.118 513.308C322.705 513.308 323.225 513.124 323.587 512.756C323.926 512.411 324.061 511.997 324.061 511.444C324.061 510.915 323.926 510.593 323.564 510.225C323.27 509.902 322.841 509.741 322.005 509.58L322.299 508.959Z" fill="white"/>
+</g>
+<mask id="mask303_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask303_13_16079)">
+<path d="M318.677 529.205C317.863 529.274 317.457 529.412 316.937 529.803C316.146 530.356 315.739 531.184 315.739 532.174C315.739 532.795 315.92 533.44 316.236 533.808C316.507 534.13 316.892 534.291 317.344 534.291C318.225 534.291 318.835 533.601 318.835 532.611C318.835 531.668 318.315 531.069 317.502 531.069C317.185 531.069 317.027 531.138 316.575 531.414C316.779 530.31 317.57 529.504 318.7 529.32L318.677 529.205ZM317.231 531.414C317.841 531.414 318.202 531.944 318.202 532.841C318.202 533.647 317.909 534.107 317.411 534.107C316.779 534.107 316.394 533.417 316.394 532.289C316.394 531.898 316.462 531.714 316.598 531.599C316.756 531.483 316.982 531.414 317.231 531.414Z" fill="white"/>
+</g>
+<mask id="mask304_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask304_13_16079)">
+<path d="M324.22 550.355H321.575L321.146 551.436L321.282 551.482C321.575 550.999 321.711 550.907 322.118 550.907H323.655L322.253 555.257H322.705L324.22 550.47V550.355Z" fill="white"/>
+</g>
+<mask id="mask305_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask305_13_16079)">
+<path d="M338.181 567.839C338.882 567.471 339.13 567.149 339.13 566.666C339.13 566.067 338.633 565.63 337.91 565.63C337.119 565.63 336.554 566.113 336.554 566.781C336.554 567.241 336.689 567.471 337.435 568.139C336.667 568.737 336.509 568.967 336.509 569.45C336.509 570.164 337.074 570.647 337.887 570.647C338.746 570.647 339.288 570.187 339.288 569.427C339.288 568.852 339.04 568.507 338.181 567.839ZM338.045 568.599C338.565 568.99 338.746 569.243 338.746 569.657C338.746 570.118 338.43 570.463 337.955 570.463C337.413 570.463 337.051 570.026 337.051 569.404C337.051 568.921 337.209 568.622 337.616 568.277L338.045 568.599ZM337.978 567.724C337.345 567.287 337.074 566.965 337.074 566.551C337.074 566.136 337.39 565.837 337.842 565.837C338.339 565.837 338.656 566.159 338.656 566.643C338.656 567.057 338.452 567.402 338.045 567.678C338 567.701 338 567.701 337.978 567.724Z" fill="white"/>
+</g>
+<mask id="mask306_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask306_13_16079)">
+<path d="M357.143 576.337C357.934 576.245 358.34 576.107 358.815 575.739C359.561 575.187 360.013 574.289 360.013 573.299C360.013 572.103 359.335 571.251 358.408 571.251C357.572 571.251 356.939 571.988 356.939 572.977C356.939 573.852 357.436 574.45 358.227 574.45C358.612 574.45 358.905 574.335 359.29 574.036C358.996 575.21 358.205 575.992 357.12 576.199L357.143 576.337ZM359.312 573.576C359.312 573.737 359.267 573.806 359.199 573.875C358.996 574.036 358.725 574.128 358.476 574.128C357.934 574.128 357.595 573.576 357.595 572.724C357.595 572.31 357.708 571.873 357.843 571.665C357.979 571.527 358.16 571.458 358.363 571.458C358.973 571.458 359.312 572.08 359.312 573.299V573.576Z" fill="white"/>
+</g>
+<mask id="mask307_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask307_13_16079)">
+<path d="M377.613 565.63L376.324 566.297V566.39C376.415 566.343 376.483 566.32 376.528 566.32C376.641 566.251 376.776 566.228 376.844 566.228C377.002 566.228 377.07 566.343 377.07 566.574V569.888C377.07 570.118 377.002 570.279 376.889 570.348C376.776 570.417 376.686 570.44 376.37 570.44V570.555H378.358V570.44C377.793 570.44 377.68 570.371 377.68 570.026V565.63H377.613ZM380.941 565.63C380.534 565.63 380.24 565.745 379.969 565.998C379.562 566.413 379.291 567.241 379.291 568.093C379.291 568.898 379.517 569.75 379.856 570.164C380.127 570.486 380.489 570.647 380.895 570.647C381.257 570.647 381.573 570.532 381.822 570.279C382.251 569.888 382.523 569.036 382.523 568.139C382.523 566.643 381.867 565.63 380.941 565.63ZM380.918 565.814C381.506 565.814 381.822 566.643 381.822 568.162C381.822 569.68 381.528 570.463 380.895 570.463C380.285 570.463 379.969 569.68 379.969 568.162C379.969 566.62 380.285 565.814 380.918 565.814Z" fill="white"/>
+</g>
+<mask id="mask308_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask308_13_16079)">
+<path d="M392.698 550.263L391.41 550.93V551.022C391.5 550.976 391.568 550.953 391.613 550.953C391.726 550.884 391.862 550.861 391.93 550.861C392.088 550.861 392.156 550.976 392.156 551.206V554.52C392.156 554.75 392.088 554.911 391.975 554.981C391.862 555.05 391.772 555.073 391.455 555.073V555.188H393.444V555.073C392.879 555.073 392.766 555.004 392.766 554.658V550.263H392.698ZM396.28 550.263L394.992 550.93V551.022C395.083 550.976 395.15 550.953 395.196 550.953C395.309 550.884 395.444 550.861 395.512 550.861C395.67 550.861 395.738 550.976 395.738 551.206V554.52C395.738 554.75 395.67 554.911 395.557 554.981C395.444 555.05 395.354 555.073 395.037 555.073V555.188H397.026V555.073C396.461 555.073 396.348 555.004 396.348 554.658V550.263H396.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask309_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="353" width="112" height="114">
+<path d="M303 466.037H414.004V353H303V466.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask309_13_16079)">
+<mask id="mask310_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask310_13_16079)">
+<path d="M325.821 393.354L343.54 378.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask311_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask311_13_16079)">
+<path d="M325.821 393.354L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask312_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask312_13_16079)">
+<path d="M325.821 393.354L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask313_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask313_13_16079)">
+<path d="M325.821 393.354L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask314_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask314_13_16079)">
+<path d="M343.54 378.382L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask315_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask315_13_16079)">
+<path d="M343.54 378.382L326.523 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask316_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask316_13_16079)">
+<path d="M343.54 378.382L377.366 389.755" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask317_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask317_13_16079)">
+<path d="M317.28 375.666L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask318_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask318_13_16079)">
+<path d="M377.366 389.755L381.612 412.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask319_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask319_13_16079)">
+<path d="M377.366 389.754L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask320_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask320_13_16079)">
+<path d="M377.366 389.755L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask321_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask321_13_16079)">
+<path d="M381.612 412.102L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask322_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask322_13_16079)">
+<path d="M381.612 412.102L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask323_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask323_13_16079)">
+<path d="M381.612 412.102L354.356 435.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask324_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask324_13_16079)">
+<path d="M397.614 391.444L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask325_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask325_13_16079)">
+<path d="M354.356 435.307L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask326_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask326_13_16079)">
+<path d="M354.356 435.307L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask327_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask327_13_16079)">
+<path d="M354.356 435.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask328_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask328_13_16079)">
+<path d="M332.308 427.895L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask329_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask329_13_16079)">
+<path d="M332.308 427.895L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask330_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask330_13_16079)">
+<path d="M330.975 447.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask331_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask331_13_16079)">
+<mask id="mask332_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="388" width="11" height="11">
+<path d="M320.864 398.402H330.778V388.307H320.864V398.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask332_13_16079)">
+<path d="M325.821 397.88C326.999 397.88 328.13 397.403 328.963 396.554C329.797 395.706 330.265 394.555 330.265 393.354C330.265 392.154 329.797 391.003 328.963 390.155C328.13 389.306 326.999 388.829 325.821 388.829C324.642 388.829 323.512 389.306 322.678 390.155C321.845 391.003 321.377 392.154 321.377 393.354C321.377 394.555 321.845 395.706 322.678 396.554C323.512 397.403 324.642 397.88 325.821 397.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask333_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask333_13_16079)">
+<mask id="mask334_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="373" width="11" height="11">
+<path d="M338.583 383.429H348.497V373.334H338.583V383.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask334_13_16079)">
+<path d="M343.54 382.907C344.719 382.907 345.849 382.43 346.683 381.581C347.516 380.733 347.984 379.582 347.984 378.382C347.984 377.181 347.516 376.03 346.683 375.182C345.849 374.333 344.719 373.856 343.54 373.856C342.362 373.856 341.231 374.333 340.398 375.182C339.565 376.03 339.096 377.181 339.096 378.382C339.096 379.582 339.565 380.733 340.398 381.581C341.231 382.43 342.362 382.907 343.54 382.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask335_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask335_13_16079)">
+<mask id="mask336_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="370" width="11" height="11">
+<path d="M312.323 380.714H322.237V370.618H312.323V380.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask336_13_16079)">
+<path d="M317.28 380.191C318.458 380.191 319.589 379.714 320.422 378.866C321.255 378.017 321.724 376.866 321.724 375.666C321.724 374.466 321.255 373.315 320.422 372.466C319.589 371.617 318.458 371.141 317.28 371.141C316.101 371.141 314.971 371.617 314.137 372.466C313.304 373.315 312.836 374.466 312.836 375.666C312.836 376.866 313.304 378.017 314.137 378.866C314.971 379.714 316.101 380.191 317.28 380.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask337_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask337_13_16079)">
+<mask id="mask338_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="321" y="362" width="11" height="11">
+<path d="M321.566 372.592H331.481V362.496H321.566V372.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask338_13_16079)">
+<path d="M326.524 372.069C327.702 372.069 328.833 371.592 329.666 370.744C330.499 369.895 330.967 368.744 330.967 367.544C330.967 366.344 330.499 365.193 329.666 364.344C328.833 363.495 327.702 363.019 326.524 363.019C325.345 363.019 324.214 363.495 323.381 364.344C322.548 365.193 322.08 366.344 322.08 367.544C322.08 368.744 322.548 369.895 323.381 370.744C324.214 371.592 325.345 372.069 326.524 372.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask339_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask339_13_16079)">
+<mask id="mask340_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="372" y="384" width="11" height="11">
+<path d="M372.409 394.802H382.323V384.707H372.409V394.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask340_13_16079)">
+<path d="M377.366 394.28C378.544 394.28 379.675 393.803 380.508 392.954C381.342 392.106 381.81 390.955 381.81 389.755C381.81 388.554 381.342 387.403 380.508 386.555C379.675 385.706 378.544 385.229 377.366 385.229C376.187 385.229 375.057 385.706 374.223 386.555C373.39 387.403 372.922 388.554 372.922 389.755C372.922 390.955 373.39 392.106 374.223 392.954C375.057 393.803 376.187 394.28 377.366 394.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask341_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask341_13_16079)">
+<mask id="mask342_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="376" y="407" width="11" height="11">
+<path d="M376.655 417.15H386.569V407.054H376.655V417.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask342_13_16079)">
+<path d="M381.612 416.628C382.791 416.628 383.921 416.151 384.755 415.302C385.588 414.453 386.056 413.302 386.056 412.102C386.056 410.902 385.588 409.751 384.755 408.902C383.921 408.054 382.791 407.577 381.612 407.577C380.434 407.577 379.303 408.054 378.47 408.902C377.637 409.751 377.168 410.902 377.168 412.102C377.168 413.302 377.637 414.453 378.47 415.302C379.303 416.151 380.434 416.628 381.612 416.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask343_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask343_13_16079)">
+<mask id="mask344_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="386" width="11" height="11">
+<path d="M392.657 396.492H402.571V386.396H392.657V396.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask344_13_16079)">
+<path d="M397.614 395.969C398.792 395.969 399.923 395.492 400.756 394.644C401.59 393.795 402.058 392.644 402.058 391.444C402.058 390.244 401.59 389.093 400.756 388.244C399.923 387.395 398.792 386.919 397.614 386.919C396.435 386.919 395.305 387.395 394.471 388.244C393.638 389.093 393.17 390.244 393.17 391.444C393.17 392.644 393.638 393.795 394.471 394.644C395.305 395.492 396.435 395.969 397.614 395.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask345_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask345_13_16079)">
+<mask id="mask346_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="398" width="11" height="11">
+<path d="M394.766 408.201H404.68V398.105H394.766V408.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask346_13_16079)">
+<path d="M399.723 407.679C400.901 407.679 402.032 407.202 402.865 406.353C403.699 405.504 404.167 404.353 404.167 403.153C404.167 401.953 403.699 400.802 402.865 399.953C402.032 399.105 400.901 398.628 399.723 398.628C398.544 398.628 397.414 399.105 396.58 399.953C395.747 400.802 395.279 401.953 395.279 403.153C395.279 404.353 395.747 405.504 396.58 406.353C397.414 407.202 398.544 407.679 399.723 407.679Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask347_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask347_13_16079)">
+<mask id="mask348_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="349" y="430" width="11" height="11">
+<path d="M349.399 440.354H359.313V430.259H349.399V440.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask348_13_16079)">
+<path d="M354.356 439.832C355.535 439.832 356.665 439.355 357.499 438.506C358.332 437.658 358.8 436.507 358.8 435.307C358.8 434.106 358.332 432.955 357.499 432.107C356.665 431.258 355.535 430.781 354.356 430.781C353.178 430.781 352.047 431.258 351.214 432.107C350.38 432.955 349.912 434.106 349.912 435.307C349.912 436.507 350.38 437.658 351.214 438.506C352.047 439.355 353.178 439.832 354.356 439.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask349_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask349_13_16079)">
+<mask id="mask350_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="327" y="422" width="11" height="11">
+<path d="M327.351 432.943H337.265V422.847H327.351V432.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask350_13_16079)">
+<path d="M332.308 432.42C333.486 432.42 334.617 431.943 335.45 431.095C336.283 430.246 336.752 429.095 336.752 427.895C336.752 426.695 336.283 425.544 335.45 424.695C334.617 423.846 333.486 423.37 332.308 423.37C331.129 423.37 329.999 423.846 329.165 424.695C328.332 425.544 327.864 426.695 327.864 427.895C327.864 429.095 328.332 430.246 329.165 431.095C329.999 431.943 331.129 432.42 332.308 432.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask351_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask351_13_16079)">
+<mask id="mask352_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="326" y="442" width="10" height="11">
+<path d="M326.018 452.355H335.932V442.259H326.018V452.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask352_13_16079)">
+<path d="M330.975 451.832C332.154 451.832 333.284 451.355 334.117 450.507C334.951 449.658 335.419 448.507 335.419 447.307C335.419 446.107 334.951 444.955 334.117 444.107C333.284 443.258 332.154 442.781 330.975 442.781C329.796 442.781 328.666 443.258 327.833 444.107C326.999 444.955 326.531 446.107 326.531 447.307C326.531 448.507 326.999 449.658 327.833 450.507C328.666 451.355 329.796 451.832 330.975 451.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask353_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask353_13_16079)">
+<mask id="mask354_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="337" y="446" width="11" height="11">
+<path d="M337.811 456.543H347.726V446.448H337.811V456.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask354_13_16079)">
+<path d="M342.769 456.021C343.947 456.021 345.078 455.544 345.911 454.695C346.744 453.847 347.213 452.696 347.213 451.496C347.213 450.295 346.744 449.144 345.911 448.296C345.078 447.447 343.947 446.97 342.769 446.97C341.59 446.97 340.459 447.447 339.626 448.296C338.793 449.144 338.325 450.295 338.325 451.496C338.325 452.696 338.793 453.847 339.626 454.695C340.459 455.544 341.59 456.021 342.769 456.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask355_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask355_13_16079)">
+<path d="M325.86 390.113C325.453 390.113 325.159 390.228 324.888 390.481C324.481 390.895 324.21 391.724 324.21 392.575C324.21 393.381 324.436 394.232 324.775 394.646C325.046 394.969 325.408 395.13 325.815 395.13C326.177 395.13 326.493 395.015 326.742 394.762C327.171 394.37 327.442 393.519 327.442 392.621C327.442 391.125 326.787 390.113 325.86 390.113ZM325.838 390.297C326.425 390.297 326.742 391.125 326.742 392.644C326.742 394.163 326.448 394.946 325.815 394.946C325.205 394.946 324.888 394.163 324.888 392.644C324.888 391.102 325.205 390.297 325.838 390.297Z" fill="white"/>
+</g>
+<mask id="mask356_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask356_13_16079)">
+<path d="M343.833 375.137L342.545 375.804V375.896C342.635 375.85 342.703 375.827 342.748 375.827C342.861 375.758 342.997 375.735 343.065 375.735C343.223 375.735 343.291 375.85 343.291 376.08V379.394C343.291 379.624 343.223 379.785 343.11 379.854C342.997 379.923 342.906 379.946 342.59 379.946V380.062H344.579V379.946C344.014 379.946 343.901 379.877 343.901 379.532V375.137H343.833Z" fill="white"/>
+</g>
+<mask id="mask357_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask357_13_16079)">
+<path d="M318.905 376.356L318.792 376.31C318.543 376.725 318.453 376.794 318.114 376.794H316.419L317.617 375.505C318.249 374.837 318.521 374.285 318.521 373.71C318.521 372.973 317.956 372.421 317.21 372.421C316.803 372.421 316.441 372.582 316.17 372.858C315.944 373.111 315.831 373.342 315.718 373.871L315.854 373.894C316.148 373.18 316.419 372.95 316.893 372.95C317.504 372.95 317.91 373.365 317.91 373.986C317.91 374.561 317.594 375.229 316.984 375.873L315.718 377.254V377.346H318.498L318.905 376.356Z" fill="white"/>
+</g>
+<mask id="mask358_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask358_13_16079)">
+<path d="M325.843 366.811C326.25 366.811 326.408 366.834 326.589 366.903C327.041 367.065 327.312 367.479 327.312 367.985C327.312 368.583 326.905 369.067 326.386 369.067C326.182 369.067 326.047 369.021 325.775 368.837C325.549 368.699 325.436 368.652 325.323 368.652C325.143 368.652 325.052 368.768 325.052 368.906C325.052 369.159 325.346 369.32 325.843 369.32C326.408 369.32 326.973 369.136 327.312 368.837C327.651 368.537 327.832 368.123 327.832 367.64C327.832 367.249 327.719 366.926 327.516 366.696C327.357 366.535 327.222 366.443 326.905 366.305C327.403 365.96 327.583 365.684 327.583 365.292C327.583 364.694 327.131 364.303 326.476 364.303C326.114 364.303 325.798 364.418 325.549 364.648C325.323 364.855 325.21 365.039 325.052 365.477L325.165 365.5C325.459 364.97 325.775 364.74 326.227 364.74C326.702 364.74 327.018 365.062 327.018 365.523C327.018 365.776 326.905 366.029 326.725 366.213C326.521 366.443 326.318 366.558 325.843 366.719V366.811Z" fill="white"/>
+</g>
+<mask id="mask359_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask359_13_16079)">
+<path d="M378.965 389.756H378.219V386.511H377.903L375.665 389.756V390.216H377.677V391.436H378.219V390.216H378.965V389.756ZM377.677 389.756H375.937L377.677 387.248V389.756Z" fill="white"/>
+</g>
+<mask id="mask360_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask360_13_16079)">
+<path d="M381.112 409.525H382.536C382.649 409.525 382.671 409.525 382.694 409.456L382.965 408.811L382.897 408.765C382.784 408.927 382.717 408.95 382.558 408.95H381.067L380.298 410.676C380.276 410.699 380.276 410.699 380.276 410.722C380.276 410.745 380.321 410.768 380.366 410.768C380.592 410.768 380.886 410.837 381.18 410.929C381.993 411.182 382.378 411.642 382.378 412.379C382.378 413.069 381.948 413.621 381.383 413.621C381.248 413.621 381.112 413.552 380.909 413.414C380.683 413.23 380.502 413.161 380.366 413.161C380.163 413.161 380.05 413.253 380.05 413.437C380.05 413.713 380.389 413.874 380.931 413.874C381.519 413.874 382.039 413.69 382.4 413.322C382.739 412.977 382.875 412.563 382.875 412.01C382.875 411.481 382.739 411.159 382.378 410.791C382.084 410.468 381.654 410.307 380.818 410.146L381.112 409.525Z" fill="white"/>
+</g>
+<mask id="mask361_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask361_13_16079)">
+<path d="M399.011 388.134C398.198 388.203 397.791 388.341 397.271 388.732C396.48 389.284 396.073 390.113 396.073 391.102C396.073 391.724 396.254 392.368 396.57 392.736C396.842 393.059 397.226 393.22 397.678 393.22C398.559 393.22 399.17 392.529 399.17 391.54C399.17 390.596 398.65 389.998 397.836 389.998C397.52 389.998 397.361 390.067 396.909 390.343C397.113 389.238 397.904 388.433 399.034 388.249L399.011 388.134ZM397.565 390.343C398.175 390.343 398.537 390.872 398.537 391.77C398.537 392.575 398.243 393.036 397.746 393.036C397.113 393.036 396.729 392.345 396.729 391.217C396.729 390.826 396.796 390.642 396.932 390.527C397.09 390.412 397.316 390.343 397.565 390.343Z" fill="white"/>
+</g>
+<mask id="mask362_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask362_13_16079)">
+<path d="M401.141 400.003H398.497L398.068 401.085L398.203 401.131C398.497 400.647 398.633 400.555 399.04 400.555H400.576L399.175 404.905H399.627L401.141 400.118V400.003Z" fill="white"/>
+</g>
+<mask id="mask363_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask363_13_16079)">
+<path d="M354.647 434.27C355.348 433.902 355.596 433.58 355.596 433.097C355.596 432.498 355.099 432.061 354.376 432.061C353.585 432.061 353.02 432.544 353.02 433.212C353.02 433.672 353.155 433.902 353.901 434.57C353.133 435.168 352.975 435.398 352.975 435.881C352.975 436.595 353.54 437.078 354.353 437.078C355.212 437.078 355.755 436.618 355.755 435.858C355.755 435.283 355.506 434.938 354.647 434.27ZM354.512 435.03C355.031 435.421 355.212 435.674 355.212 436.088C355.212 436.549 354.896 436.894 354.421 436.894C353.879 436.894 353.517 436.457 353.517 435.835C353.517 435.352 353.675 435.053 354.082 434.708L354.512 435.03ZM354.444 434.155C353.811 433.718 353.54 433.396 353.54 432.982C353.54 432.567 353.856 432.268 354.308 432.268C354.805 432.268 355.122 432.59 355.122 433.074C355.122 433.488 354.918 433.833 354.512 434.109C354.466 434.132 354.466 434.132 354.444 434.155Z" fill="white"/>
+</g>
+<mask id="mask364_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask364_13_16079)">
+<path d="M330.945 429.737C331.736 429.645 332.143 429.507 332.618 429.138C333.363 428.586 333.815 427.688 333.815 426.699C333.815 425.502 333.137 424.651 332.211 424.651C331.375 424.651 330.742 425.387 330.742 426.377C330.742 427.251 331.239 427.85 332.03 427.85C332.414 427.85 332.708 427.734 333.092 427.435C332.798 428.609 332.007 429.391 330.923 429.599L330.945 429.737ZM333.115 426.975C333.115 427.136 333.07 427.205 333.002 427.274C332.798 427.435 332.527 427.527 332.279 427.527C331.736 427.527 331.397 426.975 331.397 426.124C331.397 425.709 331.51 425.272 331.646 425.065C331.781 424.927 331.962 424.858 332.166 424.858C332.776 424.858 333.115 425.479 333.115 426.699V426.975Z" fill="white"/>
+</g>
+<mask id="mask365_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask365_13_16079)">
+<path d="M329.476 444.063L328.188 444.73V444.822C328.278 444.776 328.346 444.753 328.391 444.753C328.504 444.684 328.64 444.661 328.708 444.661C328.866 444.661 328.934 444.776 328.934 445.006V448.32C328.934 448.55 328.866 448.711 328.753 448.781C328.64 448.85 328.55 448.873 328.233 448.873V448.988H330.222V448.873C329.657 448.873 329.544 448.804 329.544 448.458V444.063H329.476ZM332.804 444.063C332.397 444.063 332.103 444.178 331.832 444.431C331.425 444.845 331.154 445.674 331.154 446.525C331.154 447.331 331.38 448.182 331.719 448.596C331.99 448.919 332.352 449.08 332.759 449.08C333.12 449.08 333.437 448.965 333.685 448.711C334.115 448.32 334.386 447.469 334.386 446.571C334.386 445.075 333.731 444.063 332.804 444.063ZM332.781 444.247C333.369 444.247 333.685 445.075 333.685 446.594C333.685 448.113 333.392 448.896 332.759 448.896C332.149 448.896 331.832 448.113 331.832 446.594C331.832 445.052 332.149 444.247 332.781 444.247Z" fill="white"/>
+</g>
+<mask id="mask366_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask366_13_16079)">
+<path d="M341.268 448.251L339.98 448.919V449.011C340.07 448.965 340.138 448.942 340.183 448.942C340.296 448.873 340.432 448.85 340.499 448.85C340.658 448.85 340.725 448.965 340.725 449.195V452.509C340.725 452.739 340.658 452.9 340.545 452.969C340.432 453.038 340.341 453.061 340.025 453.061V453.176H342.014V453.061C341.449 453.061 341.336 452.992 341.336 452.647V448.251H341.268ZM344.85 448.251L343.562 448.919V449.011C343.652 448.965 343.72 448.942 343.765 448.942C343.878 448.873 344.014 448.85 344.082 448.85C344.24 448.85 344.308 448.965 344.308 449.195V452.509C344.308 452.739 344.24 452.9 344.127 452.969C344.014 453.038 343.923 453.061 343.607 453.061V453.176H345.596V453.061C345.031 453.061 344.918 452.992 344.918 452.647V448.251H344.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask367_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="760" y="857" width="112" height="114">
+<path d="M760 970.037H871.004V857H760V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask367_13_16079)">
+<mask id="mask368_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask368_13_16079)">
+<path d="M782.821 897.354L800.54 882.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask369_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask369_13_16079)">
+<path d="M782.821 897.354L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask370_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask370_13_16079)">
+<path d="M782.821 897.354L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask371_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask371_13_16079)">
+<path d="M782.821 897.354L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask372_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask372_13_16079)">
+<path d="M800.54 882.382L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask373_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask373_13_16079)">
+<path d="M800.54 882.382L783.523 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask374_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask374_13_16079)">
+<path d="M800.54 882.382L834.366 893.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask375_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask375_13_16079)">
+<path d="M774.28 879.666L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask376_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask376_13_16079)">
+<path d="M834.366 893.754L838.612 916.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask377_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask377_13_16079)">
+<path d="M834.366 893.754L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask378_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask378_13_16079)">
+<path d="M834.366 893.754L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask379_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask379_13_16079)">
+<path d="M838.612 916.102L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask380_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask380_13_16079)">
+<path d="M838.612 916.102L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask381_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask381_13_16079)">
+<path d="M838.612 916.102L811.356 939.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask382_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask382_13_16079)">
+<path d="M854.614 895.444L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask383_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask383_13_16079)">
+<path d="M811.356 939.307L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask384_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask384_13_16079)">
+<path d="M811.356 939.306L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask385_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask385_13_16079)">
+<path d="M811.356 939.306L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask386_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask386_13_16079)">
+<path d="M789.308 931.895L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask387_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask387_13_16079)">
+<path d="M789.308 931.895L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask388_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask388_13_16079)">
+<path d="M787.975 951.307L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask389_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask389_13_16079)">
+<mask id="mask390_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="777" y="892" width="11" height="11">
+<path d="M777.864 902.402H787.778V892.307H777.864V902.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask390_13_16079)">
+<path d="M782.821 901.88C783.999 901.88 785.13 901.403 785.963 900.554C786.797 899.706 787.265 898.555 787.265 897.354C787.265 896.154 786.797 895.003 785.963 894.155C785.13 893.306 783.999 892.829 782.821 892.829C781.642 892.829 780.512 893.306 779.678 894.155C778.845 895.003 778.377 896.154 778.377 897.354C778.377 898.555 778.845 899.706 779.678 900.554C780.512 901.403 781.642 901.88 782.821 901.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask391_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask391_13_16079)">
+<mask id="mask392_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="795" y="877" width="11" height="11">
+<path d="M795.583 887.429H805.497V877.334H795.583V887.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask392_13_16079)">
+<path d="M800.54 886.907C801.719 886.907 802.849 886.43 803.683 885.581C804.516 884.733 804.984 883.582 804.984 882.382C804.984 881.181 804.516 880.03 803.683 879.182C802.849 878.333 801.719 877.856 800.54 877.856C799.362 877.856 798.231 878.333 797.398 879.182C796.565 880.03 796.096 881.181 796.096 882.382C796.096 883.582 796.565 884.733 797.398 885.581C798.231 886.43 799.362 886.907 800.54 886.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask393_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask393_13_16079)">
+<mask id="mask394_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="769" y="874" width="11" height="11">
+<path d="M769.323 884.714H779.237V874.618H769.323V884.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask394_13_16079)">
+<path d="M774.28 884.191C775.458 884.191 776.589 883.714 777.422 882.866C778.256 882.017 778.724 880.866 778.724 879.666C778.724 878.466 778.256 877.315 777.422 876.466C776.589 875.617 775.458 875.141 774.28 875.141C773.101 875.141 771.971 875.617 771.137 876.466C770.304 877.315 769.836 878.466 769.836 879.666C769.836 880.866 770.304 882.017 771.137 882.866C771.971 883.714 773.101 884.191 774.28 884.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask395_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask395_13_16079)">
+<mask id="mask396_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="778" y="866" width="11" height="11">
+<path d="M778.566 876.592H788.481V866.496H778.566V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask396_13_16079)">
+<path d="M783.524 876.069C784.702 876.069 785.833 875.592 786.666 874.744C787.499 873.895 787.968 872.744 787.968 871.544C787.968 870.344 787.499 869.193 786.666 868.344C785.833 867.495 784.702 867.019 783.524 867.019C782.345 867.019 781.215 867.495 780.381 868.344C779.548 869.193 779.08 870.344 779.08 871.544C779.08 872.744 779.548 873.895 780.381 874.744C781.215 875.592 782.345 876.069 783.524 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask397_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask397_13_16079)">
+<mask id="mask398_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="829" y="888" width="11" height="11">
+<path d="M829.409 898.802H839.323V888.707H829.409V898.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask398_13_16079)">
+<path d="M834.366 898.28C835.544 898.28 836.675 897.803 837.508 896.954C838.342 896.106 838.81 894.955 838.81 893.754C838.81 892.554 838.342 891.403 837.508 890.555C836.675 889.706 835.544 889.229 834.366 889.229C833.187 889.229 832.057 889.706 831.223 890.555C830.39 891.403 829.922 892.554 829.922 893.754C829.922 894.955 830.39 896.106 831.223 896.954C832.057 897.803 833.187 898.28 834.366 898.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask399_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask399_13_16079)">
+<mask id="mask400_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="833" y="911" width="11" height="11">
+<path d="M833.655 921.15H843.57V911.054H833.655V921.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask400_13_16079)">
+<path d="M838.612 920.628C839.791 920.628 840.921 920.151 841.755 919.302C842.588 918.453 843.056 917.302 843.056 916.102C843.056 914.902 842.588 913.751 841.755 912.902C840.921 912.054 839.791 911.577 838.612 911.577C837.434 911.577 836.303 912.054 835.47 912.902C834.637 913.751 834.168 914.902 834.168 916.102C834.168 917.302 834.637 918.453 835.47 919.302C836.303 920.151 837.434 920.628 838.612 920.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask401_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask401_13_16079)">
+<mask id="mask402_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="849" y="890" width="11" height="11">
+<path d="M849.657 900.492H859.571V890.396H849.657V900.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask402_13_16079)">
+<path d="M854.614 899.969C855.792 899.969 856.923 899.492 857.756 898.644C858.59 897.795 859.058 896.644 859.058 895.444C859.058 894.244 858.59 893.093 857.756 892.244C856.923 891.395 855.792 890.919 854.614 890.919C853.435 890.919 852.305 891.395 851.471 892.244C850.638 893.093 850.17 894.244 850.17 895.444C850.17 896.644 850.638 897.795 851.471 898.644C852.305 899.492 853.435 899.969 854.614 899.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask403_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask403_13_16079)">
+<mask id="mask404_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="851" y="902" width="11" height="11">
+<path d="M851.766 912.201H861.68V902.105H851.766V912.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask404_13_16079)">
+<path d="M856.723 911.678C857.901 911.678 859.032 911.202 859.865 910.353C860.699 909.504 861.167 908.353 861.167 907.153C861.167 905.953 860.699 904.802 859.865 903.953C859.032 903.105 857.901 902.628 856.723 902.628C855.544 902.628 854.414 903.105 853.58 903.953C852.747 904.802 852.279 905.953 852.279 907.153C852.279 908.353 852.747 909.504 853.58 910.353C854.414 911.202 855.544 911.678 856.723 911.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask405_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask405_13_16079)">
+<mask id="mask406_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="806" y="934" width="11" height="11">
+<path d="M806.399 944.354H816.313V934.259H806.399V944.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask406_13_16079)">
+<path d="M811.356 943.832C812.535 943.832 813.665 943.355 814.499 942.506C815.332 941.658 815.8 940.507 815.8 939.307C815.8 938.106 815.332 936.955 814.499 936.107C813.665 935.258 812.535 934.781 811.356 934.781C810.178 934.781 809.047 935.258 808.214 936.107C807.38 936.955 806.912 938.106 806.912 939.307C806.912 940.507 807.38 941.658 808.214 942.506C809.047 943.355 810.178 943.832 811.356 943.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask407_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask407_13_16079)">
+<mask id="mask408_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="784" y="926" width="11" height="11">
+<path d="M784.351 936.943H794.265V926.847H784.351V936.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask408_13_16079)">
+<path d="M789.308 936.42C790.486 936.42 791.617 935.943 792.45 935.095C793.283 934.246 793.752 933.095 793.752 931.895C793.752 930.695 793.283 929.544 792.45 928.695C791.617 927.846 790.486 927.37 789.308 927.37C788.129 927.37 786.999 927.846 786.165 928.695C785.332 929.544 784.864 930.695 784.864 931.895C784.864 933.095 785.332 934.246 786.165 935.095C786.999 935.943 788.129 936.42 789.308 936.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask409_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask409_13_16079)">
+<mask id="mask410_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="783" y="946" width="10" height="11">
+<path d="M783.018 956.355H792.932V946.259H783.018V956.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask410_13_16079)">
+<path d="M787.975 955.832C789.154 955.832 790.284 955.355 791.117 954.507C791.951 953.658 792.419 952.507 792.419 951.307C792.419 950.107 791.951 948.955 791.117 948.107C790.284 947.258 789.154 946.781 787.975 946.781C786.796 946.781 785.666 947.258 784.833 948.107C783.999 948.955 783.531 950.107 783.531 951.307C783.531 952.507 783.999 953.658 784.833 954.507C785.666 955.355 786.796 955.832 787.975 955.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask411_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask411_13_16079)">
+<mask id="mask412_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="794" y="950" width="11" height="11">
+<path d="M794.811 960.543H804.726V950.448H794.811V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask412_13_16079)">
+<path d="M799.769 960.021C800.947 960.021 802.078 959.544 802.911 958.695C803.744 957.847 804.213 956.696 804.213 955.496C804.213 954.295 803.744 953.144 802.911 952.296C802.078 951.447 800.947 950.97 799.769 950.97C798.59 950.97 797.46 951.447 796.626 952.296C795.793 953.144 795.325 954.295 795.325 955.496C795.325 956.696 795.793 957.847 796.626 958.695C797.46 959.544 798.59 960.021 799.769 960.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask413_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask413_13_16079)">
+<path d="M782.86 894.113C782.453 894.113 782.16 894.228 781.888 894.481C781.481 894.895 781.21 895.724 781.21 896.575C781.21 897.381 781.436 898.232 781.775 898.646C782.047 898.969 782.408 899.13 782.815 899.13C783.177 899.13 783.493 899.015 783.742 898.762C784.171 898.37 784.442 897.519 784.442 896.621C784.442 895.125 783.787 894.113 782.86 894.113ZM782.838 894.297C783.425 894.297 783.742 895.125 783.742 896.644C783.742 898.163 783.448 898.946 782.815 898.946C782.205 898.946 781.888 898.163 781.888 896.644C781.888 895.102 782.205 894.297 782.838 894.297Z" fill="white"/>
+</g>
+<mask id="mask414_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask414_13_16079)">
+<path d="M800.833 879.137L799.545 879.804V879.896C799.635 879.85 799.703 879.827 799.748 879.827C799.861 879.758 799.997 879.735 800.065 879.735C800.223 879.735 800.291 879.85 800.291 880.08V883.394C800.291 883.624 800.223 883.785 800.11 883.854C799.997 883.923 799.906 883.946 799.59 883.946V884.061H801.579V883.946C801.014 883.946 800.901 883.877 800.901 883.532V879.137H800.833Z" fill="white"/>
+</g>
+<mask id="mask415_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask415_13_16079)">
+<path d="M775.905 880.356L775.792 880.31C775.543 880.724 775.453 880.794 775.114 880.794H773.419L774.617 879.505C775.249 878.837 775.521 878.285 775.521 877.71C775.521 876.973 774.956 876.421 774.21 876.421C773.803 876.421 773.441 876.582 773.17 876.858C772.944 877.111 772.831 877.341 772.718 877.871L772.854 877.894C773.148 877.18 773.419 876.95 773.893 876.95C774.504 876.95 774.91 877.364 774.91 877.986C774.91 878.561 774.594 879.229 773.984 879.873L772.718 881.254V881.346H775.498L775.905 880.356Z" fill="white"/>
+</g>
+<mask id="mask416_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask416_13_16079)">
+<path d="M782.843 870.811C783.25 870.811 783.408 870.834 783.589 870.903C784.041 871.065 784.312 871.479 784.312 871.985C784.312 872.583 783.905 873.067 783.386 873.067C783.182 873.067 783.047 873.021 782.775 872.837C782.549 872.698 782.436 872.652 782.323 872.652C782.143 872.652 782.052 872.768 782.052 872.906C782.052 873.159 782.346 873.32 782.843 873.32C783.408 873.32 783.973 873.136 784.312 872.837C784.651 872.537 784.832 872.123 784.832 871.64C784.832 871.249 784.719 870.926 784.516 870.696C784.357 870.535 784.222 870.443 783.905 870.305C784.403 869.96 784.583 869.684 784.583 869.292C784.583 868.694 784.131 868.303 783.476 868.303C783.114 868.303 782.798 868.418 782.549 868.648C782.323 868.855 782.21 869.039 782.052 869.477L782.165 869.5C782.459 868.97 782.775 868.74 783.227 868.74C783.702 868.74 784.018 869.062 784.018 869.523C784.018 869.776 783.905 870.029 783.725 870.213C783.521 870.443 783.318 870.558 782.843 870.719V870.811Z" fill="white"/>
+</g>
+<mask id="mask417_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask417_13_16079)">
+<path d="M835.965 893.756H835.219V890.511H834.903L832.665 893.756V894.216H834.677V895.436H835.219V894.216H835.965V893.756ZM834.677 893.756H832.937L834.677 891.248V893.756Z" fill="white"/>
+</g>
+<mask id="mask418_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask418_13_16079)">
+<path d="M838.112 913.525H839.536C839.649 913.525 839.671 913.525 839.694 913.456L839.965 912.811L839.897 912.765C839.784 912.926 839.717 912.949 839.558 912.949H838.067L837.298 914.676C837.276 914.699 837.276 914.699 837.276 914.722C837.276 914.745 837.321 914.768 837.366 914.768C837.592 914.768 837.886 914.837 838.18 914.929C838.993 915.182 839.378 915.642 839.378 916.379C839.378 917.069 838.948 917.621 838.383 917.621C838.248 917.621 838.112 917.552 837.909 917.414C837.683 917.23 837.502 917.161 837.366 917.161C837.163 917.161 837.05 917.253 837.05 917.437C837.05 917.713 837.389 917.874 837.931 917.874C838.519 917.874 839.039 917.69 839.4 917.322C839.739 916.977 839.875 916.563 839.875 916.01C839.875 915.481 839.739 915.159 839.378 914.791C839.084 914.468 838.654 914.307 837.818 914.146L838.112 913.525Z" fill="white"/>
+</g>
+<mask id="mask419_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask419_13_16079)">
+<path d="M856.011 892.134C855.198 892.203 854.791 892.341 854.271 892.732C853.48 893.284 853.073 894.113 853.073 895.102C853.073 895.724 853.254 896.368 853.571 896.736C853.842 897.058 854.226 897.22 854.678 897.22C855.559 897.22 856.17 896.529 856.17 895.54C856.17 894.596 855.65 893.998 854.836 893.998C854.52 893.998 854.362 894.067 853.91 894.343C854.113 893.238 854.904 892.433 856.034 892.249L856.011 892.134ZM854.565 894.343C855.175 894.343 855.537 894.872 855.537 895.77C855.537 896.575 855.243 897.035 854.746 897.035C854.113 897.035 853.729 896.345 853.729 895.217C853.729 894.826 853.797 894.642 853.932 894.527C854.09 894.412 854.316 894.343 854.565 894.343Z" fill="white"/>
+</g>
+<mask id="mask420_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask420_13_16079)">
+<path d="M858.141 904.003H855.497L855.068 905.085L855.203 905.131C855.497 904.647 855.633 904.555 856.04 904.555H857.576L856.175 908.905H856.627L858.141 904.118V904.003Z" fill="white"/>
+</g>
+<mask id="mask421_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask421_13_16079)">
+<path d="M811.647 938.27C812.348 937.902 812.596 937.58 812.596 937.097C812.596 936.498 812.099 936.061 811.376 936.061C810.585 936.061 810.02 936.544 810.02 937.212C810.02 937.672 810.156 937.902 810.901 938.57C810.133 939.168 809.975 939.398 809.975 939.881C809.975 940.595 810.54 941.078 811.353 941.078C812.212 941.078 812.755 940.618 812.755 939.858C812.755 939.283 812.506 938.938 811.647 938.27ZM811.512 939.03C812.031 939.421 812.212 939.674 812.212 940.088C812.212 940.549 811.896 940.894 811.421 940.894C810.879 940.894 810.517 940.457 810.517 939.835C810.517 939.352 810.675 939.053 811.082 938.708L811.512 939.03ZM811.444 938.155C810.811 937.718 810.54 937.396 810.54 936.982C810.54 936.567 810.856 936.268 811.308 936.268C811.805 936.268 812.122 936.59 812.122 937.074C812.122 937.488 811.918 937.833 811.512 938.109C811.466 938.132 811.466 938.132 811.444 938.155Z" fill="white"/>
+</g>
+<mask id="mask422_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask422_13_16079)">
+<path d="M787.945 933.737C788.736 933.645 789.143 933.507 789.618 933.138C790.363 932.586 790.815 931.688 790.815 930.699C790.815 929.502 790.137 928.651 789.211 928.651C788.375 928.651 787.742 929.387 787.742 930.377C787.742 931.251 788.239 931.85 789.03 931.85C789.414 931.85 789.708 931.734 790.092 931.435C789.798 932.609 789.007 933.391 787.923 933.599L787.945 933.737ZM790.115 930.975C790.115 931.136 790.07 931.205 790.002 931.274C789.798 931.435 789.527 931.527 789.279 931.527C788.736 931.527 788.397 930.975 788.397 930.124C788.397 929.709 788.51 929.272 788.646 929.065C788.781 928.927 788.962 928.858 789.166 928.858C789.776 928.858 790.115 929.479 790.115 930.699V930.975Z" fill="white"/>
+</g>
+<mask id="mask423_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask423_13_16079)">
+<path d="M786.476 948.063L785.188 948.73V948.822C785.278 948.776 785.346 948.753 785.391 948.753C785.504 948.684 785.64 948.661 785.708 948.661C785.866 948.661 785.934 948.776 785.934 949.006V952.32C785.934 952.55 785.866 952.711 785.753 952.78C785.64 952.85 785.55 952.873 785.233 952.873V952.988H787.222V952.873C786.657 952.873 786.544 952.804 786.544 952.458V948.063H786.476ZM789.804 948.063C789.397 948.063 789.103 948.178 788.832 948.431C788.425 948.845 788.154 949.674 788.154 950.525C788.154 951.331 788.38 952.182 788.719 952.596C788.99 952.919 789.352 953.08 789.759 953.08C790.12 953.08 790.437 952.965 790.685 952.711C791.115 952.32 791.386 951.469 791.386 950.571C791.386 949.075 790.731 948.063 789.804 948.063ZM789.781 948.247C790.369 948.247 790.685 949.075 790.685 950.594C790.685 952.113 790.392 952.896 789.759 952.896C789.149 952.896 788.832 952.113 788.832 950.594C788.832 949.052 789.149 948.247 789.781 948.247Z" fill="white"/>
+</g>
+<mask id="mask424_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask424_13_16079)">
+<path d="M798.268 952.251L796.98 952.919V953.011C797.07 952.965 797.138 952.942 797.183 952.942C797.296 952.873 797.432 952.85 797.499 952.85C797.658 952.85 797.725 952.965 797.725 953.195V956.509C797.725 956.739 797.658 956.9 797.545 956.969C797.432 957.038 797.341 957.061 797.025 957.061V957.176H799.014V957.061C798.449 957.061 798.336 956.992 798.336 956.647V952.251H798.268ZM801.85 952.251L800.562 952.919V953.011C800.652 952.965 800.72 952.942 800.765 952.942C800.878 952.873 801.014 952.85 801.082 952.85C801.24 952.85 801.308 952.965 801.308 953.195V956.509C801.308 956.739 801.24 956.9 801.127 956.969C801.014 957.038 800.923 957.061 800.607 957.061V957.176H802.596V957.061C802.031 957.061 801.918 956.992 801.918 956.647V952.251H801.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask425_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1212" y="775" width="112" height="114">
+<path d="M1212 888.037H1323V775H1212V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask425_13_16079)">
+<mask id="mask426_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask426_13_16079)">
+<path d="M1234.82 815.354L1252.54 800.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask427_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask427_13_16079)">
+<path d="M1234.82 815.354L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask428_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask428_13_16079)">
+<path d="M1234.82 815.354L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask429_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask429_13_16079)">
+<path d="M1234.82 815.354L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask430_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask430_13_16079)">
+<path d="M1252.54 800.382L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask431_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask431_13_16079)">
+<path d="M1252.54 800.382L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask432_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask432_13_16079)">
+<path d="M1252.54 800.382L1286.37 811.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask433_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask433_13_16079)">
+<path d="M1226.28 797.666L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask434_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask434_13_16079)">
+<path d="M1286.37 811.754L1290.61 834.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask435_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask435_13_16079)">
+<path d="M1286.37 811.754L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask436_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask436_13_16079)">
+<path d="M1286.37 811.754L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask437_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask437_13_16079)">
+<path d="M1290.61 834.102L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask438_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask438_13_16079)">
+<path d="M1290.61 834.102L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask439_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask439_13_16079)">
+<path d="M1290.61 834.102L1263.36 857.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask440_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask440_13_16079)">
+<path d="M1306.61 813.444L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask441_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask441_13_16079)">
+<path d="M1263.36 857.307L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask442_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask442_13_16079)">
+<path d="M1263.36 857.306L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask443_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask443_13_16079)">
+<path d="M1263.36 857.306L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask444_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask444_13_16079)">
+<path d="M1241.31 849.895L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask445_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask445_13_16079)">
+<path d="M1241.31 849.895L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask446_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask446_13_16079)">
+<path d="M1239.98 869.307L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask447_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask447_13_16079)">
+<mask id="mask448_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1229" y="810" width="11" height="11">
+<path d="M1229.86 820.402H1239.78V810.307H1229.86V820.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask448_13_16079)">
+<path d="M1234.82 819.88C1236 819.88 1237.13 819.403 1237.96 818.554C1238.8 817.706 1239.26 816.555 1239.26 815.354C1239.26 814.154 1238.8 813.003 1237.96 812.155C1237.13 811.306 1236 810.829 1234.82 810.829C1233.64 810.829 1232.51 811.306 1231.68 812.155C1230.85 813.003 1230.38 814.154 1230.38 815.354C1230.38 816.555 1230.85 817.706 1231.68 818.554C1232.51 819.403 1233.64 819.88 1234.82 819.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask449_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask449_13_16079)">
+<mask id="mask450_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1247" y="795" width="11" height="11">
+<path d="M1247.58 805.429H1257.5V795.334H1247.58V805.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask450_13_16079)">
+<path d="M1252.54 804.907C1253.72 804.907 1254.85 804.43 1255.68 803.581C1256.52 802.733 1256.98 801.582 1256.98 800.382C1256.98 799.181 1256.52 798.03 1255.68 797.182C1254.85 796.333 1253.72 795.856 1252.54 795.856C1251.36 795.856 1250.23 796.333 1249.4 797.182C1248.56 798.03 1248.1 799.181 1248.1 800.382C1248.1 801.582 1248.56 802.733 1249.4 803.581C1250.23 804.43 1251.36 804.907 1252.54 804.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask451_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask451_13_16079)">
+<mask id="mask452_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1221" y="792" width="11" height="11">
+<path d="M1221.32 802.714H1231.24V792.618H1221.32V802.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask452_13_16079)">
+<path d="M1226.28 802.191C1227.46 802.191 1228.59 801.714 1229.42 800.866C1230.26 800.017 1230.72 798.866 1230.72 797.666C1230.72 796.466 1230.26 795.315 1229.42 794.466C1228.59 793.617 1227.46 793.141 1226.28 793.141C1225.1 793.141 1223.97 793.617 1223.14 794.466C1222.3 795.315 1221.84 796.466 1221.84 797.666C1221.84 798.866 1222.3 800.017 1223.14 800.866C1223.97 801.714 1225.1 802.191 1226.28 802.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask453_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask453_13_16079)">
+<mask id="mask454_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1230" y="784" width="11" height="11">
+<path d="M1230.57 794.592H1240.48V784.496H1230.57V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask454_13_16079)">
+<path d="M1235.52 794.069C1236.7 794.069 1237.83 793.592 1238.67 792.744C1239.5 791.895 1239.97 790.744 1239.97 789.544C1239.97 788.344 1239.5 787.193 1238.67 786.344C1237.83 785.495 1236.7 785.019 1235.52 785.019C1234.34 785.019 1233.21 785.495 1232.38 786.344C1231.55 787.193 1231.08 788.344 1231.08 789.544C1231.08 790.744 1231.55 791.895 1232.38 792.744C1233.21 793.592 1234.34 794.069 1235.52 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask455_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask455_13_16079)">
+<mask id="mask456_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1281" y="806" width="11" height="11">
+<path d="M1281.41 816.802H1291.32V806.707H1281.41V816.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask456_13_16079)">
+<path d="M1286.37 816.28C1287.54 816.28 1288.67 815.803 1289.51 814.954C1290.34 814.106 1290.81 812.955 1290.81 811.754C1290.81 810.554 1290.34 809.403 1289.51 808.555C1288.67 807.706 1287.54 807.229 1286.37 807.229C1285.19 807.229 1284.06 807.706 1283.22 808.555C1282.39 809.403 1281.92 810.554 1281.92 811.754C1281.92 812.955 1282.39 814.106 1283.22 814.954C1284.06 815.803 1285.19 816.28 1286.37 816.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask457_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask457_13_16079)">
+<mask id="mask458_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1285" y="829" width="11" height="11">
+<path d="M1285.66 839.15H1295.57V829.054H1285.66V839.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask458_13_16079)">
+<path d="M1290.61 838.628C1291.79 838.628 1292.92 838.151 1293.75 837.302C1294.59 836.453 1295.06 835.302 1295.06 834.102C1295.06 832.902 1294.59 831.751 1293.75 830.902C1292.92 830.054 1291.79 829.577 1290.61 829.577C1289.43 829.577 1288.3 830.054 1287.47 830.902C1286.64 831.751 1286.17 832.902 1286.17 834.102C1286.17 835.302 1286.64 836.453 1287.47 837.302C1288.3 838.151 1289.43 838.628 1290.61 838.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask459_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask459_13_16079)">
+<mask id="mask460_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1301" y="808" width="11" height="11">
+<path d="M1301.66 818.492H1311.57V808.396H1301.66V818.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask460_13_16079)">
+<path d="M1306.61 817.969C1307.79 817.969 1308.92 817.492 1309.76 816.644C1310.59 815.795 1311.06 814.644 1311.06 813.444C1311.06 812.244 1310.59 811.093 1309.76 810.244C1308.92 809.395 1307.79 808.919 1306.61 808.919C1305.44 808.919 1304.3 809.395 1303.47 810.244C1302.64 811.093 1302.17 812.244 1302.17 813.444C1302.17 814.644 1302.64 815.795 1303.47 816.644C1304.3 817.492 1305.44 817.969 1306.61 817.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask461_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask461_13_16079)">
+<mask id="mask462_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1303" y="820" width="11" height="11">
+<path d="M1303.77 830.201H1313.68V820.105H1303.77V830.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask462_13_16079)">
+<path d="M1308.72 829.678C1309.9 829.678 1311.03 829.202 1311.87 828.353C1312.7 827.504 1313.17 826.353 1313.17 825.153C1313.17 823.953 1312.7 822.802 1311.87 821.953C1311.03 821.105 1309.9 820.628 1308.72 820.628C1307.54 820.628 1306.41 821.105 1305.58 821.953C1304.75 822.802 1304.28 823.953 1304.28 825.153C1304.28 826.353 1304.75 827.504 1305.58 828.353C1306.41 829.202 1307.54 829.678 1308.72 829.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask463_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask463_13_16079)">
+<mask id="mask464_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1258" y="852" width="11" height="11">
+<path d="M1258.4 862.354H1268.31V852.259H1258.4V862.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask464_13_16079)">
+<path d="M1263.36 861.832C1264.53 861.832 1265.67 861.355 1266.5 860.506C1267.33 859.658 1267.8 858.507 1267.8 857.307C1267.8 856.106 1267.33 854.955 1266.5 854.107C1265.67 853.258 1264.53 852.781 1263.36 852.781C1262.18 852.781 1261.05 853.258 1260.21 854.107C1259.38 854.955 1258.91 856.106 1258.91 857.307C1258.91 858.507 1259.38 859.658 1260.21 860.506C1261.05 861.355 1262.18 861.832 1263.36 861.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask465_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask465_13_16079)">
+<mask id="mask466_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1236" y="844" width="11" height="11">
+<path d="M1236.35 854.943H1246.26V844.847H1236.35V854.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask466_13_16079)">
+<path d="M1241.31 854.42C1242.49 854.42 1243.62 853.943 1244.45 853.095C1245.28 852.246 1245.75 851.095 1245.75 849.895C1245.75 848.695 1245.28 847.544 1244.45 846.695C1243.62 845.846 1242.49 845.37 1241.31 845.37C1240.13 845.37 1239 845.846 1238.17 846.695C1237.33 847.544 1236.86 848.695 1236.86 849.895C1236.86 851.095 1237.33 852.246 1238.17 853.095C1239 853.943 1240.13 854.42 1241.31 854.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask467_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask467_13_16079)">
+<mask id="mask468_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1235" y="864" width="10" height="11">
+<path d="M1235.02 874.355H1244.93V864.259H1235.02V874.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask468_13_16079)">
+<path d="M1239.98 873.832C1241.15 873.832 1242.28 873.355 1243.12 872.507C1243.95 871.658 1244.42 870.507 1244.42 869.307C1244.42 868.107 1243.95 866.955 1243.12 866.107C1242.28 865.258 1241.15 864.781 1239.98 864.781C1238.8 864.781 1237.67 865.258 1236.83 866.107C1236 866.955 1235.53 868.107 1235.53 869.307C1235.53 870.507 1236 871.658 1236.83 872.507C1237.67 873.355 1238.8 873.832 1239.98 873.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask469_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask469_13_16079)">
+<mask id="mask470_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1246" y="868" width="11" height="11">
+<path d="M1246.81 878.543H1256.73V868.448H1246.81V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask470_13_16079)">
+<path d="M1251.77 878.021C1252.95 878.021 1254.08 877.544 1254.91 876.695C1255.74 875.847 1256.21 874.696 1256.21 873.496C1256.21 872.295 1255.74 871.144 1254.91 870.296C1254.08 869.447 1252.95 868.97 1251.77 868.97C1250.59 868.97 1249.46 869.447 1248.63 870.296C1247.79 871.144 1247.32 872.295 1247.32 873.496C1247.32 874.696 1247.79 875.847 1248.63 876.695C1249.46 877.544 1250.59 878.021 1251.77 878.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask471_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask471_13_16079)">
+<path d="M1234.86 812.113C1234.45 812.113 1234.16 812.228 1233.89 812.481C1233.48 812.895 1233.21 813.724 1233.21 814.575C1233.21 815.381 1233.44 816.232 1233.78 816.646C1234.05 816.969 1234.41 817.13 1234.81 817.13C1235.18 817.13 1235.49 817.015 1235.74 816.762C1236.17 816.37 1236.44 815.519 1236.44 814.621C1236.44 813.125 1235.79 812.113 1234.86 812.113ZM1234.84 812.297C1235.43 812.297 1235.74 813.125 1235.74 814.644C1235.74 816.163 1235.45 816.946 1234.81 816.946C1234.2 816.946 1233.89 816.163 1233.89 814.644C1233.89 813.102 1234.2 812.297 1234.84 812.297Z" fill="white"/>
+</g>
+<mask id="mask472_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask472_13_16079)">
+<path d="M1252.83 797.137L1251.54 797.804V797.896C1251.64 797.85 1251.7 797.827 1251.75 797.827C1251.86 797.758 1252 797.735 1252.06 797.735C1252.22 797.735 1252.29 797.85 1252.29 798.08V801.394C1252.29 801.624 1252.22 801.785 1252.11 801.854C1252 801.923 1251.91 801.946 1251.59 801.946V802.061H1253.58V801.946C1253.01 801.946 1252.9 801.877 1252.9 801.532V797.137H1252.83Z" fill="white"/>
+</g>
+<mask id="mask473_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask473_13_16079)">
+<path d="M1227.9 798.356L1227.79 798.31C1227.54 798.724 1227.45 798.794 1227.11 798.794H1225.42L1226.62 797.505C1227.25 796.837 1227.52 796.285 1227.52 795.71C1227.52 794.973 1226.96 794.421 1226.21 794.421C1225.8 794.421 1225.44 794.582 1225.17 794.858C1224.94 795.111 1224.83 795.341 1224.72 795.871L1224.85 795.894C1225.15 795.18 1225.42 794.95 1225.89 794.95C1226.5 794.95 1226.91 795.364 1226.91 795.986C1226.91 796.561 1226.59 797.229 1225.98 797.873L1224.72 799.254V799.346H1227.5L1227.9 798.356Z" fill="white"/>
+</g>
+<mask id="mask474_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask474_13_16079)">
+<path d="M1234.84 788.811C1235.25 788.811 1235.41 788.834 1235.59 788.903C1236.04 789.065 1236.31 789.479 1236.31 789.985C1236.31 790.583 1235.91 791.067 1235.39 791.067C1235.18 791.067 1235.05 791.021 1234.78 790.837C1234.55 790.698 1234.44 790.652 1234.32 790.652C1234.14 790.652 1234.05 790.768 1234.05 790.906C1234.05 791.159 1234.35 791.32 1234.84 791.32C1235.41 791.32 1235.97 791.136 1236.31 790.837C1236.65 790.537 1236.83 790.123 1236.83 789.64C1236.83 789.249 1236.72 788.926 1236.52 788.696C1236.36 788.535 1236.22 788.443 1235.91 788.305C1236.4 787.96 1236.58 787.684 1236.58 787.292C1236.58 786.694 1236.13 786.303 1235.48 786.303C1235.11 786.303 1234.8 786.418 1234.55 786.648C1234.32 786.855 1234.21 787.039 1234.05 787.477L1234.17 787.5C1234.46 786.97 1234.78 786.74 1235.23 786.74C1235.7 786.74 1236.02 787.062 1236.02 787.523C1236.02 787.776 1235.91 788.029 1235.72 788.213C1235.52 788.443 1235.32 788.558 1234.84 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask475_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask475_13_16079)">
+<path d="M1287.96 811.756H1287.22V808.511H1286.9L1284.67 811.756V812.216H1286.68V813.436H1287.22V812.216H1287.96V811.756ZM1286.68 811.756H1284.94L1286.68 809.248V811.756Z" fill="white"/>
+</g>
+<mask id="mask476_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask476_13_16079)">
+<path d="M1290.11 831.525H1291.54C1291.65 831.525 1291.67 831.525 1291.69 831.456L1291.97 830.811L1291.9 830.765C1291.78 830.926 1291.72 830.949 1291.56 830.949H1290.07L1289.3 832.676C1289.28 832.699 1289.28 832.699 1289.28 832.722C1289.28 832.745 1289.32 832.768 1289.37 832.768C1289.59 832.768 1289.89 832.837 1290.18 832.929C1290.99 833.182 1291.38 833.642 1291.38 834.379C1291.38 835.069 1290.95 835.621 1290.38 835.621C1290.25 835.621 1290.11 835.552 1289.91 835.414C1289.68 835.23 1289.5 835.161 1289.37 835.161C1289.16 835.161 1289.05 835.253 1289.05 835.437C1289.05 835.713 1289.39 835.874 1289.93 835.874C1290.52 835.874 1291.04 835.69 1291.4 835.322C1291.74 834.977 1291.87 834.563 1291.87 834.01C1291.87 833.481 1291.74 833.159 1291.38 832.791C1291.08 832.468 1290.65 832.307 1289.82 832.146L1290.11 831.525Z" fill="white"/>
+</g>
+<mask id="mask477_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask477_13_16079)">
+<path d="M1308.01 810.134C1307.2 810.203 1306.79 810.341 1306.27 810.732C1305.48 811.284 1305.07 812.113 1305.07 813.102C1305.07 813.724 1305.25 814.368 1305.57 814.736C1305.84 815.058 1306.23 815.22 1306.68 815.22C1307.56 815.22 1308.17 814.529 1308.17 813.54C1308.17 812.596 1307.65 811.998 1306.84 811.998C1306.52 811.998 1306.36 812.067 1305.91 812.343C1306.11 811.238 1306.9 810.433 1308.03 810.249L1308.01 810.134ZM1306.56 812.343C1307.18 812.343 1307.54 812.872 1307.54 813.77C1307.54 814.575 1307.24 815.035 1306.75 815.035C1306.11 815.035 1305.73 814.345 1305.73 813.217C1305.73 812.826 1305.8 812.642 1305.93 812.527C1306.09 812.412 1306.32 812.343 1306.56 812.343Z" fill="white"/>
+</g>
+<mask id="mask478_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask478_13_16079)">
+<path d="M1310.14 822.003H1307.5L1307.07 823.085L1307.2 823.131C1307.5 822.647 1307.63 822.555 1308.04 822.555H1309.58L1308.18 826.905H1308.63L1310.14 822.118V822.003Z" fill="white"/>
+</g>
+<mask id="mask479_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask479_13_16079)">
+<path d="M1263.65 856.27C1264.35 855.902 1264.6 855.58 1264.6 855.097C1264.6 854.498 1264.1 854.061 1263.38 854.061C1262.58 854.061 1262.02 854.544 1262.02 855.212C1262.02 855.672 1262.16 855.902 1262.9 856.57C1262.13 857.168 1261.97 857.398 1261.97 857.881C1261.97 858.595 1262.54 859.078 1263.35 859.078C1264.21 859.078 1264.75 858.618 1264.75 857.858C1264.75 857.283 1264.51 856.938 1263.65 856.27ZM1263.51 857.03C1264.03 857.421 1264.21 857.674 1264.21 858.088C1264.21 858.549 1263.9 858.894 1263.42 858.894C1262.88 858.894 1262.52 858.457 1262.52 857.835C1262.52 857.352 1262.68 857.053 1263.08 856.708L1263.51 857.03ZM1263.44 856.155C1262.81 855.718 1262.54 855.396 1262.54 854.982C1262.54 854.567 1262.86 854.268 1263.31 854.268C1263.81 854.268 1264.12 854.59 1264.12 855.074C1264.12 855.488 1263.92 855.833 1263.51 856.109C1263.47 856.132 1263.47 856.132 1263.44 856.155Z" fill="white"/>
+</g>
+<mask id="mask480_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask480_13_16079)">
+<path d="M1239.95 851.737C1240.74 851.645 1241.14 851.507 1241.62 851.138C1242.36 850.586 1242.82 849.688 1242.82 848.699C1242.82 847.502 1242.14 846.651 1241.21 846.651C1240.37 846.651 1239.74 847.387 1239.74 848.377C1239.74 849.251 1240.24 849.85 1241.03 849.85C1241.41 849.85 1241.71 849.734 1242.09 849.435C1241.8 850.609 1241.01 851.391 1239.92 851.599L1239.95 851.737ZM1242.11 848.975C1242.11 849.136 1242.07 849.205 1242 849.274C1241.8 849.435 1241.53 849.527 1241.28 849.527C1240.74 849.527 1240.4 848.975 1240.4 848.124C1240.4 847.709 1240.51 847.272 1240.65 847.065C1240.78 846.927 1240.96 846.858 1241.17 846.858C1241.78 846.858 1242.11 847.479 1242.11 848.699V848.975Z" fill="white"/>
+</g>
+<mask id="mask481_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask481_13_16079)">
+<path d="M1238.48 866.063L1237.19 866.73V866.822C1237.28 866.776 1237.35 866.753 1237.39 866.753C1237.5 866.684 1237.64 866.661 1237.71 866.661C1237.87 866.661 1237.93 866.776 1237.93 867.006V870.32C1237.93 870.55 1237.87 870.711 1237.75 870.78C1237.64 870.85 1237.55 870.873 1237.23 870.873V870.988H1239.22V870.873C1238.66 870.873 1238.54 870.804 1238.54 870.458V866.063H1238.48ZM1241.8 866.063C1241.4 866.063 1241.1 866.178 1240.83 866.431C1240.43 866.845 1240.15 867.674 1240.15 868.525C1240.15 869.331 1240.38 870.182 1240.72 870.596C1240.99 870.919 1241.35 871.08 1241.76 871.08C1242.12 871.08 1242.44 870.965 1242.69 870.711C1243.11 870.32 1243.39 869.469 1243.39 868.571C1243.39 867.075 1242.73 866.063 1241.8 866.063ZM1241.78 866.247C1242.37 866.247 1242.69 867.075 1242.69 868.594C1242.69 870.113 1242.39 870.896 1241.76 870.896C1241.15 870.896 1240.83 870.113 1240.83 868.594C1240.83 867.052 1241.15 866.247 1241.78 866.247Z" fill="white"/>
+</g>
+<mask id="mask482_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask482_13_16079)">
+<path d="M1250.27 870.251L1248.98 870.919V871.011C1249.07 870.965 1249.14 870.942 1249.18 870.942C1249.3 870.873 1249.43 870.85 1249.5 870.85C1249.66 870.85 1249.73 870.965 1249.73 871.195V874.509C1249.73 874.739 1249.66 874.9 1249.54 874.969C1249.43 875.038 1249.34 875.061 1249.02 875.061V875.176H1251.01V875.061C1250.45 875.061 1250.34 874.992 1250.34 874.647V870.251H1250.27ZM1253.85 870.251L1252.56 870.919V871.011C1252.65 870.965 1252.72 870.942 1252.77 870.942C1252.88 870.873 1253.01 870.85 1253.08 870.85C1253.24 870.85 1253.31 870.965 1253.31 871.195V874.509C1253.31 874.739 1253.24 874.9 1253.13 874.969C1253.01 875.038 1252.92 875.061 1252.61 875.061V875.176H1254.6V875.061C1254.03 875.061 1253.92 874.992 1253.92 874.647V870.251H1253.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask483_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="599" width="112" height="114">
+<path d="M303 712.037H414.004V599H303V712.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask483_13_16079)">
+<mask id="mask484_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask484_13_16079)">
+<path d="M373.994 647.467L399.723 613.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask485_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask485_13_16079)">
+<path d="M373.994 647.467L346.753 682.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask486_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask486_13_16079)">
+<path d="M373.994 647.467L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask487_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask487_13_16079)">
+<path d="M373.994 647.467L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask488_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask488_13_16079)">
+<path d="M373.994 647.467L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask489_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask489_13_16079)">
+<path d="M346.753 682.876L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask490_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask490_13_16079)">
+<path d="M346.753 682.876L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask491_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask491_13_16079)">
+<path d="M346.753 682.876L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask492_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask492_13_16079)">
+<path d="M343.325 666.493L334.824 615.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask493_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask493_13_16079)">
+<path d="M343.325 666.493L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask494_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask494_13_16079)">
+<path d="M343.325 666.493L376.747 697.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask495_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask495_13_16079)">
+<path d="M343.325 666.493L324.53 693.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask496_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask496_13_16079)">
+<path d="M343.325 666.493L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask497_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask497_13_16079)">
+<path d="M343.325 666.493L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask498_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask498_13_16079)">
+<path d="M334.824 615.141L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask499_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask499_13_16079)">
+<path d="M353.445 633.168L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask500_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask500_13_16079)">
+<path d="M353.445 633.168L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask501_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask501_13_16079)">
+<path d="M376.747 697.496L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask502_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask502_13_16079)">
+<path d="M324.53 693.105L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask503_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask503_13_16079)">
+<mask id="mask504_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="369" y="642" width="10" height="11">
+<path d="M369.037 652.515H378.951V642.419H369.037V652.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask504_13_16079)">
+<path d="M373.994 651.992C375.172 651.992 376.303 651.515 377.136 650.667C377.97 649.818 378.438 648.667 378.438 647.467C378.438 646.267 377.97 645.116 377.136 644.267C376.303 643.418 375.172 642.942 373.994 642.942C372.815 642.942 371.685 643.418 370.851 644.267C370.018 645.116 369.55 646.267 369.55 647.467C369.55 648.667 370.018 649.818 370.851 650.667C371.685 651.515 372.815 651.992 373.994 651.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask505_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask505_13_16079)">
+<mask id="mask506_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="608" width="11" height="11">
+<path d="M394.766 618.592H404.68V608.496H394.766V618.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask506_13_16079)">
+<path d="M399.723 618.069C400.901 618.069 402.032 617.593 402.865 616.744C403.699 615.895 404.167 614.744 404.167 613.544C404.167 612.344 403.699 611.193 402.865 610.344C402.032 609.496 400.901 609.019 399.723 609.019C398.544 609.019 397.414 609.496 396.58 610.344C395.747 611.193 395.279 612.344 395.279 613.544C395.279 614.744 395.747 615.895 396.58 616.744C397.414 617.593 398.544 618.069 399.723 618.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask507_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask507_13_16079)">
+<mask id="mask508_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="341" y="677" width="11" height="11">
+<path d="M341.796 687.924H351.71V677.829H341.796V687.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask508_13_16079)">
+<path d="M346.753 687.402C347.931 687.402 349.062 686.925 349.895 686.076C350.728 685.228 351.197 684.077 351.197 682.876C351.197 681.676 350.728 680.525 349.895 679.677C349.062 678.828 347.931 678.351 346.753 678.351C345.574 678.351 344.444 678.828 343.61 679.677C342.777 680.525 342.309 681.676 342.309 682.876C342.309 684.077 342.777 685.228 343.61 686.076C344.444 686.925 345.574 687.402 346.753 687.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask509_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask509_13_16079)">
+<mask id="mask510_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="661" width="11" height="11">
+<path d="M338.368 671.541H348.282V661.445H338.368V671.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask510_13_16079)">
+<path d="M343.325 671.018C344.503 671.018 345.634 670.541 346.467 669.693C347.3 668.844 347.769 667.693 347.769 666.493C347.769 665.293 347.3 664.142 346.467 663.293C345.634 662.444 344.503 661.968 343.325 661.968C342.146 661.968 341.016 662.444 340.182 663.293C339.349 664.142 338.881 665.293 338.881 666.493C338.881 667.693 339.349 668.844 340.182 669.693C341.016 670.541 342.146 671.018 343.325 671.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask511_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask511_13_16079)">
+<mask id="mask512_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="610" width="11" height="11">
+<path d="M329.867 620.189H339.781V610.094H329.867V620.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask512_13_16079)">
+<path d="M334.824 619.667C336.003 619.667 337.133 619.19 337.967 618.341C338.8 617.493 339.268 616.342 339.268 615.141C339.268 613.941 338.8 612.79 337.967 611.941C337.133 611.093 336.003 610.616 334.824 610.616C333.646 610.616 332.515 611.093 331.682 611.941C330.848 612.79 330.38 613.941 330.38 615.141C330.38 616.342 330.848 617.493 331.682 618.341C332.515 619.19 333.646 619.667 334.824 619.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask513_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask513_13_16079)">
+<mask id="mask514_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="348" y="628" width="11" height="11">
+<path d="M348.488 638.216H358.402V628.12H348.488V638.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask514_13_16079)">
+<path d="M353.445 637.693C354.623 637.693 355.754 637.216 356.587 636.368C357.421 635.519 357.889 634.368 357.889 633.168C357.889 631.968 357.421 630.817 356.587 629.968C355.754 629.119 354.623 628.643 353.445 628.643C352.266 628.643 351.136 629.119 350.303 629.968C349.469 630.817 349.001 631.968 349.001 633.168C349.001 634.368 349.469 635.519 350.303 636.368C351.136 637.216 352.266 637.693 353.445 637.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask515_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask515_13_16079)">
+<mask id="mask516_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="371" y="692" width="11" height="11">
+<path d="M371.79 702.543H381.704V692.448H371.79V702.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask516_13_16079)">
+<path d="M376.747 702.021C377.925 702.021 379.056 701.544 379.889 700.696C380.723 699.847 381.191 698.696 381.191 697.496C381.191 696.295 380.723 695.144 379.889 694.296C379.056 693.447 377.925 692.97 376.747 692.97C375.568 692.97 374.438 693.447 373.604 694.296C372.771 695.144 372.303 696.295 372.303 697.496C372.303 698.696 372.771 699.847 373.604 700.696C374.438 701.544 375.568 702.021 376.747 702.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask517_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask517_13_16079)">
+<mask id="mask518_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="319" y="688" width="11" height="11">
+<path d="M319.573 698.153H329.487V688.057H319.573V698.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask518_13_16079)">
+<path d="M324.53 697.63C325.708 697.63 326.839 697.153 327.672 696.305C328.506 695.456 328.974 694.305 328.974 693.105C328.974 691.905 328.506 690.754 327.672 689.905C326.839 689.056 325.708 688.58 324.53 688.58C323.351 688.58 322.221 689.056 321.388 689.905C320.554 690.754 320.086 691.905 320.086 693.105C320.086 694.305 320.554 695.456 321.388 696.305C322.221 697.153 323.351 697.63 324.53 697.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask519_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask519_13_16079)">
+<mask id="mask520_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="335" y="646" width="11" height="11">
+<path d="M335.127 656.971H345.041V646.876H335.127V656.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask520_13_16079)">
+<path d="M340.084 656.449C341.263 656.449 342.393 655.972 343.226 655.123C344.06 654.275 344.528 653.124 344.528 651.924C344.528 650.723 344.06 649.572 343.226 648.724C342.393 647.875 341.263 647.398 340.084 647.398C338.905 647.398 337.775 647.875 336.942 648.724C336.108 649.572 335.64 650.723 335.64 651.924C335.64 653.124 336.108 654.275 336.942 655.123C337.775 655.972 338.905 656.449 340.084 656.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask521_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask521_13_16079)">
+<mask id="mask522_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="673" width="11" height="11">
+<path d="M392.783 683.164H402.697V673.068H392.783V683.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask522_13_16079)">
+<path d="M397.74 682.641C398.918 682.641 400.049 682.164 400.882 681.316C401.715 680.467 402.184 679.316 402.184 678.116C402.184 676.916 401.715 675.765 400.882 674.916C400.049 674.067 398.918 673.591 397.74 673.591C396.561 673.591 395.431 674.067 394.597 674.916C393.764 675.765 393.296 676.916 393.296 678.116C393.296 679.316 393.764 680.467 394.597 681.316C395.431 682.164 396.561 682.641 397.74 682.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask523_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask523_13_16079)">
+<mask id="mask524_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="356" y="664" width="10" height="11">
+<path d="M356.043 674.696H365.958V664.601H356.043V674.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask524_13_16079)">
+<path d="M361.001 674.174C362.179 674.174 363.31 673.697 364.143 672.848C364.976 672 365.445 670.849 365.445 669.649C365.445 668.448 364.976 667.297 364.143 666.449C363.31 665.6 362.179 665.123 361.001 665.123C359.822 665.123 358.692 665.6 357.858 666.449C357.025 667.297 356.557 668.448 356.557 669.649C356.557 670.849 357.025 672 357.858 672.848C358.692 673.697 359.822 674.174 361.001 674.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask525_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask525_13_16079)">
+<mask id="mask526_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="669" width="11" height="11">
+<path d="M312.323 679.902H322.237V669.806H312.323V679.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask526_13_16079)">
+<path d="M317.28 679.38C318.458 679.38 319.589 678.903 320.422 678.054C321.256 677.206 321.724 676.054 321.724 674.854C321.724 673.654 321.256 672.503 320.422 671.654C319.589 670.806 318.458 670.329 317.28 670.329C316.101 670.329 314.971 670.806 314.137 671.654C313.304 672.503 312.836 673.654 312.836 674.854C312.836 676.054 313.304 677.206 314.137 678.054C314.971 678.903 316.101 679.38 317.28 679.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask527_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask527_13_16079)">
+<path d="M374.032 644.225C373.626 644.225 373.332 644.34 373.061 644.593C372.654 645.008 372.383 645.836 372.383 646.688C372.383 647.493 372.609 648.345 372.948 648.759C373.219 649.081 373.58 649.242 373.987 649.242C374.349 649.242 374.665 649.127 374.914 648.874C375.343 648.483 375.614 647.631 375.614 646.734C375.614 645.238 374.959 644.225 374.032 644.225ZM374.01 644.409C374.597 644.409 374.914 645.238 374.914 646.757C374.914 648.276 374.62 649.058 373.987 649.058C373.377 649.058 373.061 648.276 373.061 646.757C373.061 645.215 373.377 644.409 374.01 644.409Z" fill="white"/>
+</g>
+<mask id="mask528_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask528_13_16079)">
+<path d="M400.011 610.303L398.723 610.97V611.062C398.814 611.016 398.881 610.993 398.927 610.993C399.04 610.924 399.175 610.901 399.243 610.901C399.401 610.901 399.469 611.016 399.469 611.246V614.56C399.469 614.791 399.401 614.952 399.288 615.021C399.175 615.09 399.085 615.113 398.768 615.113V615.228H400.757V615.113C400.192 615.113 400.079 615.044 400.079 614.698V610.303H400.011Z" fill="white"/>
+</g>
+<mask id="mask529_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask529_13_16079)">
+<path d="M348.376 683.567L348.263 683.521C348.014 683.935 347.924 684.004 347.585 684.004H345.89L347.087 682.716C347.72 682.048 347.991 681.496 347.991 680.921C347.991 680.184 347.426 679.632 346.681 679.632C346.274 679.632 345.912 679.793 345.641 680.069C345.415 680.322 345.302 680.552 345.189 681.082L345.325 681.105C345.618 680.391 345.89 680.161 346.364 680.161C346.974 680.161 347.381 680.575 347.381 681.197C347.381 681.772 347.065 682.439 346.455 683.084L345.189 684.465V684.557H347.969L348.376 683.567Z" fill="white"/>
+</g>
+<mask id="mask530_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask530_13_16079)">
+<path d="M342.641 665.76C343.048 665.76 343.206 665.783 343.387 665.852C343.839 666.013 344.11 666.428 344.11 666.934C344.11 667.532 343.703 668.016 343.183 668.016C342.98 668.016 342.844 667.97 342.573 667.785C342.347 667.647 342.234 667.601 342.121 667.601C341.94 667.601 341.85 667.716 341.85 667.855C341.85 668.108 342.144 668.269 342.641 668.269C343.206 668.269 343.771 668.085 344.11 667.785C344.449 667.486 344.63 667.072 344.63 666.589C344.63 666.198 344.517 665.875 344.313 665.645C344.155 665.484 344.019 665.392 343.703 665.254C344.2 664.909 344.381 664.633 344.381 664.241C344.381 663.643 343.929 663.252 343.274 663.252C342.912 663.252 342.596 663.367 342.347 663.597C342.121 663.804 342.008 663.988 341.85 664.425L341.963 664.448C342.257 663.919 342.573 663.689 343.025 663.689C343.5 663.689 343.816 664.011 343.816 664.471C343.816 664.725 343.703 664.978 343.522 665.162C343.319 665.392 343.115 665.507 342.641 665.668V665.76Z" fill="white"/>
+</g>
+<mask id="mask531_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask531_13_16079)">
+<path d="M336.426 615.142H335.68V611.897H335.364L333.126 615.142V615.602H335.138V616.822H335.68V615.602H336.426V615.142ZM335.138 615.142H333.397L335.138 612.633V615.142Z" fill="white"/>
+</g>
+<mask id="mask532_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask532_13_16079)">
+<path d="M352.946 630.59H354.37C354.483 630.59 354.506 630.59 354.528 630.52L354.8 629.876L354.732 629.83C354.619 629.991 354.551 630.014 354.393 630.014H352.901L352.133 631.74C352.11 631.763 352.11 631.763 352.11 631.786C352.11 631.809 352.155 631.832 352.201 631.832C352.427 631.832 352.72 631.901 353.014 631.993C353.828 632.247 354.212 632.707 354.212 633.443C354.212 634.134 353.783 634.686 353.218 634.686C353.082 634.686 352.946 634.617 352.743 634.479C352.517 634.295 352.336 634.226 352.201 634.226C351.997 634.226 351.884 634.318 351.884 634.502C351.884 634.778 352.223 634.939 352.766 634.939C353.353 634.939 353.873 634.755 354.235 634.387C354.574 634.042 354.709 633.627 354.709 633.075C354.709 632.546 354.574 632.224 354.212 631.855C353.918 631.533 353.489 631.372 352.653 631.211L352.946 630.59Z" fill="white"/>
+</g>
+<mask id="mask533_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask533_13_16079)">
+<path d="M378.146 694.182C377.332 694.251 376.925 694.389 376.405 694.781C375.614 695.333 375.208 696.161 375.208 697.151C375.208 697.772 375.388 698.417 375.705 698.785C375.976 699.107 376.36 699.268 376.812 699.268C377.694 699.268 378.304 698.578 378.304 697.588C378.304 696.645 377.784 696.046 376.97 696.046C376.654 696.046 376.496 696.115 376.044 696.392C376.247 695.287 377.038 694.481 378.168 694.297L378.146 694.182ZM376.699 696.392C377.309 696.392 377.671 696.921 377.671 697.818C377.671 698.624 377.377 699.084 376.88 699.084C376.247 699.084 375.863 698.394 375.863 697.266C375.863 696.875 375.931 696.691 376.066 696.576C376.225 696.461 376.451 696.392 376.699 696.392Z" fill="white"/>
+</g>
+<mask id="mask534_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask534_13_16079)">
+<path d="M325.951 689.953H323.306L322.877 691.035L323.012 691.081C323.306 690.598 323.442 690.506 323.849 690.506H325.386L323.984 694.855H324.436L325.951 690.068V689.953Z" fill="white"/>
+</g>
+<mask id="mask535_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask535_13_16079)">
+<path d="M340.375 650.888C341.076 650.519 341.324 650.197 341.324 649.714C341.324 649.116 340.827 648.678 340.104 648.678C339.313 648.678 338.748 649.162 338.748 649.829C338.748 650.289 338.883 650.519 339.629 651.187C338.861 651.785 338.703 652.015 338.703 652.499C338.703 653.212 339.268 653.695 340.081 653.695C340.94 653.695 341.482 653.235 341.482 652.476C341.482 651.9 341.234 651.555 340.375 650.888ZM340.239 651.647C340.759 652.038 340.94 652.291 340.94 652.706C340.94 653.166 340.624 653.511 340.149 653.511C339.607 653.511 339.245 653.074 339.245 652.453C339.245 651.969 339.403 651.67 339.81 651.325L340.239 651.647ZM340.172 650.773C339.539 650.335 339.268 650.013 339.268 649.599C339.268 649.185 339.584 648.885 340.036 648.885C340.533 648.885 340.85 649.208 340.85 649.691C340.85 650.105 340.646 650.45 340.239 650.727C340.194 650.75 340.194 650.75 340.172 650.773Z" fill="white"/>
+</g>
+<mask id="mask536_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask536_13_16079)">
+<path d="M396.378 679.96C397.169 679.868 397.576 679.73 398.051 679.361C398.797 678.809 399.249 677.911 399.249 676.922C399.249 675.725 398.571 674.874 397.644 674.874C396.808 674.874 396.175 675.61 396.175 676.6C396.175 677.474 396.672 678.073 397.463 678.073C397.847 678.073 398.141 677.957 398.525 677.658C398.232 678.832 397.441 679.614 396.356 679.822L396.378 679.96ZM398.548 677.198C398.548 677.359 398.503 677.428 398.435 677.497C398.232 677.658 397.96 677.75 397.712 677.75C397.169 677.75 396.83 677.198 396.83 676.347C396.83 675.932 396.943 675.495 397.079 675.288C397.215 675.15 397.395 675.081 397.599 675.081C398.209 675.081 398.548 675.702 398.548 676.922V677.198Z" fill="white"/>
+</g>
+<mask id="mask537_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask537_13_16079)">
+<path d="M359.501 666.405L358.212 667.072V667.164C358.303 667.118 358.371 667.095 358.416 667.095C358.529 667.026 358.664 667.003 358.732 667.003C358.89 667.003 358.958 667.118 358.958 667.348V670.662C358.958 670.892 358.89 671.053 358.777 671.122C358.664 671.191 358.574 671.214 358.258 671.214V671.33H360.246V671.214C359.681 671.214 359.568 671.145 359.568 670.8V666.405H359.501ZM362.828 666.405C362.422 666.405 362.128 666.52 361.857 666.773C361.45 667.187 361.179 668.016 361.179 668.867C361.179 669.673 361.405 670.524 361.744 670.938C362.015 671.261 362.376 671.422 362.783 671.422C363.145 671.422 363.461 671.307 363.71 671.053C364.139 670.662 364.41 669.811 364.41 668.913C364.41 667.417 363.755 666.405 362.828 666.405ZM362.806 666.589C363.393 666.589 363.71 667.417 363.71 668.936C363.71 670.455 363.416 671.237 362.783 671.237C362.173 671.237 361.857 670.455 361.857 668.936C361.857 667.394 362.173 666.589 362.806 666.589Z" fill="white"/>
+</g>
+<mask id="mask538_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask538_13_16079)">
+<path d="M315.78 671.612L314.492 672.279V672.371C314.583 672.325 314.65 672.302 314.696 672.302C314.809 672.233 314.944 672.21 315.012 672.21C315.17 672.21 315.238 672.325 315.238 672.555V675.869C315.238 676.099 315.17 676.26 315.057 676.329C314.944 676.398 314.854 676.421 314.537 676.421V676.536H316.526V676.421C315.961 676.421 315.848 676.352 315.848 676.007V671.612H315.78ZM319.357 671.612L318.069 672.279V672.371C318.159 672.325 318.227 672.302 318.272 672.302C318.385 672.233 318.521 672.21 318.589 672.21C318.747 672.21 318.815 672.325 318.815 672.555V675.869C318.815 676.099 318.747 676.26 318.634 676.329C318.521 676.398 318.43 676.421 318.114 676.421V676.536H320.103V676.421C319.538 676.421 319.425 676.352 319.425 676.007V671.612H319.357Z" fill="white"/>
+</g>
+</g>
+<mask id="mask539_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="857" width="112" height="114">
+<path d="M320 970.037H431.004V857H320V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask539_13_16079)">
+<mask id="mask540_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask540_13_16079)">
+<path d="M390.994 905.467L416.723 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask541_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask541_13_16079)">
+<path d="M390.994 905.467L363.753 940.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask542_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask542_13_16079)">
+<path d="M390.994 905.467L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask543_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask543_13_16079)">
+<path d="M390.994 905.467L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask544_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask544_13_16079)">
+<path d="M390.994 905.467L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask545_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask545_13_16079)">
+<path d="M363.753 940.876L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask546_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask546_13_16079)">
+<path d="M363.753 940.876L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask547_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask547_13_16079)">
+<path d="M363.753 940.876L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask548_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask548_13_16079)">
+<path d="M360.325 924.493L351.824 873.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask549_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask549_13_16079)">
+<path d="M360.325 924.493L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask550_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask550_13_16079)">
+<path d="M360.325 924.493L393.747 955.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask551_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask551_13_16079)">
+<path d="M360.325 924.493L341.53 951.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask552_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask552_13_16079)">
+<path d="M360.325 924.493L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask553_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask553_13_16079)">
+<path d="M360.325 924.493L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask554_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask554_13_16079)">
+<path d="M351.824 873.141L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask555_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask555_13_16079)">
+<path d="M370.445 891.168L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask556_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask556_13_16079)">
+<path d="M370.445 891.168L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask557_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask557_13_16079)">
+<path d="M393.747 955.496L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask558_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask558_13_16079)">
+<path d="M341.53 951.105L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask559_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask559_13_16079)">
+<mask id="mask560_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="386" y="900" width="10" height="11">
+<path d="M386.037 910.515H395.951V900.419H386.037V910.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask560_13_16079)">
+<path d="M390.994 909.992C392.172 909.992 393.303 909.515 394.136 908.667C394.97 907.818 395.438 906.667 395.438 905.467C395.438 904.267 394.97 903.116 394.136 902.267C393.303 901.418 392.172 900.942 390.994 900.942C389.815 900.942 388.685 901.418 387.851 902.267C387.018 903.116 386.55 904.267 386.55 905.467C386.55 906.667 387.018 907.818 387.851 908.667C388.685 909.515 389.815 909.992 390.994 909.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask561_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask561_13_16079)">
+<mask id="mask562_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="411" y="866" width="11" height="11">
+<path d="M411.766 876.592H421.68V866.496H411.766V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask562_13_16079)">
+<path d="M416.723 876.069C417.901 876.069 419.032 875.593 419.865 874.744C420.699 873.895 421.167 872.744 421.167 871.544C421.167 870.344 420.699 869.193 419.865 868.344C419.032 867.496 417.901 867.019 416.723 867.019C415.544 867.019 414.414 867.496 413.58 868.344C412.747 869.193 412.279 870.344 412.279 871.544C412.279 872.744 412.747 873.895 413.58 874.744C414.414 875.593 415.544 876.069 416.723 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask563_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask563_13_16079)">
+<mask id="mask564_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="358" y="935" width="11" height="11">
+<path d="M358.796 945.924H368.71V935.829H358.796V945.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask564_13_16079)">
+<path d="M363.753 945.402C364.931 945.402 366.062 944.925 366.895 944.076C367.728 943.228 368.197 942.077 368.197 940.876C368.197 939.676 367.728 938.525 366.895 937.677C366.062 936.828 364.931 936.351 363.753 936.351C362.574 936.351 361.444 936.828 360.61 937.677C359.777 938.525 359.309 939.676 359.309 940.876C359.309 942.077 359.777 943.228 360.61 944.076C361.444 944.925 362.574 945.402 363.753 945.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask565_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask565_13_16079)">
+<mask id="mask566_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="355" y="919" width="11" height="11">
+<path d="M355.368 929.541H365.282V919.445H355.368V929.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask566_13_16079)">
+<path d="M360.325 929.018C361.503 929.018 362.634 928.541 363.467 927.693C364.3 926.844 364.769 925.693 364.769 924.493C364.769 923.293 364.3 922.142 363.467 921.293C362.634 920.444 361.503 919.968 360.325 919.968C359.146 919.968 358.016 920.444 357.182 921.293C356.349 922.142 355.881 923.293 355.881 924.493C355.881 925.693 356.349 926.844 357.182 927.693C358.016 928.541 359.146 929.018 360.325 929.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask567_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask567_13_16079)">
+<mask id="mask568_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="346" y="868" width="11" height="11">
+<path d="M346.867 878.189H356.781V868.094H346.867V878.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask568_13_16079)">
+<path d="M351.824 877.667C353.003 877.667 354.133 877.19 354.967 876.341C355.8 875.493 356.268 874.342 356.268 873.141C356.268 871.941 355.8 870.79 354.967 869.941C354.133 869.093 353.003 868.616 351.824 868.616C350.646 868.616 349.515 869.093 348.682 869.941C347.848 870.79 347.38 871.941 347.38 873.141C347.38 874.342 347.848 875.493 348.682 876.341C349.515 877.19 350.646 877.667 351.824 877.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask569_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask569_13_16079)">
+<mask id="mask570_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="365" y="886" width="11" height="11">
+<path d="M365.488 896.216H375.402V886.12H365.488V896.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask570_13_16079)">
+<path d="M370.445 895.693C371.623 895.693 372.754 895.216 373.587 894.368C374.421 893.519 374.889 892.368 374.889 891.168C374.889 889.968 374.421 888.817 373.587 887.968C372.754 887.119 371.623 886.643 370.445 886.643C369.266 886.643 368.136 887.119 367.303 887.968C366.469 888.817 366.001 889.968 366.001 891.168C366.001 892.368 366.469 893.519 367.303 894.368C368.136 895.216 369.266 895.693 370.445 895.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask571_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask571_13_16079)">
+<mask id="mask572_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="388" y="950" width="11" height="11">
+<path d="M388.79 960.543H398.704V950.448H388.79V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask572_13_16079)">
+<path d="M393.747 960.021C394.925 960.021 396.056 959.544 396.889 958.696C397.723 957.847 398.191 956.696 398.191 955.496C398.191 954.295 397.723 953.144 396.889 952.296C396.056 951.447 394.925 950.97 393.747 950.97C392.568 950.97 391.438 951.447 390.604 952.296C389.771 953.144 389.303 954.295 389.303 955.496C389.303 956.696 389.771 957.847 390.604 958.696C391.438 959.544 392.568 960.021 393.747 960.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask573_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask573_13_16079)">
+<mask id="mask574_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="336" y="946" width="11" height="11">
+<path d="M336.573 956.153H346.487V946.057H336.573V956.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask574_13_16079)">
+<path d="M341.53 955.63C342.708 955.63 343.839 955.153 344.672 954.305C345.506 953.456 345.974 952.305 345.974 951.105C345.974 949.905 345.506 948.754 344.672 947.905C343.839 947.056 342.708 946.58 341.53 946.58C340.351 946.58 339.221 947.056 338.388 947.905C337.554 948.754 337.086 949.905 337.086 951.105C337.086 952.305 337.554 953.456 338.388 954.305C339.221 955.153 340.351 955.63 341.53 955.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask575_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask575_13_16079)">
+<mask id="mask576_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="352" y="904" width="11" height="11">
+<path d="M352.127 914.971H362.041V904.876H352.127V914.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask576_13_16079)">
+<path d="M357.084 914.449C358.263 914.449 359.393 913.972 360.226 913.123C361.06 912.275 361.528 911.124 361.528 909.924C361.528 908.723 361.06 907.572 360.226 906.724C359.393 905.875 358.263 905.398 357.084 905.398C355.905 905.398 354.775 905.875 353.942 906.724C353.108 907.572 352.64 908.723 352.64 909.924C352.64 911.124 353.108 912.275 353.942 913.123C354.775 913.972 355.905 914.449 357.084 914.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask577_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask577_13_16079)">
+<mask id="mask578_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="409" y="931" width="11" height="11">
+<path d="M409.783 941.164H419.697V931.068H409.783V941.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask578_13_16079)">
+<path d="M414.74 940.641C415.918 940.641 417.049 940.164 417.882 939.316C418.715 938.467 419.184 937.316 419.184 936.116C419.184 934.916 418.715 933.765 417.882 932.916C417.049 932.067 415.918 931.591 414.74 931.591C413.561 931.591 412.431 932.067 411.597 932.916C410.764 933.765 410.296 934.916 410.296 936.116C410.296 937.316 410.764 938.467 411.597 939.316C412.431 940.164 413.561 940.641 414.74 940.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask579_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask579_13_16079)">
+<mask id="mask580_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="373" y="922" width="10" height="11">
+<path d="M373.043 932.696H382.958V922.601H373.043V932.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask580_13_16079)">
+<path d="M378.001 932.174C379.179 932.174 380.31 931.697 381.143 930.848C381.976 930 382.445 928.849 382.445 927.649C382.445 926.448 381.976 925.297 381.143 924.449C380.31 923.6 379.179 923.123 378.001 923.123C376.822 923.123 375.692 923.6 374.858 924.449C374.025 925.297 373.557 926.448 373.557 927.649C373.557 928.849 374.025 930 374.858 930.848C375.692 931.697 376.822 932.174 378.001 932.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask581_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask581_13_16079)">
+<mask id="mask582_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="927" width="11" height="11">
+<path d="M329.323 937.902H339.237V927.806H329.323V937.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask582_13_16079)">
+<path d="M334.28 937.38C335.458 937.38 336.589 936.903 337.422 936.054C338.256 935.206 338.724 934.054 338.724 932.854C338.724 931.654 338.256 930.503 337.422 929.654C336.589 928.806 335.458 928.329 334.28 928.329C333.101 928.329 331.971 928.806 331.137 929.654C330.304 930.503 329.836 931.654 329.836 932.854C329.836 934.054 330.304 935.206 331.137 936.054C331.971 936.903 333.101 937.38 334.28 937.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask583_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask583_13_16079)">
+<path d="M391.032 902.225C390.626 902.225 390.332 902.34 390.061 902.593C389.654 903.008 389.383 903.836 389.383 904.688C389.383 905.493 389.609 906.345 389.948 906.759C390.219 907.081 390.58 907.242 390.987 907.242C391.349 907.242 391.665 907.127 391.914 906.874C392.343 906.483 392.614 905.631 392.614 904.734C392.614 903.238 391.959 902.225 391.032 902.225ZM391.01 902.409C391.597 902.409 391.914 903.238 391.914 904.757C391.914 906.276 391.62 907.058 390.987 907.058C390.377 907.058 390.061 906.276 390.061 904.757C390.061 903.215 390.377 902.409 391.01 902.409Z" fill="white"/>
+</g>
+<mask id="mask584_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask584_13_16079)">
+<path d="M417.011 868.303L415.723 868.97V869.062C415.814 869.016 415.881 868.993 415.927 868.993C416.04 868.924 416.175 868.901 416.243 868.901C416.401 868.901 416.469 869.016 416.469 869.246V872.56C416.469 872.791 416.401 872.952 416.288 873.021C416.175 873.09 416.085 873.113 415.768 873.113V873.228H417.757V873.113C417.192 873.113 417.079 873.044 417.079 872.698V868.303H417.011Z" fill="white"/>
+</g>
+<mask id="mask585_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask585_13_16079)">
+<path d="M365.376 941.567L365.263 941.521C365.014 941.935 364.924 942.004 364.585 942.004H362.89L364.087 940.716C364.72 940.048 364.991 939.496 364.991 938.921C364.991 938.184 364.426 937.632 363.681 937.632C363.274 937.632 362.912 937.793 362.641 938.069C362.415 938.322 362.302 938.552 362.189 939.082L362.325 939.105C362.618 938.391 362.89 938.161 363.364 938.161C363.974 938.161 364.381 938.575 364.381 939.197C364.381 939.772 364.065 940.439 363.455 941.084L362.189 942.465V942.557H364.969L365.376 941.567Z" fill="white"/>
+</g>
+<mask id="mask586_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask586_13_16079)">
+<path d="M359.641 923.76C360.048 923.76 360.206 923.783 360.387 923.852C360.839 924.013 361.11 924.428 361.11 924.934C361.11 925.532 360.703 926.016 360.183 926.016C359.98 926.016 359.844 925.97 359.573 925.785C359.347 925.647 359.234 925.601 359.121 925.601C358.94 925.601 358.85 925.716 358.85 925.855C358.85 926.108 359.144 926.269 359.641 926.269C360.206 926.269 360.771 926.085 361.11 925.785C361.449 925.486 361.63 925.072 361.63 924.589C361.63 924.198 361.517 923.875 361.313 923.645C361.155 923.484 361.019 923.392 360.703 923.254C361.2 922.909 361.381 922.633 361.381 922.241C361.381 921.643 360.929 921.252 360.274 921.252C359.912 921.252 359.596 921.367 359.347 921.597C359.121 921.804 359.008 921.988 358.85 922.425L358.963 922.448C359.257 921.919 359.573 921.689 360.025 921.689C360.5 921.689 360.816 922.011 360.816 922.471C360.816 922.725 360.703 922.978 360.522 923.162C360.319 923.392 360.115 923.507 359.641 923.668V923.76Z" fill="white"/>
+</g>
+<mask id="mask587_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask587_13_16079)">
+<path d="M353.426 873.142H352.68V869.897H352.364L350.126 873.142V873.602H352.138V874.822H352.68V873.602H353.426V873.142ZM352.138 873.142H350.397L352.138 870.633V873.142Z" fill="white"/>
+</g>
+<mask id="mask588_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask588_13_16079)">
+<path d="M369.946 888.59H371.37C371.483 888.59 371.506 888.59 371.528 888.52L371.8 887.876L371.732 887.83C371.619 887.991 371.551 888.014 371.393 888.014H369.901L369.133 889.74C369.11 889.763 369.11 889.763 369.11 889.786C369.11 889.809 369.155 889.832 369.201 889.832C369.427 889.832 369.72 889.901 370.014 889.993C370.828 890.247 371.212 890.707 371.212 891.443C371.212 892.134 370.783 892.686 370.218 892.686C370.082 892.686 369.946 892.617 369.743 892.479C369.517 892.295 369.336 892.226 369.201 892.226C368.997 892.226 368.884 892.318 368.884 892.502C368.884 892.778 369.223 892.939 369.766 892.939C370.353 892.939 370.873 892.755 371.235 892.387C371.574 892.042 371.709 891.627 371.709 891.075C371.709 890.546 371.574 890.224 371.212 889.855C370.918 889.533 370.489 889.372 369.653 889.211L369.946 888.59Z" fill="white"/>
+</g>
+<mask id="mask589_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask589_13_16079)">
+<path d="M395.146 952.182C394.332 952.251 393.925 952.389 393.405 952.781C392.614 953.333 392.208 954.161 392.208 955.151C392.208 955.772 392.388 956.417 392.705 956.785C392.976 957.107 393.36 957.268 393.812 957.268C394.694 957.268 395.304 956.578 395.304 955.588C395.304 954.645 394.784 954.046 393.97 954.046C393.654 954.046 393.496 954.115 393.044 954.392C393.247 953.287 394.038 952.481 395.168 952.297L395.146 952.182ZM393.699 954.392C394.309 954.392 394.671 954.921 394.671 955.818C394.671 956.624 394.377 957.084 393.88 957.084C393.247 957.084 392.863 956.394 392.863 955.266C392.863 954.875 392.931 954.691 393.066 954.576C393.225 954.461 393.451 954.392 393.699 954.392Z" fill="white"/>
+</g>
+<mask id="mask590_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask590_13_16079)">
+<path d="M342.951 947.953H340.306L339.877 949.035L340.012 949.081C340.306 948.598 340.442 948.506 340.849 948.506H342.386L340.984 952.855H341.436L342.951 948.068V947.953Z" fill="white"/>
+</g>
+<mask id="mask591_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask591_13_16079)">
+<path d="M357.375 908.888C358.076 908.519 358.324 908.197 358.324 907.714C358.324 907.116 357.827 906.678 357.104 906.678C356.313 906.678 355.748 907.162 355.748 907.829C355.748 908.289 355.883 908.519 356.629 909.187C355.861 909.785 355.703 910.015 355.703 910.499C355.703 911.212 356.268 911.695 357.081 911.695C357.94 911.695 358.482 911.235 358.482 910.476C358.482 909.9 358.234 909.555 357.375 908.888ZM357.239 909.647C357.759 910.038 357.94 910.291 357.94 910.706C357.94 911.166 357.624 911.511 357.149 911.511C356.607 911.511 356.245 911.074 356.245 910.453C356.245 909.969 356.403 909.67 356.81 909.325L357.239 909.647ZM357.172 908.773C356.539 908.335 356.268 908.013 356.268 907.599C356.268 907.185 356.584 906.885 357.036 906.885C357.533 906.885 357.85 907.208 357.85 907.691C357.85 908.105 357.646 908.45 357.239 908.727C357.194 908.75 357.194 908.75 357.172 908.773Z" fill="white"/>
+</g>
+<mask id="mask592_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask592_13_16079)">
+<path d="M413.378 937.96C414.169 937.868 414.576 937.73 415.051 937.361C415.797 936.809 416.249 935.911 416.249 934.922C416.249 933.725 415.571 932.874 414.644 932.874C413.808 932.874 413.175 933.61 413.175 934.6C413.175 935.474 413.672 936.073 414.463 936.073C414.847 936.073 415.141 935.957 415.525 935.658C415.232 936.832 414.441 937.614 413.356 937.822L413.378 937.96ZM415.548 935.198C415.548 935.359 415.503 935.428 415.435 935.497C415.232 935.658 414.96 935.75 414.712 935.75C414.169 935.75 413.83 935.198 413.83 934.347C413.83 933.932 413.943 933.495 414.079 933.288C414.215 933.15 414.395 933.081 414.599 933.081C415.209 933.081 415.548 933.702 415.548 934.922V935.198Z" fill="white"/>
+</g>
+<mask id="mask593_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask593_13_16079)">
+<path d="M376.501 924.405L375.212 925.072V925.164C375.303 925.118 375.371 925.095 375.416 925.095C375.529 925.026 375.664 925.003 375.732 925.003C375.89 925.003 375.958 925.118 375.958 925.348V928.662C375.958 928.892 375.89 929.053 375.777 929.122C375.664 929.191 375.574 929.214 375.258 929.214V929.33H377.246V929.214C376.681 929.214 376.568 929.145 376.568 928.8V924.405H376.501ZM379.828 924.405C379.422 924.405 379.128 924.52 378.857 924.773C378.45 925.187 378.179 926.016 378.179 926.867C378.179 927.673 378.405 928.524 378.744 928.938C379.015 929.261 379.376 929.422 379.783 929.422C380.145 929.422 380.461 929.307 380.71 929.053C381.139 928.662 381.41 927.811 381.41 926.913C381.41 925.417 380.755 924.405 379.828 924.405ZM379.806 924.589C380.393 924.589 380.71 925.417 380.71 926.936C380.71 928.455 380.416 929.237 379.783 929.237C379.173 929.237 378.857 928.455 378.857 926.936C378.857 925.394 379.173 924.589 379.806 924.589Z" fill="white"/>
+</g>
+<mask id="mask594_13_16079" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask594_13_16079)">
+<path d="M332.78 929.612L331.492 930.279V930.371C331.583 930.325 331.65 930.302 331.696 930.302C331.809 930.233 331.944 930.21 332.012 930.21C332.17 930.21 332.238 930.325 332.238 930.555V933.869C332.238 934.099 332.17 934.26 332.057 934.329C331.944 934.398 331.854 934.421 331.537 934.421V934.536H333.526V934.421C332.961 934.421 332.848 934.352 332.848 934.007V929.612H332.78ZM336.357 929.612L335.069 930.279V930.371C335.159 930.325 335.227 930.302 335.272 930.302C335.385 930.233 335.521 930.21 335.589 930.21C335.747 930.21 335.815 930.325 335.815 930.555V933.869C335.815 934.099 335.747 934.26 335.634 934.329C335.521 934.398 335.43 934.421 335.114 934.421V934.536H337.103V934.421C336.538 934.421 336.425 934.352 336.425 934.007V929.612H336.357Z" fill="white"/>
+</g>
+</g>
+<path d="M216.565 235H207.284V208.818H216.642C219.275 208.818 221.542 209.342 223.443 210.391C225.343 211.43 226.805 212.926 227.828 214.878C228.859 216.83 229.375 219.165 229.375 221.884C229.375 224.611 228.859 226.955 227.828 228.915C226.805 230.875 225.335 232.379 223.417 233.428C221.508 234.476 219.224 235 216.565 235ZM212.819 230.257H216.335C217.971 230.257 219.348 229.967 220.464 229.388C221.589 228.8 222.433 227.892 222.995 226.665C223.567 225.429 223.852 223.835 223.852 221.884C223.852 219.949 223.567 218.368 222.995 217.141C222.433 215.913 221.593 215.01 220.477 214.43C219.361 213.851 217.984 213.561 216.348 213.561H212.819V230.257ZM232.653 235V215.364H238.099V235H232.653ZM235.389 212.832C234.579 212.832 233.885 212.564 233.305 212.027C232.734 211.482 232.448 210.83 232.448 210.071C232.448 209.321 232.734 208.678 233.305 208.141C233.885 207.595 234.579 207.322 235.389 207.322C236.198 207.322 236.889 207.595 237.46 208.141C238.039 208.678 238.329 209.321 238.329 210.071C238.329 210.83 238.039 211.482 237.46 212.027C236.889 212.564 236.198 212.832 235.389 212.832ZM250.614 235.384C248.602 235.384 246.872 234.957 245.423 234.105C243.983 233.244 242.875 232.051 242.1 230.526C241.332 229 240.949 227.244 240.949 225.259C240.949 223.247 241.337 221.483 242.112 219.966C242.896 218.44 244.009 217.251 245.449 216.399C246.889 215.538 248.602 215.108 250.588 215.108C252.301 215.108 253.801 215.419 255.088 216.041C256.375 216.663 257.394 217.537 258.144 218.662C258.894 219.787 259.307 221.108 259.384 222.625H254.244C254.1 221.645 253.716 220.857 253.094 220.26C252.48 219.655 251.675 219.352 250.678 219.352C249.834 219.352 249.097 219.582 248.466 220.043C247.844 220.494 247.358 221.155 247.009 222.024C246.659 222.893 246.484 223.946 246.484 225.182C246.484 226.435 246.655 227.5 246.996 228.378C247.345 229.256 247.835 229.925 248.466 230.385C249.097 230.845 249.834 231.075 250.678 231.075C251.3 231.075 251.858 230.947 252.352 230.692C252.855 230.436 253.269 230.065 253.592 229.58C253.925 229.085 254.142 228.493 254.244 227.803H259.384C259.298 229.303 258.889 230.624 258.156 231.766C257.432 232.899 256.43 233.786 255.152 234.425C253.874 235.064 252.361 235.384 250.614 235.384ZM272.595 215.364V219.455H260.77V215.364H272.595ZM263.454 210.659H268.9V228.966C268.9 229.469 268.977 229.861 269.131 230.142C269.284 230.415 269.497 230.607 269.77 230.717C270.051 230.828 270.375 230.884 270.741 230.884C270.997 230.884 271.253 230.862 271.508 230.82C271.764 230.768 271.96 230.73 272.096 230.705L272.953 234.757C272.68 234.842 272.297 234.94 271.802 235.051C271.308 235.17 270.707 235.243 270 235.268C268.687 235.32 267.537 235.145 266.548 234.744C265.568 234.344 264.805 233.722 264.26 232.878C263.714 232.034 263.446 230.969 263.454 229.682V210.659ZM275.423 235V215.364H280.869V235H275.423ZM278.158 212.832C277.349 212.832 276.654 212.564 276.075 212.027C275.504 211.482 275.218 210.83 275.218 210.071C275.218 209.321 275.504 208.678 276.075 208.141C276.654 207.595 277.349 207.322 278.158 207.322C278.968 207.322 279.658 207.595 280.229 208.141C280.809 208.678 281.099 209.321 281.099 210.071C281.099 210.83 280.809 211.482 280.229 212.027C279.658 212.564 278.968 212.832 278.158 212.832ZM293.383 235.384C291.398 235.384 289.68 234.962 288.231 234.118C286.791 233.266 285.679 232.081 284.895 230.564C284.111 229.038 283.719 227.27 283.719 225.259C283.719 223.23 284.111 221.457 284.895 219.94C285.679 218.415 286.791 217.23 288.231 216.386C289.68 215.534 291.398 215.108 293.383 215.108C295.369 215.108 297.082 215.534 298.523 216.386C299.971 217.23 301.088 218.415 301.872 219.94C302.656 221.457 303.048 223.23 303.048 225.259C303.048 227.27 302.656 229.038 301.872 230.564C301.088 232.081 299.971 233.266 298.523 234.118C297.082 234.962 295.369 235.384 293.383 235.384ZM293.409 231.165C294.312 231.165 295.067 230.909 295.672 230.398C296.277 229.878 296.733 229.17 297.04 228.276C297.355 227.381 297.513 226.362 297.513 225.22C297.513 224.078 297.355 223.06 297.04 222.165C296.733 221.27 296.277 220.562 295.672 220.043C295.067 219.523 294.312 219.263 293.409 219.263C292.497 219.263 291.73 219.523 291.108 220.043C290.494 220.562 290.03 221.27 289.714 222.165C289.408 223.06 289.254 224.078 289.254 225.22C289.254 226.362 289.408 227.381 289.714 228.276C290.03 229.17 290.494 229.878 291.108 230.398C291.73 230.909 292.497 231.165 293.409 231.165ZM311.315 223.648V235H305.869V215.364H311.06V218.828H311.29C311.724 217.686 312.453 216.783 313.476 216.118C314.499 215.445 315.739 215.108 317.196 215.108C318.56 215.108 319.749 215.406 320.763 216.003C321.777 216.599 322.565 217.452 323.128 218.56C323.69 219.659 323.972 220.972 323.972 222.497V235H318.526V223.469C318.534 222.267 318.227 221.33 317.605 220.656C316.983 219.974 316.126 219.634 315.036 219.634C314.303 219.634 313.655 219.791 313.092 220.107C312.538 220.422 312.104 220.882 311.788 221.487C311.482 222.084 311.324 222.804 311.315 223.648ZM333.143 235.371C331.89 235.371 330.774 235.153 329.794 234.719C328.814 234.276 328.038 233.624 327.467 232.763C326.905 231.893 326.623 230.811 326.623 229.516C326.623 228.425 326.824 227.509 327.224 226.767C327.625 226.026 328.17 225.429 328.861 224.977C329.551 224.526 330.335 224.185 331.213 223.955C332.099 223.724 333.028 223.562 334 223.469C335.142 223.349 336.062 223.239 336.761 223.136C337.46 223.026 337.967 222.864 338.283 222.651C338.598 222.437 338.756 222.122 338.756 221.705V221.628C338.756 220.818 338.5 220.192 337.989 219.749C337.486 219.305 336.77 219.084 335.841 219.084C334.861 219.084 334.081 219.301 333.501 219.736C332.922 220.162 332.538 220.699 332.351 221.347L327.314 220.938C327.569 219.744 328.072 218.713 328.822 217.844C329.572 216.966 330.54 216.293 331.724 215.824C332.917 215.347 334.298 215.108 335.866 215.108C336.957 215.108 338.001 215.236 338.998 215.491C340.004 215.747 340.895 216.143 341.67 216.68C342.454 217.217 343.072 217.908 343.524 218.751C343.976 219.587 344.202 220.588 344.202 221.756V235H339.037V232.277H338.883C338.568 232.891 338.146 233.432 337.618 233.901C337.089 234.361 336.454 234.723 335.713 234.987C334.971 235.243 334.115 235.371 333.143 235.371ZM334.703 231.612C335.504 231.612 336.212 231.455 336.825 231.139C337.439 230.815 337.92 230.381 338.27 229.835C338.619 229.29 338.794 228.672 338.794 227.982V225.898C338.623 226.009 338.389 226.111 338.091 226.205C337.801 226.29 337.473 226.371 337.106 226.447C336.74 226.516 336.373 226.58 336.007 226.639C335.64 226.69 335.308 226.737 335.01 226.78C334.371 226.874 333.812 227.023 333.335 227.227C332.858 227.432 332.487 227.709 332.223 228.058C331.959 228.399 331.827 228.825 331.827 229.337C331.827 230.078 332.095 230.645 332.632 231.037C333.177 231.42 333.868 231.612 334.703 231.612ZM347.707 235V215.364H352.987V218.79H353.191C353.549 217.571 354.15 216.651 354.994 216.028C355.837 215.398 356.809 215.082 357.908 215.082C358.181 215.082 358.475 215.099 358.791 215.134C359.106 215.168 359.383 215.214 359.622 215.274V220.107C359.366 220.03 359.012 219.962 358.56 219.902C358.109 219.842 357.695 219.812 357.32 219.812C356.519 219.812 355.803 219.987 355.173 220.337C354.55 220.678 354.056 221.155 353.69 221.768C353.332 222.382 353.153 223.089 353.153 223.891V235H347.707ZM365.677 242.364C364.987 242.364 364.339 242.308 363.734 242.197C363.137 242.095 362.643 241.963 362.251 241.801L363.478 237.736C364.117 237.932 364.693 238.038 365.204 238.055C365.724 238.072 366.171 237.953 366.546 237.697C366.93 237.442 367.241 237.007 367.48 236.393L367.799 235.562L360.755 215.364H366.482L370.548 229.784H370.752L374.856 215.364H380.622L372.99 237.122C372.623 238.179 372.125 239.099 371.494 239.884C370.872 240.676 370.083 241.286 369.129 241.712C368.174 242.146 367.024 242.364 365.677 242.364ZM390.301 235V215.364H395.491V218.828H395.721C396.13 217.678 396.812 216.77 397.767 216.105C398.721 215.44 399.863 215.108 401.193 215.108C402.539 215.108 403.686 215.445 404.632 216.118C405.578 216.783 406.208 217.686 406.524 218.828H406.728C407.129 217.703 407.853 216.804 408.901 216.131C409.958 215.449 411.207 215.108 412.647 215.108C414.48 215.108 415.967 215.692 417.109 216.859C418.259 218.018 418.835 219.663 418.835 221.794V235H413.401V222.868C413.401 221.777 413.112 220.959 412.532 220.413C411.953 219.868 411.228 219.595 410.359 219.595C409.37 219.595 408.599 219.911 408.045 220.541C407.491 221.163 407.214 221.986 407.214 223.009V235H401.934V222.753C401.934 221.79 401.657 221.023 401.103 220.452C400.558 219.881 399.838 219.595 398.943 219.595C398.338 219.595 397.792 219.749 397.306 220.055C396.829 220.354 396.45 220.776 396.169 221.321C395.887 221.858 395.747 222.489 395.747 223.213V235H390.301ZM428.016 235.371C426.763 235.371 425.647 235.153 424.667 234.719C423.686 234.276 422.911 233.624 422.34 232.763C421.777 231.893 421.496 230.811 421.496 229.516C421.496 228.425 421.696 227.509 422.097 226.767C422.498 226.026 423.043 225.429 423.733 224.977C424.424 224.526 425.208 224.185 426.086 223.955C426.972 223.724 427.901 223.562 428.873 223.469C430.015 223.349 430.935 223.239 431.634 223.136C432.333 223.026 432.84 222.864 433.155 222.651C433.471 222.437 433.628 222.122 433.628 221.705V221.628C433.628 220.818 433.373 220.192 432.861 219.749C432.358 219.305 431.642 219.084 430.713 219.084C429.733 219.084 428.953 219.301 428.374 219.736C427.794 220.162 427.411 220.699 427.223 221.347L422.186 220.938C422.442 219.744 422.945 218.713 423.695 217.844C424.445 216.966 425.412 216.293 426.597 215.824C427.79 215.347 429.171 215.108 430.739 215.108C431.83 215.108 432.874 215.236 433.871 215.491C434.877 215.747 435.767 216.143 436.543 216.68C437.327 217.217 437.945 217.908 438.397 218.751C438.848 219.587 439.074 220.588 439.074 221.756V235H433.909V232.277H433.756C433.441 232.891 433.019 233.432 432.49 233.901C431.962 234.361 431.327 234.723 430.586 234.987C429.844 235.243 428.988 235.371 428.016 235.371ZM429.576 231.612C430.377 231.612 431.084 231.455 431.698 231.139C432.311 230.815 432.793 230.381 433.142 229.835C433.492 229.29 433.667 228.672 433.667 227.982V225.898C433.496 226.009 433.262 226.111 432.963 226.205C432.674 226.29 432.346 226.371 431.979 226.447C431.613 226.516 431.246 226.58 430.88 226.639C430.513 226.69 430.181 226.737 429.882 226.78C429.243 226.874 428.685 227.023 428.208 227.227C427.73 227.432 427.36 227.709 427.096 228.058C426.831 228.399 426.699 228.825 426.699 229.337C426.699 230.078 426.968 230.645 427.505 231.037C428.05 231.42 428.74 231.612 429.576 231.612ZM442.579 242.364V215.364H447.949V218.662H448.192C448.43 218.134 448.775 217.597 449.227 217.051C449.687 216.497 450.284 216.037 451.017 215.67C451.758 215.295 452.679 215.108 453.778 215.108C455.21 215.108 456.531 215.483 457.741 216.233C458.952 216.974 459.919 218.095 460.643 219.595C461.368 221.087 461.73 222.957 461.73 225.207C461.73 227.398 461.376 229.247 460.669 230.756C459.97 232.256 459.015 233.393 457.805 234.169C456.604 234.936 455.257 235.32 453.765 235.32C452.709 235.32 451.809 235.145 451.068 234.795C450.335 234.446 449.734 234.007 449.265 233.479C448.797 232.942 448.439 232.401 448.192 231.855H448.025V242.364H442.579ZM447.91 225.182C447.91 226.349 448.072 227.368 448.396 228.237C448.72 229.107 449.189 229.784 449.802 230.27C450.416 230.747 451.162 230.986 452.04 230.986C452.926 230.986 453.676 230.743 454.29 230.257C454.903 229.763 455.368 229.081 455.683 228.212C456.007 227.334 456.169 226.324 456.169 225.182C456.169 224.048 456.011 223.051 455.696 222.19C455.381 221.33 454.916 220.656 454.302 220.17C453.689 219.685 452.934 219.442 452.04 219.442C451.153 219.442 450.403 219.676 449.79 220.145C449.184 220.614 448.72 221.278 448.396 222.139C448.072 223 447.91 224.014 447.91 225.182ZM464.641 242.364V215.364H470.01V218.662H470.253C470.491 218.134 470.837 217.597 471.288 217.051C471.749 216.497 472.345 216.037 473.078 215.67C473.82 215.295 474.74 215.108 475.84 215.108C477.271 215.108 478.592 215.483 479.803 216.233C481.013 216.974 481.98 218.095 482.705 219.595C483.429 221.087 483.791 222.957 483.791 225.207C483.791 227.398 483.438 229.247 482.73 230.756C482.031 232.256 481.077 233.393 479.866 234.169C478.665 234.936 477.318 235.32 475.827 235.32C474.77 235.32 473.871 235.145 473.129 234.795C472.396 234.446 471.795 234.007 471.327 233.479C470.858 232.942 470.5 232.401 470.253 231.855H470.087V242.364H464.641ZM469.972 225.182C469.972 226.349 470.134 227.368 470.457 228.237C470.781 229.107 471.25 229.784 471.864 230.27C472.477 230.747 473.223 230.986 474.101 230.986C474.987 230.986 475.737 230.743 476.351 230.257C476.965 229.763 477.429 229.081 477.744 228.212C478.068 227.334 478.23 226.324 478.23 225.182C478.23 224.048 478.072 223.051 477.757 222.19C477.442 221.33 476.977 220.656 476.364 220.17C475.75 219.685 474.996 219.442 474.101 219.442C473.215 219.442 472.465 219.676 471.851 220.145C471.246 220.614 470.781 221.278 470.457 222.139C470.134 223 469.972 224.014 469.972 225.182ZM486.702 235V215.364H492.148V235H486.702ZM489.438 212.832C488.628 212.832 487.933 212.564 487.354 212.027C486.783 211.482 486.497 210.83 486.497 210.071C486.497 209.321 486.783 208.678 487.354 208.141C487.933 207.595 488.628 207.322 489.438 207.322C490.247 207.322 490.938 207.595 491.509 208.141C492.088 208.678 492.378 209.321 492.378 210.071C492.378 210.83 492.088 211.482 491.509 212.027C490.938 212.564 490.247 212.832 489.438 212.832ZM501.237 223.648V235H495.79V215.364H500.981V218.828H501.211C501.646 217.686 502.374 216.783 503.397 216.118C504.42 215.445 505.66 215.108 507.117 215.108C508.481 215.108 509.67 215.406 510.684 216.003C511.698 216.599 512.487 217.452 513.049 218.56C513.612 219.659 513.893 220.972 513.893 222.497V235H508.447V223.469C508.455 222.267 508.148 221.33 507.526 220.656C506.904 219.974 506.048 219.634 504.957 219.634C504.224 219.634 503.576 219.791 503.013 220.107C502.46 220.422 502.025 220.882 501.71 221.487C501.403 222.084 501.245 222.804 501.237 223.648ZM526.312 242.773C524.547 242.773 523.035 242.53 521.773 242.044C520.52 241.567 519.523 240.915 518.782 240.088C518.04 239.261 517.559 238.332 517.337 237.301L522.374 236.624C522.528 237.016 522.77 237.382 523.103 237.723C523.435 238.064 523.874 238.337 524.42 238.541C524.974 238.754 525.647 238.861 526.439 238.861C527.624 238.861 528.6 238.571 529.367 237.991C530.143 237.42 530.53 236.462 530.53 235.115V231.523H530.3C530.062 232.068 529.704 232.584 529.226 233.07C528.749 233.555 528.135 233.952 527.385 234.259C526.635 234.565 525.741 234.719 524.701 234.719C523.226 234.719 521.884 234.378 520.674 233.696C519.472 233.006 518.513 231.953 517.797 230.538C517.09 229.115 516.736 227.317 516.736 225.143C516.736 222.919 517.099 221.061 517.823 219.57C518.547 218.078 519.51 216.962 520.712 216.22C521.922 215.479 523.248 215.108 524.688 215.108C525.787 215.108 526.708 215.295 527.449 215.67C528.191 216.037 528.787 216.497 529.239 217.051C529.699 217.597 530.053 218.134 530.3 218.662H530.505V215.364H535.912V235.192C535.912 236.862 535.503 238.26 534.685 239.385C533.867 240.51 532.733 241.354 531.285 241.916C529.844 242.487 528.187 242.773 526.312 242.773ZM526.427 230.628C527.305 230.628 528.046 230.411 528.651 229.976C529.265 229.533 529.733 228.902 530.057 228.084C530.39 227.257 530.556 226.268 530.556 225.118C530.556 223.967 530.394 222.97 530.07 222.126C529.746 221.274 529.278 220.614 528.664 220.145C528.05 219.676 527.305 219.442 526.427 219.442C525.532 219.442 524.778 219.685 524.164 220.17C523.55 220.648 523.086 221.312 522.77 222.165C522.455 223.017 522.297 224.001 522.297 225.118C522.297 226.251 522.455 227.232 522.77 228.058C523.094 228.876 523.559 229.511 524.164 229.963C524.778 230.406 525.532 230.628 526.427 230.628ZM547.138 242.364V215.364H552.508V218.662H552.751C552.989 218.134 553.334 217.597 553.786 217.051C554.246 216.497 554.843 216.037 555.576 215.67C556.317 215.295 557.238 215.108 558.337 215.108C559.769 215.108 561.09 215.483 562.3 216.233C563.51 216.974 564.478 218.095 565.202 219.595C565.927 221.087 566.289 222.957 566.289 225.207C566.289 227.398 565.935 229.247 565.228 230.756C564.529 232.256 563.574 233.393 562.364 234.169C561.162 234.936 559.816 235.32 558.324 235.32C557.268 235.32 556.368 235.145 555.627 234.795C554.894 234.446 554.293 234.007 553.824 233.479C553.356 232.942 552.998 232.401 552.751 231.855H552.584V242.364H547.138ZM552.469 225.182C552.469 226.349 552.631 227.368 552.955 228.237C553.279 229.107 553.748 229.784 554.361 230.27C554.975 230.747 555.721 230.986 556.599 230.986C557.485 230.986 558.235 230.743 558.849 230.257C559.462 229.763 559.927 229.081 560.242 228.212C560.566 227.334 560.728 226.324 560.728 225.182C560.728 224.048 560.57 223.051 560.255 222.19C559.939 221.33 559.475 220.656 558.861 220.17C558.248 219.685 557.493 219.442 556.599 219.442C555.712 219.442 554.962 219.676 554.349 220.145C553.743 220.614 553.279 221.278 552.955 222.139C552.631 223 552.469 224.014 552.469 225.182ZM578.148 235.384C576.129 235.384 574.39 234.974 572.932 234.156C571.484 233.33 570.367 232.162 569.583 230.653C568.799 229.136 568.407 227.342 568.407 225.271C568.407 223.251 568.799 221.479 569.583 219.953C570.367 218.428 571.471 217.239 572.894 216.386C574.326 215.534 576.005 215.108 577.931 215.108C579.227 215.108 580.432 215.317 581.549 215.734C582.674 216.143 583.654 216.761 584.489 217.588C585.333 218.415 585.989 219.455 586.458 220.707C586.927 221.952 587.161 223.409 587.161 225.08V226.575H570.58V223.2H582.035C582.035 222.416 581.864 221.722 581.523 221.116C581.182 220.511 580.709 220.038 580.104 219.697C579.508 219.348 578.813 219.173 578.021 219.173C577.194 219.173 576.461 219.365 575.822 219.749C575.191 220.124 574.697 220.631 574.339 221.27C573.981 221.901 573.798 222.604 573.789 223.379V226.588C573.789 227.56 573.968 228.399 574.326 229.107C574.692 229.814 575.208 230.359 575.873 230.743C576.538 231.126 577.326 231.318 578.238 231.318C578.843 231.318 579.397 231.233 579.9 231.062C580.403 230.892 580.833 230.636 581.191 230.295C581.549 229.955 581.822 229.537 582.009 229.043L587.046 229.375C586.79 230.585 586.266 231.642 585.474 232.545C584.69 233.44 583.675 234.139 582.431 234.642C581.195 235.136 579.768 235.384 578.148 235.384ZM589.995 235V215.364H595.275V218.79H595.48C595.837 217.571 596.438 216.651 597.282 216.028C598.126 215.398 599.097 215.082 600.197 215.082C600.47 215.082 600.764 215.099 601.079 215.134C601.394 215.168 601.671 215.214 601.91 215.274V220.107C601.654 220.03 601.301 219.962 600.849 219.902C600.397 219.842 599.984 219.812 599.609 219.812C598.808 219.812 598.092 219.987 597.461 220.337C596.839 220.678 596.345 221.155 595.978 221.768C595.62 222.382 595.441 223.089 595.441 223.891V235H589.995ZM615.435 215.364V219.455H603.609V215.364H615.435ZM606.294 210.659H611.74V228.966C611.74 229.469 611.817 229.861 611.97 230.142C612.124 230.415 612.337 230.607 612.609 230.717C612.891 230.828 613.214 230.884 613.581 230.884C613.837 230.884 614.092 230.862 614.348 230.82C614.604 230.768 614.8 230.73 614.936 230.705L615.793 234.757C615.52 234.842 615.136 234.94 614.642 235.051C614.148 235.17 613.547 235.243 612.839 235.268C611.527 235.32 610.376 235.145 609.388 234.744C608.408 234.344 607.645 233.722 607.099 232.878C606.554 232.034 606.285 230.969 606.294 229.682V210.659ZM630.855 226.639V215.364H636.301V235H631.072V231.433H630.867C630.424 232.584 629.687 233.509 628.656 234.207C627.633 234.906 626.384 235.256 624.91 235.256C623.597 235.256 622.443 234.957 621.445 234.361C620.448 233.764 619.668 232.916 619.106 231.817C618.552 230.717 618.271 229.401 618.262 227.866V215.364H623.708V226.895C623.717 228.054 624.028 228.97 624.641 229.643C625.255 230.317 626.078 230.653 627.109 230.653C627.765 230.653 628.379 230.504 628.95 230.206C629.521 229.899 629.981 229.447 630.33 228.851C630.688 228.254 630.863 227.517 630.855 226.639ZM639.937 235V215.364H645.217V218.79H645.421C645.779 217.571 646.38 216.651 647.224 216.028C648.067 215.398 649.039 215.082 650.138 215.082C650.411 215.082 650.705 215.099 651.021 215.134C651.336 215.168 651.613 215.214 651.851 215.274V220.107C651.596 220.03 651.242 219.962 650.79 219.902C650.339 219.842 649.925 219.812 649.55 219.812C648.749 219.812 648.033 219.987 647.403 220.337C646.78 220.678 646.286 221.155 645.92 221.768C645.562 222.382 645.383 223.089 645.383 223.891V235H639.937ZM654.049 235V208.818H659.495V218.662H659.662C659.9 218.134 660.245 217.597 660.697 217.051C661.157 216.497 661.754 216.037 662.487 215.67C663.228 215.295 664.149 215.108 665.248 215.108C666.68 215.108 668.001 215.483 669.211 216.233C670.422 216.974 671.389 218.095 672.113 219.595C672.838 221.087 673.2 222.957 673.2 225.207C673.2 227.398 672.846 229.247 672.139 230.756C671.44 232.256 670.486 233.393 669.275 234.169C668.074 234.936 666.727 235.32 665.236 235.32C664.179 235.32 663.28 235.145 662.538 234.795C661.805 234.446 661.204 234.007 660.736 233.479C660.267 232.942 659.909 232.401 659.662 231.855H659.419V235H654.049ZM659.38 225.182C659.38 226.349 659.542 227.368 659.866 228.237C660.19 229.107 660.659 229.784 661.272 230.27C661.886 230.747 662.632 230.986 663.51 230.986C664.396 230.986 665.146 230.743 665.76 230.257C666.373 229.763 666.838 229.081 667.153 228.212C667.477 227.334 667.639 226.324 667.639 225.182C667.639 224.048 667.481 223.051 667.166 222.19C666.851 221.33 666.386 220.656 665.772 220.17C665.159 219.685 664.405 219.442 663.51 219.442C662.623 219.442 661.873 219.676 661.26 220.145C660.655 220.614 660.19 221.278 659.866 222.139C659.542 223 659.38 224.014 659.38 225.182ZM681.713 235.371C680.46 235.371 679.344 235.153 678.364 234.719C677.384 234.276 676.608 233.624 676.037 232.763C675.475 231.893 675.193 230.811 675.193 229.516C675.193 228.425 675.394 227.509 675.794 226.767C676.195 226.026 676.74 225.429 677.431 224.977C678.121 224.526 678.905 224.185 679.783 223.955C680.669 223.724 681.598 223.562 682.57 223.469C683.712 223.349 684.632 223.239 685.331 223.136C686.03 223.026 686.537 222.864 686.853 222.651C687.168 222.437 687.326 222.122 687.326 221.705V221.628C687.326 220.818 687.07 220.192 686.559 219.749C686.056 219.305 685.34 219.084 684.411 219.084C683.431 219.084 682.651 219.301 682.071 219.736C681.492 220.162 681.108 220.699 680.921 221.347L675.884 220.938C676.139 219.744 676.642 218.713 677.392 217.844C678.142 216.966 679.11 216.293 680.294 215.824C681.487 215.347 682.868 215.108 684.436 215.108C685.527 215.108 686.571 215.236 687.568 215.491C688.574 215.747 689.465 216.143 690.24 216.68C691.024 217.217 691.642 217.908 692.094 218.751C692.546 219.587 692.772 220.588 692.772 221.756V235H687.607V232.277H687.453C687.138 232.891 686.716 233.432 686.188 233.901C685.659 234.361 685.024 234.723 684.283 234.987C683.541 235.243 682.685 235.371 681.713 235.371ZM683.273 231.612C684.074 231.612 684.782 231.455 685.395 231.139C686.009 230.815 686.49 230.381 686.84 229.835C687.189 229.29 687.364 228.672 687.364 227.982V225.898C687.193 226.009 686.959 226.111 686.661 226.205C686.371 226.29 686.043 226.371 685.676 226.447C685.31 226.516 684.943 226.58 684.577 226.639C684.21 226.69 683.878 226.737 683.58 226.78C682.941 226.874 682.382 227.023 681.905 227.227C681.428 227.432 681.057 227.709 680.793 228.058C680.529 228.399 680.397 228.825 680.397 229.337C680.397 230.078 680.665 230.645 681.202 231.037C681.747 231.42 682.438 231.612 683.273 231.612ZM706.721 215.364V219.455H694.896V215.364H706.721ZM697.581 210.659H703.027V228.966C703.027 229.469 703.103 229.861 703.257 230.142C703.41 230.415 703.623 230.607 703.896 230.717C704.177 230.828 704.501 230.884 704.868 230.884C705.123 230.884 705.379 230.862 705.635 230.82C705.89 230.768 706.086 230.73 706.223 230.705L707.079 234.757C706.807 234.842 706.423 234.94 705.929 235.051C705.434 235.17 704.834 235.243 704.126 235.268C702.814 235.32 701.663 235.145 700.674 234.744C699.694 234.344 698.932 233.722 698.386 232.878C697.841 232.034 697.572 230.969 697.581 229.682V210.659ZM709.549 235V215.364H714.995V235H709.549ZM712.285 212.832C711.475 212.832 710.78 212.564 710.201 212.027C709.63 211.482 709.344 210.83 709.344 210.071C709.344 209.321 709.63 208.678 710.201 208.141C710.78 207.595 711.475 207.322 712.285 207.322C713.094 207.322 713.785 207.595 714.356 208.141C714.935 208.678 715.225 209.321 715.225 210.071C715.225 210.83 714.935 211.482 714.356 212.027C713.785 212.564 713.094 212.832 712.285 212.832ZM727.51 235.384C725.524 235.384 723.807 234.962 722.358 234.118C720.917 233.266 719.805 232.081 719.021 230.564C718.237 229.038 717.845 227.27 717.845 225.259C717.845 223.23 718.237 221.457 719.021 219.94C719.805 218.415 720.917 217.23 722.358 216.386C723.807 215.534 725.524 215.108 727.51 215.108C729.495 215.108 731.209 215.534 732.649 216.386C734.098 217.23 735.214 218.415 735.998 219.94C736.782 221.457 737.174 223.23 737.174 225.259C737.174 227.27 736.782 229.038 735.998 230.564C735.214 232.081 734.098 233.266 732.649 234.118C731.209 234.962 729.495 235.384 727.51 235.384ZM727.535 231.165C728.439 231.165 729.193 230.909 729.798 230.398C730.403 229.878 730.859 229.17 731.166 228.276C731.481 227.381 731.639 226.362 731.639 225.22C731.639 224.078 731.481 223.06 731.166 222.165C730.859 221.27 730.403 220.562 729.798 220.043C729.193 219.523 728.439 219.263 727.535 219.263C726.623 219.263 725.856 219.523 725.234 220.043C724.62 220.562 724.156 221.27 723.841 222.165C723.534 223.06 723.38 224.078 723.38 225.22C723.38 226.362 723.534 227.381 723.841 228.276C724.156 229.17 724.62 229.878 725.234 230.398C725.856 230.909 726.623 231.165 727.535 231.165ZM745.442 223.648V235H739.996V215.364H745.186V218.828H745.416C745.851 217.686 746.579 216.783 747.602 216.118C748.625 215.445 749.865 215.108 751.322 215.108C752.686 215.108 753.875 215.406 754.889 216.003C755.903 216.599 756.692 217.452 757.254 218.56C757.817 219.659 758.098 220.972 758.098 222.497V235H752.652V223.469C752.66 222.267 752.354 221.33 751.731 220.656C751.109 219.974 750.253 219.634 749.162 219.634C748.429 219.634 747.781 219.791 747.219 220.107C746.665 220.422 746.23 220.882 745.915 221.487C745.608 222.084 745.45 222.804 745.442 223.648ZM778.008 220.963L773.022 221.27C772.937 220.844 772.754 220.46 772.473 220.119C772.191 219.77 771.821 219.493 771.36 219.288C770.909 219.075 770.368 218.969 769.737 218.969C768.893 218.969 768.181 219.148 767.602 219.506C767.022 219.855 766.733 220.324 766.733 220.912C766.733 221.381 766.92 221.777 767.295 222.101C767.67 222.425 768.314 222.685 769.226 222.881L772.779 223.597C774.689 223.989 776.112 224.619 777.049 225.489C777.987 226.358 778.456 227.5 778.456 228.915C778.456 230.202 778.076 231.331 777.318 232.303C776.568 233.274 775.537 234.033 774.224 234.578C772.92 235.115 771.416 235.384 769.711 235.384C767.112 235.384 765.041 234.842 763.498 233.76C761.964 232.669 761.065 231.186 760.801 229.311L766.157 229.03C766.319 229.822 766.711 230.428 767.333 230.845C767.956 231.254 768.753 231.459 769.724 231.459C770.679 231.459 771.446 231.276 772.025 230.909C772.613 230.534 772.912 230.053 772.92 229.464C772.912 228.97 772.703 228.565 772.294 228.25C771.885 227.926 771.254 227.679 770.402 227.509L767.001 226.831C765.083 226.447 763.656 225.783 762.718 224.837C761.789 223.891 761.325 222.685 761.325 221.219C761.325 219.957 761.666 218.871 762.348 217.959C763.038 217.047 764.005 216.344 765.25 215.849C766.503 215.355 767.968 215.108 769.647 215.108C772.128 215.108 774.079 215.632 775.503 216.68C776.934 217.729 777.77 219.156 778.008 220.963ZM261.09 263.364V267.455H249.265V263.364H261.09ZM251.949 258.659H257.395V276.966C257.395 277.469 257.472 277.861 257.625 278.142C257.779 278.415 257.992 278.607 258.265 278.717C258.546 278.828 258.87 278.884 259.236 278.884C259.492 278.884 259.748 278.862 260.003 278.82C260.259 278.768 260.455 278.73 260.591 278.705L261.448 282.757C261.175 282.842 260.792 282.94 260.297 283.051C259.803 283.17 259.202 283.243 258.495 283.268C257.182 283.32 256.032 283.145 255.043 282.744C254.063 282.344 253.3 281.722 252.755 280.878C252.209 280.034 251.941 278.969 251.949 277.682V258.659ZM272.579 283.384C270.593 283.384 268.876 282.962 267.427 282.118C265.986 281.266 264.874 280.081 264.09 278.564C263.306 277.038 262.914 275.27 262.914 273.259C262.914 271.23 263.306 269.457 264.09 267.94C264.874 266.415 265.986 265.23 267.427 264.386C268.876 263.534 270.593 263.108 272.579 263.108C274.564 263.108 276.278 263.534 277.718 264.386C279.167 265.23 280.283 266.415 281.067 267.94C281.851 269.457 282.243 271.23 282.243 273.259C282.243 275.27 281.851 277.038 281.067 278.564C280.283 280.081 279.167 281.266 277.718 282.118C276.278 282.962 274.564 283.384 272.579 283.384ZM272.604 279.165C273.508 279.165 274.262 278.909 274.867 278.398C275.472 277.878 275.928 277.17 276.235 276.276C276.55 275.381 276.708 274.362 276.708 273.22C276.708 272.078 276.55 271.06 276.235 270.165C275.928 269.27 275.472 268.562 274.867 268.043C274.262 267.523 273.508 267.263 272.604 267.263C271.692 267.263 270.925 267.523 270.303 268.043C269.689 268.562 269.225 269.27 268.91 270.165C268.603 271.06 268.449 272.078 268.449 273.22C268.449 274.362 268.603 275.381 268.91 276.276C269.225 277.17 269.689 277.878 270.303 278.398C270.925 278.909 271.692 279.165 272.604 279.165ZM292.677 290.364V263.364H298.046V266.662H298.289C298.528 266.134 298.873 265.597 299.324 265.051C299.785 264.497 300.381 264.037 301.114 263.67C301.856 263.295 302.776 263.108 303.876 263.108C305.307 263.108 306.628 263.483 307.839 264.233C309.049 264.974 310.016 266.095 310.741 267.595C311.465 269.087 311.827 270.957 311.827 273.207C311.827 275.398 311.474 277.247 310.766 278.756C310.067 280.256 309.113 281.393 307.903 282.169C306.701 282.936 305.354 283.32 303.863 283.32C302.806 283.32 301.907 283.145 301.165 282.795C300.432 282.446 299.831 282.007 299.363 281.479C298.894 280.942 298.536 280.401 298.289 279.855H298.123V290.364H292.677ZM298.008 273.182C298.008 274.349 298.17 275.368 298.493 276.237C298.817 277.107 299.286 277.784 299.9 278.27C300.513 278.747 301.259 278.986 302.137 278.986C303.023 278.986 303.773 278.743 304.387 278.257C305.001 277.763 305.465 277.081 305.78 276.212C306.104 275.334 306.266 274.324 306.266 273.182C306.266 272.048 306.108 271.051 305.793 270.19C305.478 269.33 305.013 268.656 304.4 268.17C303.786 267.685 303.032 267.442 302.137 267.442C301.251 267.442 300.501 267.676 299.887 268.145C299.282 268.614 298.817 269.278 298.493 270.139C298.17 271 298.008 272.014 298.008 273.182ZM323.687 283.384C321.667 283.384 319.928 282.974 318.471 282.156C317.022 281.33 315.906 280.162 315.121 278.653C314.337 277.136 313.945 275.342 313.945 273.271C313.945 271.251 314.337 269.479 315.121 267.953C315.906 266.428 317.009 265.239 318.433 264.386C319.864 263.534 321.543 263.108 323.469 263.108C324.765 263.108 325.971 263.317 327.087 263.734C328.212 264.143 329.192 264.761 330.028 265.588C330.871 266.415 331.528 267.455 331.996 268.707C332.465 269.952 332.7 271.409 332.7 273.08V274.575H316.119V271.2H327.573C327.573 270.416 327.403 269.722 327.062 269.116C326.721 268.511 326.248 268.038 325.643 267.697C325.046 267.348 324.352 267.173 323.559 267.173C322.732 267.173 321.999 267.365 321.36 267.749C320.729 268.124 320.235 268.631 319.877 269.27C319.519 269.901 319.336 270.604 319.327 271.379V274.588C319.327 275.56 319.506 276.399 319.864 277.107C320.231 277.814 320.746 278.359 321.411 278.743C322.076 279.126 322.864 279.318 323.776 279.318C324.381 279.318 324.935 279.233 325.438 279.062C325.941 278.892 326.371 278.636 326.729 278.295C327.087 277.955 327.36 277.537 327.548 277.043L332.585 277.375C332.329 278.585 331.805 279.642 331.012 280.545C330.228 281.44 329.214 282.139 327.969 282.642C326.734 283.136 325.306 283.384 323.687 283.384ZM335.534 283V263.364H340.813V266.79H341.018C341.376 265.571 341.977 264.651 342.82 264.028C343.664 263.398 344.636 263.082 345.735 263.082C346.008 263.082 346.302 263.099 346.617 263.134C346.933 263.168 347.21 263.214 347.448 263.274V268.107C347.193 268.03 346.839 267.962 346.387 267.902C345.936 267.842 345.522 267.812 345.147 267.812C344.346 267.812 343.63 267.987 342.999 268.337C342.377 268.678 341.883 269.155 341.516 269.768C341.159 270.382 340.98 271.089 340.98 271.891V283H335.534ZM361.088 263.364V267.455H348.969V263.364H361.088ZM351.743 283V261.945C351.743 260.521 352.02 259.341 352.574 258.403C353.136 257.466 353.903 256.763 354.875 256.294C355.847 255.825 356.95 255.591 358.186 255.591C359.021 255.591 359.784 255.655 360.474 255.783C361.173 255.911 361.693 256.026 362.034 256.128L361.062 260.219C360.849 260.151 360.585 260.087 360.27 260.027C359.963 259.967 359.648 259.938 359.324 259.938C358.523 259.938 357.964 260.125 357.649 260.5C357.334 260.866 357.176 261.382 357.176 262.047V283H351.743ZM371.864 283.384C369.878 283.384 368.161 282.962 366.712 282.118C365.272 281.266 364.16 280.081 363.375 278.564C362.591 277.038 362.199 275.27 362.199 273.259C362.199 271.23 362.591 269.457 363.375 267.94C364.16 266.415 365.272 265.23 366.712 264.386C368.161 263.534 369.878 263.108 371.864 263.108C373.85 263.108 375.563 263.534 377.003 264.386C378.452 265.23 379.569 266.415 380.353 267.94C381.137 269.457 381.529 271.23 381.529 273.259C381.529 275.27 381.137 277.038 380.353 278.564C379.569 280.081 378.452 281.266 377.003 282.118C375.563 282.962 373.85 283.384 371.864 283.384ZM371.89 279.165C372.793 279.165 373.547 278.909 374.152 278.398C374.758 277.878 375.214 277.17 375.52 276.276C375.836 275.381 375.993 274.362 375.993 273.22C375.993 272.078 375.836 271.06 375.52 270.165C375.214 269.27 374.758 268.562 374.152 268.043C373.547 267.523 372.793 267.263 371.89 267.263C370.978 267.263 370.211 267.523 369.589 268.043C368.975 268.562 368.51 269.27 368.195 270.165C367.888 271.06 367.735 272.078 367.735 273.22C367.735 274.362 367.888 275.381 368.195 276.276C368.51 277.17 368.975 277.878 369.589 278.398C370.211 278.909 370.978 279.165 371.89 279.165ZM384.35 283V263.364H389.63V266.79H389.834C390.192 265.571 390.793 264.651 391.637 264.028C392.481 263.398 393.452 263.082 394.552 263.082C394.825 263.082 395.119 263.099 395.434 263.134C395.749 263.168 396.026 263.214 396.265 263.274V268.107C396.009 268.03 395.655 267.962 395.204 267.902C394.752 267.842 394.339 267.812 393.964 267.812C393.163 267.812 392.447 267.987 391.816 268.337C391.194 268.678 390.7 269.155 390.333 269.768C389.975 270.382 389.796 271.089 389.796 271.891V283H384.35ZM398.361 283V263.364H403.551V266.828H403.781C404.19 265.678 404.872 264.77 405.826 264.105C406.781 263.44 407.923 263.108 409.253 263.108C410.599 263.108 411.746 263.445 412.692 264.118C413.638 264.783 414.268 265.686 414.584 266.828H414.788C415.189 265.703 415.913 264.804 416.961 264.131C418.018 263.449 419.267 263.108 420.707 263.108C422.54 263.108 424.027 263.692 425.169 264.859C426.319 266.018 426.895 267.663 426.895 269.794V283H421.461V270.868C421.461 269.777 421.172 268.959 420.592 268.413C420.013 267.868 419.288 267.595 418.419 267.595C417.43 267.595 416.659 267.911 416.105 268.541C415.551 269.163 415.274 269.986 415.274 271.009V283H409.994V270.753C409.994 269.79 409.717 269.023 409.163 268.452C408.618 267.881 407.897 267.595 407.003 267.595C406.397 267.595 405.852 267.749 405.366 268.055C404.889 268.354 404.51 268.776 404.228 269.321C403.947 269.858 403.807 270.489 403.807 271.213V283H398.361ZM436.076 283.371C434.823 283.371 433.707 283.153 432.727 282.719C431.746 282.276 430.971 281.624 430.4 280.763C429.837 279.893 429.556 278.811 429.556 277.516C429.556 276.425 429.756 275.509 430.157 274.767C430.557 274.026 431.103 273.429 431.793 272.977C432.484 272.526 433.268 272.185 434.146 271.955C435.032 271.724 435.961 271.562 436.932 271.469C438.075 271.349 438.995 271.239 439.694 271.136C440.393 271.026 440.9 270.864 441.215 270.651C441.53 270.437 441.688 270.122 441.688 269.705V269.628C441.688 268.818 441.432 268.192 440.921 267.749C440.418 267.305 439.702 267.084 438.773 267.084C437.793 267.084 437.013 267.301 436.434 267.736C435.854 268.162 435.471 268.699 435.283 269.347L430.246 268.938C430.502 267.744 431.005 266.713 431.755 265.844C432.505 264.966 433.472 264.293 434.657 263.824C435.85 263.347 437.231 263.108 438.799 263.108C439.89 263.108 440.934 263.236 441.931 263.491C442.937 263.747 443.827 264.143 444.603 264.68C445.387 265.217 446.005 265.908 446.457 266.751C446.908 267.587 447.134 268.588 447.134 269.756V283H441.969V280.277H441.816C441.501 280.891 441.079 281.432 440.55 281.901C440.022 282.361 439.387 282.723 438.646 282.987C437.904 283.243 437.048 283.371 436.076 283.371ZM437.636 279.612C438.437 279.612 439.144 279.455 439.758 279.139C440.371 278.815 440.853 278.381 441.202 277.835C441.552 277.29 441.727 276.672 441.727 275.982V273.898C441.556 274.009 441.322 274.111 441.023 274.205C440.734 274.29 440.405 274.371 440.039 274.447C439.673 274.516 439.306 274.58 438.94 274.639C438.573 274.69 438.241 274.737 437.942 274.78C437.303 274.874 436.745 275.023 436.268 275.227C435.79 275.432 435.42 275.709 435.155 276.058C434.891 276.399 434.759 276.825 434.759 277.337C434.759 278.078 435.028 278.645 435.565 279.037C436.11 279.42 436.8 279.612 437.636 279.612ZM456.085 271.648V283H450.639V263.364H455.83V266.828H456.06C456.494 265.686 457.223 264.783 458.246 264.118C459.269 263.445 460.509 263.108 461.966 263.108C463.33 263.108 464.519 263.406 465.533 264.003C466.547 264.599 467.335 265.452 467.898 266.56C468.46 267.659 468.742 268.972 468.742 270.497V283H463.296V271.469C463.304 270.267 462.997 269.33 462.375 268.656C461.753 267.974 460.896 267.634 459.806 267.634C459.073 267.634 458.425 267.791 457.862 268.107C457.308 268.422 456.874 268.882 456.558 269.487C456.252 270.084 456.094 270.804 456.085 271.648ZM481.186 283.384C479.175 283.384 477.445 282.957 475.996 282.105C474.555 281.244 473.447 280.051 472.672 278.526C471.905 277 471.521 275.244 471.521 273.259C471.521 271.247 471.909 269.483 472.685 267.966C473.469 266.44 474.581 265.251 476.021 264.399C477.462 263.538 479.175 263.108 481.16 263.108C482.874 263.108 484.374 263.419 485.66 264.041C486.947 264.663 487.966 265.537 488.716 266.662C489.466 267.787 489.879 269.108 489.956 270.625H484.817C484.672 269.645 484.288 268.857 483.666 268.26C483.052 267.655 482.247 267.352 481.25 267.352C480.406 267.352 479.669 267.582 479.038 268.043C478.416 268.494 477.93 269.155 477.581 270.024C477.231 270.893 477.057 271.946 477.057 273.182C477.057 274.435 477.227 275.5 477.568 276.378C477.918 277.256 478.408 277.925 479.038 278.385C479.669 278.845 480.406 279.075 481.25 279.075C481.872 279.075 482.43 278.947 482.925 278.692C483.427 278.436 483.841 278.065 484.165 277.58C484.497 277.085 484.714 276.493 484.817 275.803H489.956C489.871 277.303 489.462 278.624 488.729 279.766C488.004 280.899 487.003 281.786 485.724 282.425C484.446 283.064 482.933 283.384 481.186 283.384ZM501.672 283.384C499.652 283.384 497.913 282.974 496.456 282.156C495.007 281.33 493.89 280.162 493.106 278.653C492.322 277.136 491.93 275.342 491.93 273.271C491.93 271.251 492.322 269.479 493.106 267.953C493.89 266.428 494.994 265.239 496.417 264.386C497.849 263.534 499.528 263.108 501.454 263.108C502.75 263.108 503.956 263.317 505.072 263.734C506.197 264.143 507.177 264.761 508.013 265.588C508.856 266.415 509.513 267.455 509.981 268.707C510.45 269.952 510.684 271.409 510.684 273.08V274.575H494.103V271.2H505.558C505.558 270.416 505.388 269.722 505.047 269.116C504.706 268.511 504.233 268.038 503.628 267.697C503.031 267.348 502.336 267.173 501.544 267.173C500.717 267.173 499.984 267.365 499.345 267.749C498.714 268.124 498.22 268.631 497.862 269.27C497.504 269.901 497.321 270.604 497.312 271.379V274.588C497.312 275.56 497.491 276.399 497.849 277.107C498.216 277.814 498.731 278.359 499.396 278.743C500.061 279.126 500.849 279.318 501.761 279.318C502.366 279.318 502.92 279.233 503.423 279.062C503.926 278.892 504.356 278.636 504.714 278.295C505.072 277.955 505.345 277.537 505.532 277.043L510.569 277.375C510.314 278.585 509.789 279.642 508.997 280.545C508.213 281.44 507.199 282.139 505.954 282.642C504.718 283.136 503.291 283.384 501.672 283.384ZM528.366 283.32C526.875 283.32 525.524 282.936 524.314 282.169C523.112 281.393 522.157 280.256 521.45 278.756C520.751 277.247 520.402 275.398 520.402 273.207C520.402 270.957 520.764 269.087 521.488 267.595C522.213 266.095 523.176 264.974 524.378 264.233C525.588 263.483 526.913 263.108 528.353 263.108C529.453 263.108 530.369 263.295 531.102 263.67C531.843 264.037 532.44 264.497 532.892 265.051C533.352 265.597 533.701 266.134 533.94 266.662H534.106V256.818H539.54V283H534.17V279.855H533.94C533.684 280.401 533.322 280.942 532.853 281.479C532.393 282.007 531.792 282.446 531.051 282.795C530.318 283.145 529.423 283.32 528.366 283.32ZM530.092 278.986C530.97 278.986 531.711 278.747 532.316 278.27C532.93 277.784 533.399 277.107 533.723 276.237C534.055 275.368 534.221 274.349 534.221 273.182C534.221 272.014 534.059 271 533.736 270.139C533.412 269.278 532.943 268.614 532.329 268.145C531.716 267.676 530.97 267.442 530.092 267.442C529.197 267.442 528.443 267.685 527.829 268.17C527.216 268.656 526.751 269.33 526.436 270.19C526.12 271.051 525.963 272.048 525.963 273.182C525.963 274.324 526.12 275.334 526.436 276.212C526.76 277.081 527.224 277.763 527.829 278.257C528.443 278.743 529.197 278.986 530.092 278.986ZM543.297 283V263.364H548.743V283H543.297ZM546.033 260.832C545.223 260.832 544.529 260.564 543.949 260.027C543.378 259.482 543.093 258.83 543.093 258.071C543.093 257.321 543.378 256.678 543.949 256.141C544.529 255.595 545.223 255.322 546.033 255.322C546.843 255.322 547.533 255.595 548.104 256.141C548.683 256.678 548.973 257.321 548.973 258.071C548.973 258.83 548.683 259.482 548.104 260.027C547.533 260.564 546.843 260.832 546.033 260.832ZM568.724 268.963L563.738 269.27C563.653 268.844 563.47 268.46 563.188 268.119C562.907 267.77 562.536 267.493 562.076 267.288C561.624 267.075 561.083 266.969 560.452 266.969C559.609 266.969 558.897 267.148 558.318 267.506C557.738 267.855 557.448 268.324 557.448 268.912C557.448 269.381 557.636 269.777 558.011 270.101C558.386 270.425 559.029 270.685 559.941 270.881L563.495 271.597C565.404 271.989 566.827 272.619 567.765 273.489C568.702 274.358 569.171 275.5 569.171 276.915C569.171 278.202 568.792 279.331 568.033 280.303C567.283 281.274 566.252 282.033 564.94 282.578C563.636 283.115 562.131 283.384 560.427 283.384C557.827 283.384 555.756 282.842 554.214 281.76C552.68 280.669 551.781 279.186 551.516 277.311L556.873 277.03C557.035 277.822 557.427 278.428 558.049 278.845C558.671 279.254 559.468 279.459 560.44 279.459C561.394 279.459 562.161 279.276 562.741 278.909C563.329 278.534 563.627 278.053 563.636 277.464C563.627 276.97 563.418 276.565 563.009 276.25C562.6 275.926 561.97 275.679 561.117 275.509L557.717 274.831C555.799 274.447 554.372 273.783 553.434 272.837C552.505 271.891 552.041 270.685 552.041 269.219C552.041 267.957 552.381 266.871 553.063 265.959C553.754 265.047 554.721 264.344 555.965 263.849C557.218 263.355 558.684 263.108 560.363 263.108C562.843 263.108 564.795 263.632 566.218 264.68C567.65 265.729 568.485 267.156 568.724 268.963ZM582.325 263.364V267.455H570.5V263.364H582.325ZM573.185 258.659H578.631V276.966C578.631 277.469 578.707 277.861 578.861 278.142C579.014 278.415 579.227 278.607 579.5 278.717C579.781 278.828 580.105 278.884 580.471 278.884C580.727 278.884 580.983 278.862 581.239 278.82C581.494 278.768 581.69 278.73 581.827 278.705L582.683 282.757C582.41 282.842 582.027 282.94 581.533 283.051C581.038 283.17 580.437 283.243 579.73 283.268C578.418 283.32 577.267 283.145 576.278 282.744C575.298 282.344 574.535 281.722 573.99 280.878C573.444 280.034 573.176 278.969 573.185 277.682V258.659ZM585.153 283V263.364H590.433V266.79H590.637C590.995 265.571 591.596 264.651 592.44 264.028C593.283 263.398 594.255 263.082 595.354 263.082C595.627 263.082 595.921 263.099 596.237 263.134C596.552 263.168 596.829 263.214 597.068 263.274V268.107C596.812 268.03 596.458 267.962 596.006 267.902C595.555 267.842 595.141 267.812 594.766 267.812C593.965 267.812 593.249 267.987 592.619 268.337C591.997 268.678 591.502 269.155 591.136 269.768C590.778 270.382 590.599 271.089 590.599 271.891V283H585.153ZM599.163 283V263.364H604.609V283H599.163ZM601.899 260.832C601.089 260.832 600.395 260.564 599.815 260.027C599.244 259.482 598.959 258.83 598.959 258.071C598.959 257.321 599.244 256.678 599.815 256.141C600.395 255.595 601.089 255.322 601.899 255.322C602.709 255.322 603.399 255.595 603.97 256.141C604.55 256.678 604.839 257.321 604.839 258.071C604.839 258.83 604.55 259.482 603.97 260.027C603.399 260.564 602.709 260.832 601.899 260.832ZM608.354 283V256.818H613.8V266.662H613.966C614.205 266.134 614.55 265.597 615.002 265.051C615.462 264.497 616.059 264.037 616.792 263.67C617.533 263.295 618.454 263.108 619.553 263.108C620.985 263.108 622.306 263.483 623.516 264.233C624.726 264.974 625.694 266.095 626.418 267.595C627.142 269.087 627.505 270.957 627.505 273.207C627.505 275.398 627.151 277.247 626.444 278.756C625.745 280.256 624.79 281.393 623.58 282.169C622.378 282.936 621.032 283.32 619.54 283.32C618.483 283.32 617.584 283.145 616.843 282.795C616.11 282.446 615.509 282.007 615.04 281.479C614.571 280.942 614.213 280.401 613.966 279.855H613.723V283H608.354ZM613.685 273.182C613.685 274.349 613.847 275.368 614.171 276.237C614.495 277.107 614.963 277.784 615.577 278.27C616.191 278.747 616.936 278.986 617.814 278.986C618.701 278.986 619.451 278.743 620.064 278.257C620.678 277.763 621.142 277.081 621.458 276.212C621.782 275.334 621.944 274.324 621.944 273.182C621.944 272.048 621.786 271.051 621.471 270.19C621.155 269.33 620.691 268.656 620.077 268.17C619.463 267.685 618.709 267.442 617.814 267.442C616.928 267.442 616.178 267.676 615.564 268.145C614.959 268.614 614.495 269.278 614.171 270.139C613.847 271 613.685 272.014 613.685 273.182ZM643.011 274.639V263.364H648.457V283H643.228V279.433H643.024C642.58 280.584 641.843 281.509 640.812 282.207C639.789 282.906 638.541 283.256 637.066 283.256C635.754 283.256 634.599 282.957 633.602 282.361C632.605 281.764 631.825 280.916 631.262 279.817C630.708 278.717 630.427 277.401 630.419 275.866V263.364H635.865V274.895C635.873 276.054 636.184 276.97 636.798 277.643C637.411 278.317 638.234 278.653 639.265 278.653C639.921 278.653 640.535 278.504 641.106 278.206C641.677 277.899 642.137 277.447 642.487 276.851C642.845 276.254 643.019 275.517 643.011 274.639ZM662.538 263.364V267.455H650.712V263.364H662.538ZM653.397 258.659H658.843V276.966C658.843 277.469 658.92 277.861 659.073 278.142C659.227 278.415 659.44 278.607 659.712 278.717C659.994 278.828 660.317 278.884 660.684 278.884C660.94 278.884 661.195 278.862 661.451 278.82C661.707 278.768 661.903 278.73 662.039 278.705L662.896 282.757C662.623 282.842 662.239 282.94 661.745 283.051C661.251 283.17 660.65 283.243 659.942 283.268C658.63 283.32 657.479 283.145 656.491 282.744C655.511 282.344 654.748 281.722 654.202 280.878C653.657 280.034 653.389 278.969 653.397 277.682V258.659ZM665.365 283V263.364H670.811V283H665.365ZM668.101 260.832C667.291 260.832 666.597 260.564 666.017 260.027C665.446 259.482 665.161 258.83 665.161 258.071C665.161 257.321 665.446 256.678 666.017 256.141C666.597 255.595 667.291 255.322 668.101 255.322C668.911 255.322 669.601 255.595 670.172 256.141C670.752 256.678 671.041 257.321 671.041 258.071C671.041 258.83 670.752 259.482 670.172 260.027C669.601 260.564 668.911 260.832 668.101 260.832ZM683.326 283.384C681.34 283.384 679.623 282.962 678.174 282.118C676.734 281.266 675.621 280.081 674.837 278.564C674.053 277.038 673.661 275.27 673.661 273.259C673.661 271.23 674.053 269.457 674.837 267.94C675.621 266.415 676.734 265.23 678.174 264.386C679.623 263.534 681.34 263.108 683.326 263.108C685.312 263.108 687.025 263.534 688.465 264.386C689.914 265.23 691.031 266.415 691.815 267.94C692.599 269.457 692.991 271.23 692.991 273.259C692.991 275.27 692.599 277.038 691.815 278.564C691.031 280.081 689.914 281.266 688.465 282.118C687.025 282.962 685.312 283.384 683.326 283.384ZM683.352 279.165C684.255 279.165 685.009 278.909 685.614 278.398C686.219 277.878 686.675 277.17 686.982 276.276C687.298 275.381 687.455 274.362 687.455 273.22C687.455 272.078 687.298 271.06 686.982 270.165C686.675 269.27 686.219 268.562 685.614 268.043C685.009 267.523 684.255 267.263 683.352 267.263C682.44 267.263 681.673 267.523 681.05 268.043C680.437 268.562 679.972 269.27 679.657 270.165C679.35 271.06 679.197 272.078 679.197 273.22C679.197 274.362 679.35 275.381 679.657 276.276C679.972 277.17 680.437 277.878 681.05 278.398C681.673 278.909 682.44 279.165 683.352 279.165ZM701.258 271.648V283H695.812V263.364H701.002V266.828H701.232C701.667 265.686 702.396 264.783 703.419 264.118C704.441 263.445 705.681 263.108 707.139 263.108C708.502 263.108 709.691 263.406 710.705 264.003C711.72 264.599 712.508 265.452 713.07 266.56C713.633 267.659 713.914 268.972 713.914 270.497V283H708.468V271.469C708.477 270.267 708.17 269.33 707.548 268.656C706.926 267.974 706.069 267.634 704.978 267.634C704.245 267.634 703.597 267.791 703.035 268.107C702.481 268.422 702.046 268.882 701.731 269.487C701.424 270.084 701.267 270.804 701.258 271.648ZM733.825 268.963L728.839 269.27C728.754 268.844 728.57 268.46 728.289 268.119C728.008 267.77 727.637 267.493 727.177 267.288C726.725 267.075 726.184 266.969 725.553 266.969C724.71 266.969 723.998 267.148 723.418 267.506C722.839 267.855 722.549 268.324 722.549 268.912C722.549 269.381 722.737 269.777 723.112 270.101C723.487 270.425 724.13 270.685 725.042 270.881L728.596 271.597C730.505 271.989 731.928 272.619 732.866 273.489C733.803 274.358 734.272 275.5 734.272 276.915C734.272 278.202 733.893 279.331 733.134 280.303C732.384 281.274 731.353 282.033 730.041 282.578C728.737 283.115 727.232 283.384 725.528 283.384C722.928 283.384 720.857 282.842 719.315 281.76C717.781 280.669 716.881 279.186 716.617 277.311L721.974 277.03C722.136 277.822 722.528 278.428 723.15 278.845C723.772 279.254 724.569 279.459 725.541 279.459C726.495 279.459 727.262 279.276 727.842 278.909C728.43 278.534 728.728 278.053 728.737 277.464C728.728 276.97 728.519 276.565 728.11 276.25C727.701 275.926 727.07 275.679 726.218 275.509L722.817 274.831C720.9 274.447 719.472 273.783 718.535 272.837C717.606 271.891 717.141 270.685 717.141 269.219C717.141 267.957 717.482 266.871 718.164 265.959C718.854 265.047 719.822 264.344 721.066 263.849C722.319 263.355 723.785 263.108 725.464 263.108C727.944 263.108 729.896 263.632 731.319 264.68C732.751 265.729 733.586 267.156 733.825 268.963Z" fill="black"/>
+<path d="M282.981 821V794.818H293.311C295.297 794.818 296.988 795.197 298.386 795.956C299.784 796.706 300.849 797.75 301.582 799.088C302.324 800.418 302.694 801.952 302.694 803.69C302.694 805.429 302.319 806.963 301.569 808.293C300.819 809.622 299.733 810.658 298.309 811.399C296.895 812.141 295.182 812.511 293.17 812.511H286.586V808.075H292.275C293.341 808.075 294.219 807.892 294.909 807.526C295.608 807.151 296.128 806.635 296.469 805.979C296.818 805.314 296.993 804.551 296.993 803.69C296.993 802.821 296.818 802.062 296.469 801.415C296.128 800.759 295.608 800.251 294.909 799.893C294.21 799.527 293.324 799.344 292.25 799.344H288.517V821H282.981ZM314.1 821.384C312.08 821.384 310.342 820.974 308.884 820.156C307.435 819.33 306.319 818.162 305.535 816.653C304.751 815.136 304.359 813.342 304.359 811.271C304.359 809.251 304.751 807.479 305.535 805.953C306.319 804.428 307.423 803.239 308.846 802.386C310.278 801.534 311.957 801.108 313.883 801.108C315.178 801.108 316.384 801.317 317.501 801.734C318.626 802.143 319.606 802.761 320.441 803.588C321.285 804.415 321.941 805.455 322.41 806.707C322.879 807.952 323.113 809.409 323.113 811.08V812.575H306.532V809.2H317.986C317.986 808.416 317.816 807.722 317.475 807.116C317.134 806.511 316.661 806.038 316.056 805.697C315.46 805.348 314.765 805.173 313.972 805.173C313.146 805.173 312.413 805.365 311.773 805.749C311.143 806.124 310.648 806.631 310.29 807.27C309.933 807.901 309.749 808.604 309.741 809.379V812.588C309.741 813.56 309.92 814.399 310.278 815.107C310.644 815.814 311.16 816.359 311.825 816.743C312.489 817.126 313.278 817.318 314.19 817.318C314.795 817.318 315.349 817.233 315.852 817.062C316.354 816.892 316.785 816.636 317.143 816.295C317.501 815.955 317.773 815.537 317.961 815.043L322.998 815.375C322.742 816.585 322.218 817.642 321.425 818.545C320.641 819.44 319.627 820.139 318.383 820.642C317.147 821.136 315.719 821.384 314.1 821.384ZM325.947 821V801.364H331.227V804.79H331.431C331.789 803.571 332.39 802.651 333.234 802.028C334.078 801.398 335.049 801.082 336.149 801.082C336.421 801.082 336.715 801.099 337.031 801.134C337.346 801.168 337.623 801.214 337.862 801.274V806.107C337.606 806.03 337.252 805.962 336.801 805.902C336.349 805.842 335.936 805.812 335.561 805.812C334.759 805.812 334.043 805.987 333.413 806.337C332.791 806.678 332.296 807.155 331.93 807.768C331.572 808.382 331.393 809.089 331.393 809.891V821H325.947ZM351.501 801.364V805.455H339.382V801.364H351.501ZM342.156 821V799.945C342.156 798.521 342.433 797.341 342.987 796.403C343.55 795.466 344.317 794.763 345.288 794.294C346.26 793.825 347.364 793.591 348.599 793.591C349.435 793.591 350.197 793.655 350.888 793.783C351.587 793.911 352.107 794.026 352.447 794.128L351.476 798.219C351.263 798.151 350.999 798.087 350.683 798.027C350.376 797.967 350.061 797.938 349.737 797.938C348.936 797.938 348.378 798.125 348.062 798.5C347.747 798.866 347.589 799.382 347.589 800.047V821H342.156ZM362.277 821.384C360.292 821.384 358.574 820.962 357.125 820.118C355.685 819.266 354.573 818.081 353.789 816.564C353.005 815.038 352.613 813.27 352.613 811.259C352.613 809.23 353.005 807.457 353.789 805.94C354.573 804.415 355.685 803.23 357.125 802.386C358.574 801.534 360.292 801.108 362.277 801.108C364.263 801.108 365.976 801.534 367.417 802.386C368.866 803.23 369.982 804.415 370.766 805.94C371.55 807.457 371.942 809.23 371.942 811.259C371.942 813.27 371.55 815.038 370.766 816.564C369.982 818.081 368.866 819.266 367.417 820.118C365.976 820.962 364.263 821.384 362.277 821.384ZM362.303 817.165C363.206 817.165 363.961 816.909 364.566 816.398C365.171 815.878 365.627 815.17 365.934 814.276C366.249 813.381 366.407 812.362 366.407 811.22C366.407 810.078 366.249 809.06 365.934 808.165C365.627 807.27 365.171 806.562 364.566 806.043C363.961 805.523 363.206 805.263 362.303 805.263C361.391 805.263 360.624 805.523 360.002 806.043C359.388 806.562 358.924 807.27 358.608 808.165C358.302 809.06 358.148 810.078 358.148 811.22C358.148 812.362 358.302 813.381 358.608 814.276C358.924 815.17 359.388 815.878 360.002 816.398C360.624 816.909 361.391 817.165 362.303 817.165ZM374.763 821V801.364H380.043V804.79H380.248C380.606 803.571 381.207 802.651 382.05 802.028C382.894 801.398 383.866 801.082 384.965 801.082C385.238 801.082 385.532 801.099 385.847 801.134C386.163 801.168 386.44 801.214 386.678 801.274V806.107C386.423 806.03 386.069 805.962 385.617 805.902C385.165 805.842 384.752 805.812 384.377 805.812C383.576 805.812 382.86 805.987 382.229 806.337C381.607 806.678 381.113 807.155 380.746 807.768C380.388 808.382 380.209 809.089 380.209 809.891V821H374.763ZM388.774 821V801.364H393.964V804.828H394.194C394.603 803.678 395.285 802.77 396.24 802.105C397.194 801.44 398.336 801.108 399.666 801.108C401.013 801.108 402.159 801.445 403.105 802.118C404.051 802.783 404.682 803.686 404.997 804.828H405.201C405.602 803.703 406.326 802.804 407.375 802.131C408.432 801.449 409.68 801.108 411.121 801.108C412.953 801.108 414.44 801.692 415.582 802.859C416.733 804.018 417.308 805.663 417.308 807.794V821H411.875V808.868C411.875 807.777 411.585 806.959 411.005 806.413C410.426 805.868 409.701 805.595 408.832 805.595C407.844 805.595 407.072 805.911 406.518 806.541C405.964 807.163 405.687 807.986 405.687 809.009V821H400.407V808.753C400.407 807.79 400.13 807.023 399.576 806.452C399.031 805.881 398.311 805.595 397.416 805.595C396.811 805.595 396.265 805.749 395.78 806.055C395.302 806.354 394.923 806.776 394.642 807.321C394.361 807.858 394.22 808.489 394.22 809.213V821H388.774ZM426.489 821.371C425.236 821.371 424.12 821.153 423.14 820.719C422.16 820.276 421.384 819.624 420.813 818.763C420.251 817.893 419.969 816.811 419.969 815.516C419.969 814.425 420.17 813.509 420.57 812.767C420.971 812.026 421.516 811.429 422.207 810.977C422.897 810.526 423.681 810.185 424.559 809.955C425.445 809.724 426.374 809.562 427.346 809.469C428.488 809.349 429.408 809.239 430.107 809.136C430.806 809.026 431.313 808.864 431.629 808.651C431.944 808.437 432.102 808.122 432.102 807.705V807.628C432.102 806.818 431.846 806.192 431.334 805.749C430.832 805.305 430.116 805.084 429.187 805.084C428.207 805.084 427.427 805.301 426.847 805.736C426.268 806.162 425.884 806.699 425.697 807.347L420.66 806.938C420.915 805.744 421.418 804.713 422.168 803.844C422.918 802.966 423.886 802.293 425.07 801.824C426.263 801.347 427.644 801.108 429.212 801.108C430.303 801.108 431.347 801.236 432.344 801.491C433.35 801.747 434.241 802.143 435.016 802.68C435.8 803.217 436.418 803.908 436.87 804.751C437.322 805.587 437.548 806.588 437.548 807.756V821H432.383V818.277H432.229C431.914 818.891 431.492 819.432 430.964 819.901C430.435 820.361 429.8 820.723 429.059 820.987C428.317 821.243 427.461 821.371 426.489 821.371ZM428.049 817.612C428.85 817.612 429.557 817.455 430.171 817.139C430.785 816.815 431.266 816.381 431.616 815.835C431.965 815.29 432.14 814.672 432.14 813.982V811.898C431.969 812.009 431.735 812.111 431.437 812.205C431.147 812.29 430.819 812.371 430.452 812.447C430.086 812.516 429.719 812.58 429.353 812.639C428.986 812.69 428.654 812.737 428.356 812.78C427.717 812.874 427.158 813.023 426.681 813.227C426.204 813.432 425.833 813.709 425.569 814.058C425.305 814.399 425.173 814.825 425.173 815.337C425.173 816.078 425.441 816.645 425.978 817.037C426.523 817.42 427.214 817.612 428.049 817.612ZM446.499 809.648V821H441.053V801.364H446.243V804.828H446.473C446.908 803.686 447.636 802.783 448.659 802.118C449.682 801.445 450.922 801.108 452.379 801.108C453.743 801.108 454.932 801.406 455.946 802.003C456.96 802.599 457.749 803.452 458.311 804.56C458.874 805.659 459.155 806.972 459.155 808.497V821H453.709V809.469C453.717 808.267 453.411 807.33 452.788 806.656C452.166 805.974 451.31 805.634 450.219 805.634C449.486 805.634 448.838 805.791 448.276 806.107C447.722 806.422 447.287 806.882 446.972 807.487C446.665 808.084 446.507 808.804 446.499 809.648ZM471.599 821.384C469.588 821.384 467.858 820.957 466.409 820.105C464.969 819.244 463.861 818.051 463.085 816.526C462.318 815 461.935 813.244 461.935 811.259C461.935 809.247 462.322 807.483 463.098 805.966C463.882 804.44 464.994 803.251 466.435 802.399C467.875 801.538 469.588 801.108 471.574 801.108C473.287 801.108 474.787 801.419 476.074 802.041C477.361 802.663 478.379 803.537 479.129 804.662C479.879 805.787 480.293 807.108 480.369 808.625H475.23C475.085 807.645 474.702 806.857 474.079 806.26C473.466 805.655 472.66 805.352 471.663 805.352C470.82 805.352 470.082 805.582 469.452 806.043C468.829 806.494 468.344 807.155 467.994 808.024C467.645 808.893 467.47 809.946 467.47 811.182C467.47 812.435 467.641 813.5 467.981 814.378C468.331 815.256 468.821 815.925 469.452 816.385C470.082 816.845 470.82 817.075 471.663 817.075C472.285 817.075 472.844 816.947 473.338 816.692C473.841 816.436 474.254 816.065 474.578 815.58C474.91 815.085 475.128 814.493 475.23 813.803H480.369C480.284 815.303 479.875 816.624 479.142 817.766C478.418 818.899 477.416 819.786 476.138 820.425C474.859 821.064 473.347 821.384 471.599 821.384ZM492.085 821.384C490.065 821.384 488.326 820.974 486.869 820.156C485.42 819.33 484.304 818.162 483.52 816.653C482.736 815.136 482.344 813.342 482.344 811.271C482.344 809.251 482.736 807.479 483.52 805.953C484.304 804.428 485.407 803.239 486.831 802.386C488.263 801.534 489.942 801.108 491.868 801.108C493.163 801.108 494.369 801.317 495.486 801.734C496.611 802.143 497.591 802.761 498.426 803.588C499.27 804.415 499.926 805.455 500.395 806.707C500.863 807.952 501.098 809.409 501.098 811.08V812.575H484.517V809.2H495.971C495.971 808.416 495.801 807.722 495.46 807.116C495.119 806.511 494.646 806.038 494.041 805.697C493.444 805.348 492.75 805.173 491.957 805.173C491.13 805.173 490.397 805.365 489.758 805.749C489.128 806.124 488.633 806.631 488.275 807.27C487.917 807.901 487.734 808.604 487.726 809.379V812.588C487.726 813.56 487.905 814.399 488.263 815.107C488.629 815.814 489.145 816.359 489.809 816.743C490.474 817.126 491.263 817.318 492.174 817.318C492.78 817.318 493.334 817.233 493.836 817.062C494.339 816.892 494.77 816.636 495.128 816.295C495.486 815.955 495.758 815.537 495.946 815.043L500.983 815.375C500.727 816.585 500.203 817.642 499.41 818.545C498.626 819.44 497.612 820.139 496.368 820.642C495.132 821.136 493.704 821.384 492.085 821.384ZM527.882 806.963L522.896 807.27C522.811 806.844 522.628 806.46 522.346 806.119C522.065 805.77 521.694 805.493 521.234 805.288C520.782 805.075 520.241 804.969 519.611 804.969C518.767 804.969 518.055 805.148 517.476 805.506C516.896 805.855 516.606 806.324 516.606 806.912C516.606 807.381 516.794 807.777 517.169 808.101C517.544 808.425 518.187 808.685 519.099 808.881L522.653 809.597C524.562 809.989 525.986 810.619 526.923 811.489C527.861 812.358 528.329 813.5 528.329 814.915C528.329 816.202 527.95 817.331 527.192 818.303C526.442 819.274 525.41 820.033 524.098 820.578C522.794 821.115 521.29 821.384 519.585 821.384C516.986 821.384 514.915 820.842 513.372 819.76C511.838 818.669 510.939 817.186 510.674 815.311L516.031 815.03C516.193 815.822 516.585 816.428 517.207 816.845C517.829 817.254 518.626 817.459 519.598 817.459C520.552 817.459 521.319 817.276 521.899 816.909C522.487 816.534 522.785 816.053 522.794 815.464C522.785 814.97 522.576 814.565 522.167 814.25C521.758 813.926 521.128 813.679 520.275 813.509L516.875 812.831C514.957 812.447 513.53 811.783 512.592 810.837C511.663 809.891 511.199 808.685 511.199 807.219C511.199 805.957 511.54 804.871 512.221 803.959C512.912 803.047 513.879 802.344 515.123 801.849C516.376 801.355 517.842 801.108 519.521 801.108C522.001 801.108 523.953 801.632 525.376 802.68C526.808 803.729 527.643 805.156 527.882 806.963ZM539.987 821.384C537.968 821.384 536.229 820.974 534.772 820.156C533.323 819.33 532.206 818.162 531.422 816.653C530.638 815.136 530.246 813.342 530.246 811.271C530.246 809.251 530.638 807.479 531.422 805.953C532.206 804.428 533.31 803.239 534.733 802.386C536.165 801.534 537.844 801.108 539.77 801.108C541.066 801.108 542.272 801.317 543.388 801.734C544.513 802.143 545.493 802.761 546.328 803.588C547.172 804.415 547.828 805.455 548.297 806.707C548.766 807.952 549 809.409 549 811.08V812.575H532.419V809.2H543.874C543.874 808.416 543.703 807.722 543.362 807.116C543.022 806.511 542.549 806.038 541.943 805.697C541.347 805.348 540.652 805.173 539.86 805.173C539.033 805.173 538.3 805.365 537.661 805.749C537.03 806.124 536.536 806.631 536.178 807.27C535.82 807.901 535.637 808.604 535.628 809.379V812.588C535.628 813.56 535.807 814.399 536.165 815.107C536.531 815.814 537.047 816.359 537.712 816.743C538.377 817.126 539.165 817.318 540.077 817.318C540.682 817.318 541.236 817.233 541.739 817.062C542.242 816.892 542.672 816.636 543.03 816.295C543.388 815.955 543.661 815.537 543.848 815.043L548.885 815.375C548.63 816.585 548.105 817.642 547.313 818.545C546.529 819.44 545.514 820.139 544.27 820.642C543.034 821.136 541.607 821.384 539.987 821.384ZM551.834 828.364V801.364H557.204V804.662H557.446C557.685 804.134 558.03 803.597 558.482 803.051C558.942 802.497 559.539 802.037 560.272 801.67C561.013 801.295 561.934 801.108 563.033 801.108C564.465 801.108 565.786 801.483 566.996 802.233C568.206 802.974 569.174 804.095 569.898 805.595C570.623 807.087 570.985 808.957 570.985 811.207C570.985 813.398 570.631 815.247 569.924 816.756C569.225 818.256 568.27 819.393 567.06 820.169C565.858 820.936 564.512 821.32 563.02 821.32C561.964 821.32 561.064 821.145 560.323 820.795C559.59 820.446 558.989 820.007 558.52 819.479C558.052 818.942 557.694 818.401 557.446 817.855H557.28V828.364H551.834ZM557.165 811.182C557.165 812.349 557.327 813.368 557.651 814.237C557.975 815.107 558.444 815.784 559.057 816.27C559.671 816.747 560.417 816.986 561.294 816.986C562.181 816.986 562.931 816.743 563.544 816.257C564.158 815.763 564.623 815.081 564.938 814.212C565.262 813.334 565.424 812.324 565.424 811.182C565.424 810.048 565.266 809.051 564.951 808.19C564.635 807.33 564.171 806.656 563.557 806.17C562.944 805.685 562.189 805.442 561.294 805.442C560.408 805.442 559.658 805.676 559.044 806.145C558.439 806.614 557.975 807.278 557.651 808.139C557.327 809 557.165 810.014 557.165 811.182ZM579.495 821.371C578.242 821.371 577.126 821.153 576.145 820.719C575.165 820.276 574.39 819.624 573.819 818.763C573.256 817.893 572.975 816.811 572.975 815.516C572.975 814.425 573.175 813.509 573.576 812.767C573.976 812.026 574.522 811.429 575.212 810.977C575.903 810.526 576.687 810.185 577.565 809.955C578.451 809.724 579.38 809.562 580.351 809.469C581.494 809.349 582.414 809.239 583.113 809.136C583.812 809.026 584.319 808.864 584.634 808.651C584.949 808.437 585.107 808.122 585.107 807.705V807.628C585.107 806.818 584.851 806.192 584.34 805.749C583.837 805.305 583.121 805.084 582.192 805.084C581.212 805.084 580.432 805.301 579.853 805.736C579.273 806.162 578.89 806.699 578.702 807.347L573.665 806.938C573.921 805.744 574.424 804.713 575.174 803.844C575.924 802.966 576.891 802.293 578.076 801.824C579.269 801.347 580.65 801.108 582.218 801.108C583.309 801.108 584.353 801.236 585.35 801.491C586.356 801.747 587.246 802.143 588.022 802.68C588.806 803.217 589.424 803.908 589.876 804.751C590.327 805.587 590.553 806.588 590.553 807.756V821H585.388V818.277H585.235C584.92 818.891 584.498 819.432 583.969 819.901C583.441 820.361 582.806 820.723 582.065 820.987C581.323 821.243 580.467 821.371 579.495 821.371ZM581.055 817.612C581.856 817.612 582.563 817.455 583.177 817.139C583.79 816.815 584.272 816.381 584.621 815.835C584.971 815.29 585.145 814.672 585.145 813.982V811.898C584.975 812.009 584.741 812.111 584.442 812.205C584.153 812.29 583.824 812.371 583.458 812.447C583.092 812.516 582.725 812.58 582.359 812.639C581.992 812.69 581.66 812.737 581.361 812.78C580.722 812.874 580.164 813.023 579.687 813.227C579.209 813.432 578.839 813.709 578.574 814.058C578.31 814.399 578.178 814.825 578.178 815.337C578.178 816.078 578.447 816.645 578.984 817.037C579.529 817.42 580.219 817.612 581.055 817.612ZM594.058 821V801.364H599.338V804.79H599.543C599.901 803.571 600.501 802.651 601.345 802.028C602.189 801.398 603.161 801.082 604.26 801.082C604.533 801.082 604.827 801.099 605.142 801.134C605.457 801.168 605.734 801.214 605.973 801.274V806.107C605.717 806.03 605.364 805.962 604.912 805.902C604.46 805.842 604.047 805.812 603.672 805.812C602.871 805.812 602.155 805.987 601.524 806.337C600.902 806.678 600.408 807.155 600.041 807.768C599.683 808.382 599.504 809.089 599.504 809.891V821H594.058ZM613.106 821.371C611.853 821.371 610.736 821.153 609.756 820.719C608.776 820.276 608.001 819.624 607.43 818.763C606.867 817.893 606.586 816.811 606.586 815.516C606.586 814.425 606.786 813.509 607.187 812.767C607.587 812.026 608.133 811.429 608.823 810.977C609.513 810.526 610.297 810.185 611.175 809.955C612.062 809.724 612.991 809.562 613.962 809.469C615.104 809.349 616.025 809.239 616.724 809.136C617.422 809.026 617.93 808.864 618.245 808.651C618.56 808.437 618.718 808.122 618.718 807.705V807.628C618.718 806.818 618.462 806.192 617.951 805.749C617.448 805.305 616.732 805.084 615.803 805.084C614.823 805.084 614.043 805.301 613.464 805.736C612.884 806.162 612.501 806.699 612.313 807.347L607.276 806.938C607.532 805.744 608.035 804.713 608.785 803.844C609.535 802.966 610.502 802.293 611.687 801.824C612.88 801.347 614.261 801.108 615.829 801.108C616.92 801.108 617.964 801.236 618.961 801.491C619.967 801.747 620.857 802.143 621.633 802.68C622.417 803.217 623.035 803.908 623.486 804.751C623.938 805.587 624.164 806.588 624.164 807.756V821H618.999V818.277H618.846C618.53 818.891 618.109 819.432 617.58 819.901C617.052 820.361 616.417 820.723 615.675 820.987C614.934 821.243 614.077 821.371 613.106 821.371ZM614.665 817.612C615.467 817.612 616.174 817.455 616.788 817.139C617.401 816.815 617.883 816.381 618.232 815.835C618.582 815.29 618.756 814.672 618.756 813.982V811.898C618.586 812.009 618.351 812.111 618.053 812.205C617.763 812.29 617.435 812.371 617.069 812.447C616.702 812.516 616.336 812.58 615.969 812.639C615.603 812.69 615.27 812.737 614.972 812.78C614.333 812.874 613.775 813.023 613.297 813.227C612.82 813.432 612.449 813.709 612.185 814.058C611.921 814.399 611.789 814.825 611.789 815.337C611.789 816.078 612.057 816.645 612.594 817.037C613.14 817.42 613.83 817.612 614.665 817.612ZM627.771 821V794.818H633.217V804.662H633.384C633.622 804.134 633.967 803.597 634.419 803.051C634.879 802.497 635.476 802.037 636.209 801.67C636.95 801.295 637.871 801.108 638.97 801.108C640.402 801.108 641.723 801.483 642.933 802.233C644.144 802.974 645.111 804.095 645.835 805.595C646.56 807.087 646.922 808.957 646.922 811.207C646.922 813.398 646.568 815.247 645.861 816.756C645.162 818.256 644.207 819.393 642.997 820.169C641.796 820.936 640.449 821.32 638.957 821.32C637.901 821.32 637.001 821.145 636.26 820.795C635.527 820.446 634.926 820.007 634.457 819.479C633.989 818.942 633.631 818.401 633.384 817.855H633.141V821H627.771ZM633.102 811.182C633.102 812.349 633.264 813.368 633.588 814.237C633.912 815.107 634.381 815.784 634.994 816.27C635.608 816.747 636.354 816.986 637.232 816.986C638.118 816.986 638.868 816.743 639.482 816.257C640.095 815.763 640.56 815.081 640.875 814.212C641.199 813.334 641.361 812.324 641.361 811.182C641.361 810.048 641.203 809.051 640.888 808.19C640.572 807.33 640.108 806.656 639.494 806.17C638.881 805.685 638.126 805.442 637.232 805.442C636.345 805.442 635.595 805.676 634.982 806.145C634.376 806.614 633.912 807.278 633.588 808.139C633.264 809 633.102 810.014 633.102 811.182ZM649.836 821V801.364H655.282V821H649.836ZM652.572 798.832C651.762 798.832 651.067 798.564 650.488 798.027C649.917 797.482 649.631 796.83 649.631 796.071C649.631 795.321 649.917 794.678 650.488 794.141C651.067 793.595 651.762 793.322 652.572 793.322C653.381 793.322 654.072 793.595 654.643 794.141C655.222 794.678 655.512 795.321 655.512 796.071C655.512 796.83 655.222 797.482 654.643 798.027C654.072 798.564 653.381 798.832 652.572 798.832ZM664.37 794.818V821H658.924V794.818H664.37ZM668.013 821V801.364H673.459V821H668.013ZM670.749 798.832C669.939 798.832 669.245 798.564 668.665 798.027C668.094 797.482 667.808 796.83 667.808 796.071C667.808 795.321 668.094 794.678 668.665 794.141C669.245 793.595 669.939 793.322 670.749 793.322C671.558 793.322 672.249 793.595 672.82 794.141C673.399 794.678 673.689 795.321 673.689 796.071C673.689 796.83 673.399 797.482 672.82 798.027C672.249 798.564 671.558 798.832 670.749 798.832ZM687.546 801.364V805.455H675.721V801.364H687.546ZM678.406 796.659H683.852V814.966C683.852 815.469 683.928 815.861 684.082 816.142C684.235 816.415 684.448 816.607 684.721 816.717C685.002 816.828 685.326 816.884 685.692 816.884C685.948 816.884 686.204 816.862 686.46 816.82C686.715 816.768 686.911 816.73 687.048 816.705L687.904 820.757C687.631 820.842 687.248 820.94 686.754 821.051C686.259 821.17 685.658 821.243 684.951 821.268C683.639 821.32 682.488 821.145 681.499 820.744C680.519 820.344 679.756 819.722 679.211 818.878C678.665 818.034 678.397 816.969 678.406 815.682V796.659ZM693.736 828.364C693.046 828.364 692.398 828.308 691.793 828.197C691.196 828.095 690.702 827.963 690.31 827.801L691.537 823.736C692.176 823.932 692.752 824.038 693.263 824.055C693.783 824.072 694.23 823.953 694.605 823.697C694.989 823.442 695.3 823.007 695.539 822.393L695.858 821.562L688.814 801.364H694.541L698.607 815.784H698.811L702.915 801.364H708.681L701.048 823.122C700.682 824.179 700.183 825.099 699.553 825.884C698.931 826.676 698.142 827.286 697.188 827.712C696.233 828.146 695.083 828.364 693.736 828.364Z" fill="black"/>
+<path d="M1099.12 468.121C1100.29 466.95 1100.29 465.05 1099.12 463.879L1080.03 444.787C1078.86 443.615 1076.96 443.615 1075.79 444.787C1074.62 445.958 1074.62 447.858 1075.79 449.029L1092.76 466L1075.79 482.971C1074.62 484.142 1074.62 486.042 1075.79 487.213C1076.96 488.385 1078.86 488.385 1080.03 487.213L1099.12 468.121ZM725 466V469H1097V466V463H725V466Z" fill="black"/>
+<path d="M908.867 865.379C907.695 866.55 907.695 868.45 908.867 869.621L927.958 888.713C929.13 889.885 931.03 889.885 932.201 888.713C933.373 887.542 933.373 885.642 932.201 884.471L915.231 867.5L932.201 850.529C933.373 849.358 933.373 847.458 932.201 846.287C931.03 845.115 929.13 845.115 927.958 846.287L908.867 865.379ZM1097.01 867.5V864.5L910.988 864.5V867.5V870.5L1097.01 870.5V867.5Z" fill="black"/>
+<path d="M501.707 398.707C502.098 398.317 502.098 397.683 501.707 397.293L495.343 390.929C494.953 390.538 494.319 390.538 493.929 390.929C493.538 391.319 493.538 391.953 493.929 392.343L499.586 398L493.929 403.657C493.538 404.047 493.538 404.681 493.929 405.071C494.319 405.462 494.953 405.462 495.343 405.071L501.707 398.707ZM451 398V399H501V398V397H451V398Z" fill="black"/>
+<path d="M501.707 530.707C502.098 530.317 502.098 529.683 501.707 529.293L495.343 522.929C494.953 522.538 494.319 522.538 493.929 522.929C493.538 523.319 493.538 523.953 493.929 524.343L499.586 530L493.929 535.657C493.538 536.047 493.538 536.681 493.929 537.071C494.319 537.462 494.953 537.462 495.343 537.071L501.707 530.707ZM451 530V531H501V530V529H451V530Z" fill="black"/>
+<path d="M501.707 659.707C502.098 659.317 502.098 658.683 501.707 658.293L495.343 651.929C494.953 651.538 494.319 651.538 493.929 651.929C493.538 652.319 493.538 652.953 493.929 653.343L499.586 659L493.929 664.657C493.538 665.047 493.538 665.681 493.929 666.071C494.319 666.462 494.953 666.462 495.343 666.071L501.707 659.707ZM451 659V660H501V659V658H451V659Z" fill="black"/>
+<path d="M465 892.5H502C503.933 892.5 505.5 894.067 505.5 896V932C505.5 933.933 503.933 935.5 502 935.5H465C463.067 935.5 461.5 933.933 461.5 932V896C461.5 894.067 463.067 892.5 465 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M490.563 897.591L482.126 928.938H477.434L485.871 897.591H490.563Z" fill="black"/>
+<path d="M261 894.5H298C299.933 894.5 301.5 896.067 301.5 898V934C301.5 935.933 299.933 937.5 298 937.5H261C259.067 937.5 257.5 935.933 257.5 934V898C257.5 896.067 259.067 894.5 261 894.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M269.993 927.332C269.149 927.332 268.424 927.034 267.819 926.438C267.223 925.832 266.924 925.108 266.924 924.264C266.924 923.429 267.223 922.713 267.819 922.116C268.424 921.52 269.149 921.222 269.993 921.222C270.811 921.222 271.527 921.52 272.14 922.116C272.754 922.713 273.061 923.429 273.061 924.264C273.061 924.827 272.916 925.342 272.626 925.811C272.345 926.271 271.974 926.642 271.514 926.923C271.054 927.196 270.547 927.332 269.993 927.332ZM279.995 927.332C279.151 927.332 278.427 927.034 277.822 926.438C277.225 925.832 276.927 925.108 276.927 924.264C276.927 923.429 277.225 922.713 277.822 922.116C278.427 921.52 279.151 921.222 279.995 921.222C280.813 921.222 281.529 921.52 282.143 922.116C282.757 922.713 283.063 923.429 283.063 924.264C283.063 924.827 282.919 925.342 282.629 925.811C282.347 926.271 281.977 926.642 281.517 926.923C281.056 927.196 280.549 927.332 279.995 927.332ZM289.998 927.332C289.154 927.332 288.43 927.034 287.825 926.438C287.228 925.832 286.93 925.108 286.93 924.264C286.93 923.429 287.228 922.713 287.825 922.116C288.43 921.52 289.154 921.222 289.998 921.222C290.816 921.222 291.532 921.52 292.146 922.116C292.759 922.713 293.066 923.429 293.066 924.264C293.066 924.827 292.921 925.342 292.631 925.811C292.35 926.271 291.979 926.642 291.519 926.923C291.059 927.196 290.552 927.332 289.998 927.332Z" fill="black"/>
+<path d="M689 892.5H726C727.933 892.5 729.5 894.067 729.5 896V932C729.5 933.933 727.933 935.5 726 935.5H689C687.067 935.5 685.5 933.933 685.5 932V896C685.5 894.067 687.067 892.5 689 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M699 916.78V912.28L717 904.354V909.531L704.676 914.479L704.842 914.21V914.849L704.676 914.581L717 919.528V924.706L699 916.78Z" fill="black"/>
+<rect x="538" y="334" width="152" height="261" rx="2" stroke="black" stroke-width="4"/>
+<rect x="526" y="843" width="346" height="141" rx="6" stroke="black" stroke-width="4"/>
+<defs>
+<clipPath id="clip0_13_16079">
+<rect width="212" height="217" fill="white" transform="translate(1152 383)"/>
+</clipPath>
+<clipPath id="clip1_13_16079">
+<rect width="95" height="95" fill="white" transform="translate(566 609)"/>
+</clipPath>
+<clipPath id="clip2_13_16079">
+<rect width="212" height="217" fill="white" transform="translate(1656 383)"/>
+</clipPath>
+</defs>
+</svg>

--- a/docs/source/_static/separability-functor.svg
+++ b/docs/source/_static/separability-functor.svg
@@ -1,0 +1,3541 @@
+<svg width="2040" height="1040" viewBox="0 0 2040 1040" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="91" width="2036" height="947" rx="32" fill="#E6711C" fill-opacity="0.17" stroke="black" stroke-width="4"/>
+<path d="M469.493 751.332C468.649 751.332 467.924 751.034 467.319 750.438C466.723 749.832 466.424 749.108 466.424 748.264C466.424 747.429 466.723 746.713 467.319 746.116C467.924 745.52 468.649 745.222 469.493 745.222C470.311 745.222 471.027 745.52 471.64 746.116C472.254 746.713 472.561 747.429 472.561 748.264C472.561 748.827 472.416 749.342 472.126 749.811C471.845 750.271 471.474 750.642 471.014 750.923C470.554 751.196 470.047 751.332 469.493 751.332ZM479.495 751.332C478.651 751.332 477.927 751.034 477.322 750.438C476.725 749.832 476.427 749.108 476.427 748.264C476.427 747.429 476.725 746.713 477.322 746.116C477.927 745.52 478.651 745.222 479.495 745.222C480.313 745.222 481.029 745.52 481.643 746.116C482.257 746.713 482.563 747.429 482.563 748.264C482.563 748.827 482.419 749.342 482.129 749.811C481.847 750.271 481.477 750.642 481.017 750.923C480.556 751.196 480.049 751.332 479.495 751.332ZM489.498 751.332C488.654 751.332 487.93 751.034 487.325 750.438C486.728 749.832 486.43 749.108 486.43 748.264C486.43 747.429 486.728 746.713 487.325 746.116C487.93 745.52 488.654 745.222 489.498 745.222C490.316 745.222 491.032 745.52 491.646 746.116C492.259 746.713 492.566 747.429 492.566 748.264C492.566 748.827 492.421 749.342 492.131 749.811C491.85 750.271 491.479 750.642 491.019 750.923C490.559 751.196 490.052 751.332 489.498 751.332Z" fill="black"/>
+<rect x="1044" y="235" width="945" height="675" rx="32" fill="white" stroke="black" stroke-width="4"/>
+<mask id="mask0_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1726" y="775" width="112" height="114">
+<path d="M1726 888.037H1837V775H1726V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_13_16078)">
+<mask id="mask1_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_13_16078)">
+<path d="M1822.72 831.52L1817.2 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask2_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_13_16078)">
+<path d="M1822.72 831.52L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask3_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_13_16078)">
+<path d="M1822.72 831.52L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask4_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_13_16078)">
+<path d="M1822.72 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask5_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_13_16078)">
+<path d="M1817.2 810.532L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask6_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_13_16078)">
+<path d="M1817.2 810.532L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask7_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_13_16078)">
+<path d="M1817.2 810.532L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask8_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_13_16078)">
+<path d="M1802.11 795.168L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask9_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_13_16078)">
+<path d="M1760.89 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask10_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_13_16078)">
+<path d="M1760.89 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask11_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_13_16078)">
+<path d="M1760.89 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask12_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_13_16078)">
+<path d="M1745.8 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask13_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_13_16078)">
+<path d="M1745.8 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask14_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_13_16078)">
+<path d="M1745.8 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask15_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_13_16078)">
+<path d="M1740.28 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask16_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_13_16078)">
+<path d="M1760.89 867.872L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask17_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_13_16078)">
+<path d="M1760.89 867.872H1802.11" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask18_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_13_16078)">
+<path d="M1760.89 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask19_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_13_16078)">
+<path d="M1781.5 873.495L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask20_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_13_16078)">
+<path d="M1781.5 873.495L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask21_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_13_16078)">
+<path d="M1802.11 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask22_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_13_16078)">
+<path d="M1822.72 831.52L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask23_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_13_16078)">
+<path d="M1822.72 831.52L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask24_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_13_16078)">
+<path d="M1822.72 831.52L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask25_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_13_16078)">
+<path d="M1822.72 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask26_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask26_13_16078)">
+<path d="M1822.72 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask27_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask27_13_16078)">
+<path d="M1822.72 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask28_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask28_13_16078)">
+<path d="M1822.72 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask29_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask29_13_16078)">
+<path d="M1817.2 810.532H1745.8" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask30_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask30_13_16078)">
+<path d="M1817.2 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask31_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask31_13_16078)">
+<path d="M1817.2 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask32_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask32_13_16078)">
+<path d="M1817.2 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask33_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask33_13_16078)">
+<path d="M1817.2 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask34_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask34_13_16078)">
+<path d="M1817.2 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask35_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask35_13_16078)">
+<path d="M1817.2 810.532V852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask36_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask36_13_16078)">
+<path d="M1802.11 795.168H1760.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask37_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask37_13_16078)">
+<path d="M1802.11 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask38_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask38_13_16078)">
+<path d="M1802.11 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask39_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask39_13_16078)">
+<path d="M1802.11 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask40_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask40_13_16078)">
+<path d="M1802.11 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask41_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask41_13_16078)">
+<path d="M1802.11 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask42_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask42_13_16078)">
+<path d="M1802.11 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask43_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask43_13_16078)">
+<path d="M1802.11 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask44_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask44_13_16078)">
+<path d="M1781.5 789.544L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask45_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask45_13_16078)">
+<path d="M1781.5 789.544L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask46_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask46_13_16078)">
+<path d="M1781.5 789.544L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask47_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask47_13_16078)">
+<path d="M1781.5 789.544L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask48_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask48_13_16078)">
+<path d="M1781.5 789.544L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask49_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask49_13_16078)">
+<path d="M1781.5 789.544V873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask50_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask50_13_16078)">
+<path d="M1781.5 789.544L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask51_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask51_13_16078)">
+<path d="M1781.5 789.544L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask52_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask52_13_16078)">
+<path d="M1760.89 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask53_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask53_13_16078)">
+<path d="M1760.89 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask54_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask54_13_16078)">
+<path d="M1760.89 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask55_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask55_13_16078)">
+<path d="M1760.89 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask56_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask56_13_16078)">
+<path d="M1745.8 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask57_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask57_13_16078)">
+<path d="M1745.8 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask58_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask58_13_16078)">
+<path d="M1745.8 810.532L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask59_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask59_13_16078)">
+<path d="M1740.28 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask60_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask60_13_16078)">
+<path d="M1740.28 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask61_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask61_13_16078)">
+<path d="M1740.28 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask62_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask62_13_16078)">
+<path d="M1740.28 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask63_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask63_13_16078)">
+<path d="M1745.8 852.508L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask64_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask64_13_16078)">
+<path d="M1745.8 852.508L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask65_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask65_13_16078)">
+<path d="M1745.8 852.508L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask66_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask66_13_16078)">
+<path d="M1745.8 852.508L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask67_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask67_13_16078)">
+<mask id="mask68_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1817" y="826" width="11" height="11">
+<path d="M1817.77 836.568H1827.68V826.472H1817.77V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask68_13_16078)">
+<path d="M1822.72 836.045C1823.9 836.045 1825.03 835.568 1825.87 834.72C1826.7 833.871 1827.17 832.72 1827.17 831.52C1827.17 830.32 1826.7 829.168 1825.87 828.32C1825.03 827.471 1823.9 826.994 1822.72 826.994C1821.54 826.994 1820.41 827.471 1819.58 828.32C1818.75 829.168 1818.28 830.32 1818.28 831.52C1818.28 832.72 1818.75 833.871 1819.58 834.72C1820.41 835.568 1821.54 836.045 1822.72 836.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask69_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask69_13_16078)">
+<mask id="mask70_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="805" width="11" height="11">
+<path d="M1812.24 815.58H1822.16V805.484H1812.24V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask70_13_16078)">
+<path d="M1817.2 815.057C1818.38 815.057 1819.51 814.58 1820.34 813.732C1821.18 812.883 1821.64 811.732 1821.64 810.532C1821.64 809.332 1821.18 808.181 1820.34 807.332C1819.51 806.483 1818.38 806.007 1817.2 806.007C1816.02 806.007 1814.89 806.483 1814.06 807.332C1813.22 808.181 1812.76 809.332 1812.76 810.532C1812.76 811.732 1813.22 812.883 1814.06 813.732C1814.89 814.58 1816.02 815.057 1817.2 815.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask71_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask71_13_16078)">
+<mask id="mask72_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="790" width="11" height="11">
+<path d="M1797.15 800.215H1807.07V790.12H1797.15V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask72_13_16078)">
+<path d="M1802.11 799.693C1803.29 799.693 1804.42 799.216 1805.25 798.367C1806.09 797.519 1806.56 796.368 1806.56 795.168C1806.56 793.967 1806.09 792.816 1805.25 791.968C1804.42 791.119 1803.29 790.642 1802.11 790.642C1800.93 790.642 1799.8 791.119 1798.97 791.968C1798.14 792.816 1797.67 793.967 1797.67 795.168C1797.67 796.368 1798.14 797.519 1798.97 798.367C1799.8 799.216 1800.93 799.693 1802.11 799.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask73_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask73_13_16078)">
+<mask id="mask74_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="784" width="11" height="11">
+<path d="M1776.54 794.592H1786.46V784.496H1776.54V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask74_13_16078)">
+<path d="M1781.5 794.069C1782.68 794.069 1783.81 793.592 1784.64 792.744C1785.48 791.895 1785.95 790.744 1785.95 789.544C1785.95 788.344 1785.48 787.193 1784.64 786.344C1783.81 785.495 1782.68 785.019 1781.5 785.019C1780.32 785.019 1779.19 785.495 1778.36 786.344C1777.53 787.193 1777.06 788.344 1777.06 789.544C1777.06 790.744 1777.53 791.895 1778.36 792.744C1779.19 793.592 1780.32 794.069 1781.5 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask75_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask75_13_16078)">
+<mask id="mask76_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="790" width="11" height="11">
+<path d="M1755.93 800.215H1765.85V790.12H1755.93V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask76_13_16078)">
+<path d="M1760.89 799.693C1762.07 799.693 1763.2 799.216 1764.03 798.367C1764.87 797.519 1765.33 796.368 1765.33 795.168C1765.33 793.967 1764.87 792.816 1764.03 791.968C1763.2 791.119 1762.07 790.642 1760.89 790.642C1759.71 790.642 1758.58 791.119 1757.75 791.968C1756.91 792.816 1756.45 793.967 1756.45 795.168C1756.45 796.368 1756.91 797.519 1757.75 798.367C1758.58 799.216 1759.71 799.693 1760.89 799.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask77_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask77_13_16078)">
+<mask id="mask78_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="805" width="11" height="11">
+<path d="M1740.85 815.58H1750.76V805.484H1740.85V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask78_13_16078)">
+<path d="M1745.8 815.057C1746.98 815.057 1748.11 814.58 1748.94 813.732C1749.78 812.883 1750.25 811.732 1750.25 810.532C1750.25 809.332 1749.78 808.181 1748.94 807.332C1748.11 806.483 1746.98 806.007 1745.8 806.007C1744.62 806.007 1743.49 806.483 1742.66 807.332C1741.83 808.181 1741.36 809.332 1741.36 810.532C1741.36 811.732 1741.83 812.883 1742.66 813.732C1743.49 814.58 1744.62 815.057 1745.8 815.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask79_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask79_13_16078)">
+<mask id="mask80_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1735" y="826" width="11" height="11">
+<path d="M1735.32 836.568H1745.24V826.472H1735.32V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask80_13_16078)">
+<path d="M1740.28 836.045C1741.46 836.045 1742.59 835.568 1743.42 834.72C1744.26 833.871 1744.72 832.72 1744.72 831.52C1744.72 830.32 1744.26 829.168 1743.42 828.32C1742.59 827.471 1741.46 826.994 1740.28 826.994C1739.1 826.994 1737.97 827.471 1737.14 828.32C1736.3 829.168 1735.84 830.32 1735.84 831.52C1735.84 832.72 1736.3 833.871 1737.14 834.72C1737.97 835.568 1739.1 836.045 1740.28 836.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask81_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask81_13_16078)">
+<mask id="mask82_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="847" width="11" height="11">
+<path d="M1740.85 857.555H1750.76V847.46H1740.85V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask82_13_16078)">
+<path d="M1745.8 857.033C1746.98 857.033 1748.11 856.556 1748.94 855.708C1749.78 854.859 1750.25 853.708 1750.25 852.508C1750.25 851.308 1749.78 850.156 1748.94 849.308C1748.11 848.459 1746.98 847.982 1745.8 847.982C1744.62 847.982 1743.49 848.459 1742.66 849.308C1741.83 850.156 1741.36 851.308 1741.36 852.508C1741.36 853.708 1741.83 854.859 1742.66 855.708C1743.49 856.556 1744.62 857.033 1745.8 857.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask83_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask83_13_16078)">
+<mask id="mask84_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="862" width="11" height="11">
+<path d="M1755.93 872.92H1765.85V862.824H1755.93V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask84_13_16078)">
+<path d="M1760.89 872.397C1762.07 872.397 1763.2 871.92 1764.03 871.072C1764.87 870.223 1765.33 869.072 1765.33 867.872C1765.33 866.672 1764.87 865.521 1764.03 864.672C1763.2 863.823 1762.07 863.347 1760.89 863.347C1759.71 863.347 1758.58 863.823 1757.75 864.672C1756.91 865.521 1756.45 866.672 1756.45 867.872C1756.45 869.072 1756.91 870.223 1757.75 871.072C1758.58 871.92 1759.71 872.397 1760.89 872.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask85_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask85_13_16078)">
+<mask id="mask86_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="868" width="11" height="11">
+<path d="M1776.54 878.543H1786.46V868.448H1776.54V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask86_13_16078)">
+<path d="M1781.5 878.021C1782.68 878.021 1783.81 877.544 1784.64 876.695C1785.48 875.847 1785.95 874.696 1785.95 873.496C1785.95 872.295 1785.48 871.144 1784.64 870.296C1783.81 869.447 1782.68 868.97 1781.5 868.97C1780.32 868.97 1779.19 869.447 1778.36 870.296C1777.53 871.144 1777.06 872.295 1777.06 873.496C1777.06 874.696 1777.53 875.847 1778.36 876.695C1779.19 877.544 1780.32 878.021 1781.5 878.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask87_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask87_13_16078)">
+<mask id="mask88_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="862" width="11" height="11">
+<path d="M1797.15 872.92H1807.07V862.824H1797.15V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask88_13_16078)">
+<path d="M1802.11 872.397C1803.29 872.397 1804.42 871.92 1805.25 871.072C1806.09 870.223 1806.56 869.072 1806.56 867.872C1806.56 866.672 1806.09 865.521 1805.25 864.672C1804.42 863.823 1803.29 863.347 1802.11 863.347C1800.93 863.347 1799.8 863.823 1798.97 864.672C1798.14 865.521 1797.67 866.672 1797.67 867.872C1797.67 869.072 1798.14 870.223 1798.97 871.072C1799.8 871.92 1800.93 872.397 1802.11 872.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask89_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask89_13_16078)">
+<mask id="mask90_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="847" width="11" height="11">
+<path d="M1812.24 857.555H1822.16V847.46H1812.24V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask90_13_16078)">
+<path d="M1817.2 857.033C1818.38 857.033 1819.51 856.556 1820.34 855.708C1821.18 854.859 1821.64 853.708 1821.64 852.508C1821.64 851.308 1821.18 850.156 1820.34 849.308C1819.51 848.459 1818.38 847.982 1817.2 847.982C1816.02 847.982 1814.89 848.459 1814.06 849.308C1813.22 850.156 1812.76 851.308 1812.76 852.508C1812.76 853.708 1813.22 854.859 1814.06 855.708C1814.89 856.556 1816.02 857.033 1817.2 857.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask91_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask91_13_16078)">
+<path d="M1822.77 828.274C1822.36 828.274 1822.07 828.389 1821.79 828.642C1821.39 829.057 1821.12 829.885 1821.12 830.737C1821.12 831.542 1821.34 832.394 1821.68 832.808C1821.95 833.13 1822.31 833.291 1822.72 833.291C1823.08 833.291 1823.4 833.176 1823.65 832.923C1824.08 832.532 1824.35 831.68 1824.35 830.783C1824.35 829.287 1823.69 828.274 1822.77 828.274ZM1822.74 828.458C1823.33 828.458 1823.65 829.287 1823.65 830.806C1823.65 832.325 1823.35 833.107 1822.72 833.107C1822.11 833.107 1821.79 832.325 1821.79 830.806C1821.79 829.264 1822.11 828.458 1822.74 828.458Z" fill="white"/>
+</g>
+<mask id="mask92_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask92_13_16078)">
+<path d="M1817.49 807.291L1816.2 807.959V808.051C1816.29 808.005 1816.36 807.982 1816.4 807.982C1816.52 807.913 1816.65 807.89 1816.72 807.89C1816.88 807.89 1816.95 808.005 1816.95 808.235V811.549C1816.95 811.779 1816.88 811.94 1816.77 812.009C1816.65 812.078 1816.56 812.101 1816.25 812.101V812.216H1818.24V812.101C1817.67 812.101 1817.56 812.032 1817.56 811.687V807.291H1817.49Z" fill="white"/>
+</g>
+<mask id="mask93_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask93_13_16078)">
+<path d="M1803.74 795.859L1803.62 795.813C1803.38 796.228 1803.29 796.297 1802.95 796.297H1801.25L1802.45 795.008C1803.08 794.34 1803.35 793.788 1803.35 793.213C1803.35 792.476 1802.79 791.924 1802.04 791.924C1801.64 791.924 1801.27 792.085 1801 792.361C1800.78 792.614 1800.66 792.844 1800.55 793.374L1800.69 793.397C1800.98 792.683 1801.25 792.453 1801.73 792.453C1802.34 792.453 1802.74 792.868 1802.74 793.489C1802.74 794.064 1802.43 794.732 1801.82 795.376L1800.55 796.757V796.849H1803.33L1803.74 795.859Z" fill="white"/>
+</g>
+<mask id="mask94_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask94_13_16078)">
+<path d="M1780.82 788.811C1781.23 788.811 1781.39 788.834 1781.57 788.903C1782.02 789.065 1782.29 789.479 1782.29 789.985C1782.29 790.583 1781.88 791.067 1781.36 791.067C1781.16 791.067 1781.02 791.021 1780.75 790.837C1780.53 790.698 1780.41 790.652 1780.3 790.652C1780.12 790.652 1780.03 790.768 1780.03 790.906C1780.03 791.159 1780.32 791.32 1780.82 791.32C1781.39 791.32 1781.95 791.136 1782.29 790.837C1782.63 790.537 1782.81 790.123 1782.81 789.64C1782.81 789.249 1782.7 788.926 1782.49 788.696C1782.33 788.535 1782.2 788.443 1781.88 788.305C1782.38 787.96 1782.56 787.684 1782.56 787.292C1782.56 786.694 1782.11 786.303 1781.45 786.303C1781.09 786.303 1780.78 786.418 1780.53 786.648C1780.3 786.855 1780.19 787.039 1780.03 787.477L1780.14 787.5C1780.44 786.97 1780.75 786.74 1781.2 786.74C1781.68 786.74 1782 787.062 1782 787.523C1782 787.776 1781.88 788.029 1781.7 788.213C1781.5 788.443 1781.3 788.558 1780.82 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask95_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask95_13_16078)">
+<path d="M1762.49 795.169H1761.75V791.924H1761.43L1759.19 795.169V795.629H1761.2V796.849H1761.75V795.629H1762.49V795.169ZM1761.2 795.169H1759.46L1761.2 792.66V795.169Z" fill="white"/>
+</g>
+<mask id="mask96_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask96_13_16078)">
+<path d="M1745.3 807.959H1746.72C1746.84 807.959 1746.86 807.959 1746.88 807.89L1747.15 807.245L1747.08 807.199C1746.97 807.36 1746.9 807.383 1746.75 807.383H1745.25L1744.49 809.109C1744.46 809.132 1744.46 809.132 1744.46 809.156C1744.46 809.179 1744.51 809.202 1744.55 809.202C1744.78 809.202 1745.07 809.271 1745.37 809.363C1746.18 809.616 1746.56 810.076 1746.56 810.812C1746.56 811.503 1746.13 812.055 1745.57 812.055C1745.43 812.055 1745.3 811.986 1745.1 811.848C1744.87 811.664 1744.69 811.595 1744.55 811.595C1744.35 811.595 1744.24 811.687 1744.24 811.871C1744.24 812.147 1744.58 812.308 1745.12 812.308C1745.71 812.308 1746.23 812.124 1746.59 811.756C1746.93 811.411 1747.06 810.997 1747.06 810.444C1747.06 809.915 1746.93 809.593 1746.56 809.225C1746.27 808.902 1745.84 808.741 1745 808.58L1745.3 807.959Z" fill="white"/>
+</g>
+<mask id="mask97_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask97_13_16078)">
+<path d="M1741.68 828.205C1740.86 828.274 1740.46 828.412 1739.94 828.803C1739.15 829.356 1738.74 830.184 1738.74 831.174C1738.74 831.795 1738.92 832.44 1739.24 832.808C1739.51 833.13 1739.89 833.291 1740.34 833.291C1741.22 833.291 1741.84 832.601 1741.84 831.611C1741.84 830.668 1741.32 830.069 1740.5 830.069C1740.19 830.069 1740.03 830.138 1739.58 830.414C1739.78 829.31 1740.57 828.504 1741.7 828.32L1741.68 828.205ZM1740.23 830.414C1740.84 830.414 1741.2 830.944 1741.2 831.841C1741.2 832.647 1740.91 833.107 1740.41 833.107C1739.78 833.107 1739.39 832.417 1739.39 831.289C1739.39 830.898 1739.46 830.714 1739.6 830.599C1739.76 830.483 1739.98 830.414 1740.23 830.414Z" fill="white"/>
+</g>
+<mask id="mask98_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask98_13_16078)">
+<path d="M1747.22 849.355H1744.58L1744.15 850.436L1744.28 850.482C1744.58 849.999 1744.71 849.907 1745.12 849.907H1746.65L1745.25 854.257H1745.71L1747.22 849.47V849.355Z" fill="white"/>
+</g>
+<mask id="mask99_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask99_13_16078)">
+<path d="M1761.18 866.839C1761.88 866.471 1762.13 866.149 1762.13 865.666C1762.13 865.067 1761.63 864.63 1760.91 864.63C1760.12 864.63 1759.55 865.113 1759.55 865.781C1759.55 866.241 1759.69 866.471 1760.44 867.139C1759.67 867.737 1759.51 867.967 1759.51 868.45C1759.51 869.164 1760.07 869.647 1760.89 869.647C1761.75 869.647 1762.29 869.187 1762.29 868.427C1762.29 867.852 1762.04 867.507 1761.18 866.839ZM1761.05 867.599C1761.57 867.99 1761.75 868.243 1761.75 868.657C1761.75 869.118 1761.43 869.463 1760.95 869.463C1760.41 869.463 1760.05 869.026 1760.05 868.404C1760.05 867.921 1760.21 867.622 1760.62 867.277L1761.05 867.599ZM1760.98 866.724C1760.34 866.287 1760.07 865.965 1760.07 865.551C1760.07 865.136 1760.39 864.837 1760.84 864.837C1761.34 864.837 1761.66 865.159 1761.66 865.643C1761.66 866.057 1761.45 866.402 1761.05 866.678C1761 866.701 1761 866.701 1760.98 866.724Z" fill="white"/>
+</g>
+<mask id="mask100_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask100_13_16078)">
+<path d="M1780.14 875.337C1780.93 875.245 1781.34 875.107 1781.81 874.739C1782.56 874.187 1783.01 873.289 1783.01 872.299C1783.01 871.103 1782.33 870.251 1781.41 870.251C1780.57 870.251 1779.94 870.988 1779.94 871.977C1779.94 872.852 1780.44 873.45 1781.23 873.45C1781.61 873.45 1781.91 873.335 1782.29 873.036C1782 874.21 1781.2 874.992 1780.12 875.199L1780.14 875.337ZM1782.31 872.576C1782.31 872.737 1782.27 872.806 1782.2 872.875C1782 873.036 1781.72 873.128 1781.48 873.128C1780.93 873.128 1780.59 872.576 1780.59 871.724C1780.59 871.31 1780.71 870.873 1780.84 870.665C1780.98 870.527 1781.16 870.458 1781.36 870.458C1781.97 870.458 1782.31 871.08 1782.31 872.299V872.576Z" fill="white"/>
+</g>
+<mask id="mask101_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask101_13_16078)">
+<path d="M1800.61 864.63L1799.32 865.297V865.39C1799.41 865.343 1799.48 865.32 1799.53 865.32C1799.64 865.251 1799.78 865.228 1799.84 865.228C1800 865.228 1800.07 865.343 1800.07 865.574V868.888C1800.07 869.118 1800 869.279 1799.89 869.348C1799.78 869.417 1799.69 869.44 1799.37 869.44V869.555H1801.36V869.44C1800.79 869.44 1800.68 869.371 1800.68 869.026V864.63H1800.61ZM1803.94 864.63C1803.53 864.63 1803.24 864.745 1802.97 864.998C1802.56 865.413 1802.29 866.241 1802.29 867.093C1802.29 867.898 1802.52 868.75 1802.86 869.164C1803.13 869.486 1803.49 869.647 1803.9 869.647C1804.26 869.647 1804.57 869.532 1804.82 869.279C1805.25 868.888 1805.52 868.036 1805.52 867.139C1805.52 865.643 1804.87 864.63 1803.94 864.63ZM1803.92 864.814C1804.51 864.814 1804.82 865.643 1804.82 867.162C1804.82 868.68 1804.53 869.463 1803.9 869.463C1803.29 869.463 1802.97 868.68 1802.97 867.162C1802.97 865.62 1803.29 864.814 1803.92 864.814Z" fill="white"/>
+</g>
+<mask id="mask102_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask102_13_16078)">
+<path d="M1815.7 849.263L1814.41 849.93V850.022C1814.5 849.976 1814.57 849.953 1814.61 849.953C1814.73 849.884 1814.86 849.861 1814.93 849.861C1815.09 849.861 1815.16 849.976 1815.16 850.206V853.52C1815.16 853.75 1815.09 853.911 1814.98 853.981C1814.86 854.05 1814.77 854.073 1814.46 854.073V854.188H1816.44V854.073C1815.88 854.073 1815.77 854.004 1815.77 853.658V849.263H1815.7ZM1819.28 849.263L1817.99 849.93V850.022C1818.08 849.976 1818.15 849.953 1818.2 849.953C1818.31 849.884 1818.44 849.861 1818.51 849.861C1818.67 849.861 1818.74 849.976 1818.74 850.206V853.52C1818.74 853.75 1818.67 853.911 1818.56 853.981C1818.44 854.05 1818.35 854.073 1818.04 854.073V854.188H1820.03V854.073C1819.46 854.073 1819.35 854.004 1819.35 853.658V849.263H1819.28Z" fill="white"/>
+</g>
+</g>
+<g clip-path="url(#clip0_13_16078)">
+<path d="M1160.83 590.958V383H1152V600H1364V590.958H1160.83Z" fill="#E6711C"/>
+<path d="M1364 464.375H1324.25V572.875H1364V464.375Z" fill="#E6711C"/>
+<path d="M1315.42 482.775H1275.67V572.875H1315.42V482.775Z" fill="#E6711C"/>
+<path d="M1266.83 534.367H1227.08V572.884H1266.83V534.367Z" fill="#E6711C"/>
+<path d="M1218.25 512.26H1178.5V572.884H1218.25V512.26Z" fill="#E6711C"/>
+</g>
+<g clip-path="url(#clip1_13_16078)">
+<path d="M569.958 700.042V609H566V704H661V700.042H569.958Z" fill="#F9D925"/>
+<path d="M661 644.625H643.188V692.125H661V644.625Z" fill="#F9D925"/>
+<path d="M639.229 652.68H621.417V692.125H639.229V652.68Z" fill="#F9D925"/>
+<path d="M617.458 675.267H599.646V692.129H617.458V675.267Z" fill="#F9D925"/>
+<path d="M595.687 665.588H577.875V692.129H595.687V665.588Z" fill="#F9D925"/>
+</g>
+<path d="M569.958 441.042V350H566V445H661V441.042H569.958Z" fill="#E6711C"/>
+<path d="M661 385.625H643.188V433.125H661V385.625Z" fill="#E6711C"/>
+<path d="M639.229 393.68H621.417V433.125H639.229V393.68Z" fill="#E6711C"/>
+<path d="M617.458 416.267H599.646V433.129H617.458V416.267Z" fill="#E6711C"/>
+<path d="M595.687 406.588H577.875V433.129H595.687V406.588Z" fill="#E6711C"/>
+<path d="M569.958 571.042V480H566V575H661V571.042H569.958Z" fill="#5C0B4D"/>
+<path d="M661 515.625H643.188V563.125H661V515.625Z" fill="#5C0B4D"/>
+<path d="M639.229 523.68H621.417V563.125H639.229V523.68Z" fill="#5C0B4D"/>
+<path d="M617.458 546.267H599.646V563.129H617.458V546.267Z" fill="#5C0B4D"/>
+<path d="M595.687 536.588H577.875V563.129H595.687V536.588Z" fill="#5C0B4D"/>
+<g clip-path="url(#clip2_13_16078)">
+<path d="M1664.83 590.958V383H1656V600H1868V590.958H1664.83Z" fill="#5C0B4D"/>
+<path d="M1868 464.375H1828.25V572.875H1868V464.375Z" fill="#5C0B4D"/>
+<path d="M1819.42 482.775H1779.67V572.875H1819.42V482.775Z" fill="#5C0B4D"/>
+<path d="M1770.83 534.367H1731.08V572.884H1770.83V534.367Z" fill="#5C0B4D"/>
+<path d="M1722.25 512.26H1682.5V572.884H1722.25V512.26Z" fill="#5C0B4D"/>
+</g>
+<path d="M1154.25 655V628.818H1164.58C1166.56 628.818 1168.26 629.197 1169.65 629.956C1171.05 630.706 1172.12 631.75 1172.85 633.088C1173.59 634.418 1173.96 635.952 1173.96 637.69C1173.96 639.429 1173.59 640.963 1172.84 642.293C1172.09 643.622 1171 644.658 1169.58 645.399C1168.16 646.141 1166.45 646.511 1164.44 646.511H1157.85V642.075H1163.54C1164.61 642.075 1165.49 641.892 1166.18 641.526C1166.88 641.151 1167.4 640.635 1167.74 639.979C1168.09 639.314 1168.26 638.551 1168.26 637.69C1168.26 636.821 1168.09 636.062 1167.74 635.415C1167.4 634.759 1166.88 634.251 1166.18 633.893C1165.48 633.527 1164.59 633.344 1163.52 633.344H1159.78V655H1154.25ZM1185.37 655.384C1183.35 655.384 1181.61 654.974 1180.15 654.156C1178.7 653.33 1177.59 652.162 1176.8 650.653C1176.02 649.136 1175.63 647.342 1175.63 645.271C1175.63 643.251 1176.02 641.479 1176.8 639.953C1177.59 638.428 1178.69 637.239 1180.11 636.386C1181.55 635.534 1183.22 635.108 1185.15 635.108C1186.45 635.108 1187.65 635.317 1188.77 635.734C1189.89 636.143 1190.87 636.761 1191.71 637.588C1192.55 638.415 1193.21 639.455 1193.68 640.707C1194.15 641.952 1194.38 643.409 1194.38 645.08V646.575H1177.8V643.2H1189.25C1189.25 642.416 1189.08 641.722 1188.74 641.116C1188.4 640.511 1187.93 640.038 1187.32 639.697C1186.73 639.348 1186.03 639.173 1185.24 639.173C1184.41 639.173 1183.68 639.365 1183.04 639.749C1182.41 640.124 1181.92 640.631 1181.56 641.27C1181.2 641.901 1181.02 642.604 1181.01 643.379V646.588C1181.01 647.56 1181.19 648.399 1181.55 649.107C1181.91 649.814 1182.43 650.359 1183.09 650.743C1183.76 651.126 1184.55 651.318 1185.46 651.318C1186.06 651.318 1186.62 651.233 1187.12 651.062C1187.62 650.892 1188.05 650.636 1188.41 650.295C1188.77 649.955 1189.04 649.537 1189.23 649.043L1194.27 649.375C1194.01 650.585 1193.49 651.642 1192.69 652.545C1191.91 653.44 1190.9 654.139 1189.65 654.642C1188.41 655.136 1186.99 655.384 1185.37 655.384ZM1197.21 655V635.364H1202.49V638.79H1202.7C1203.06 637.571 1203.66 636.651 1204.5 636.028C1205.35 635.398 1206.32 635.082 1207.42 635.082C1207.69 635.082 1207.98 635.099 1208.3 635.134C1208.61 635.168 1208.89 635.214 1209.13 635.274V640.107C1208.87 640.03 1208.52 639.962 1208.07 639.902C1207.62 639.842 1207.2 639.812 1206.83 639.812C1206.03 639.812 1205.31 639.987 1204.68 640.337C1204.06 640.678 1203.56 641.155 1203.2 641.768C1202.84 642.382 1202.66 643.089 1202.66 643.891V655H1197.21ZM1222.77 635.364V639.455H1210.65V635.364H1222.77ZM1213.42 655V633.945C1213.42 632.521 1213.7 631.341 1214.26 630.403C1214.82 629.466 1215.58 628.763 1216.56 628.294C1217.53 627.825 1218.63 627.591 1219.87 627.591C1220.7 627.591 1221.47 627.655 1222.16 627.783C1222.85 627.911 1223.37 628.026 1223.72 628.128L1222.74 632.219C1222.53 632.151 1222.27 632.087 1221.95 632.027C1221.64 631.967 1221.33 631.938 1221.01 631.938C1220.2 631.938 1219.65 632.125 1219.33 632.5C1219.02 632.866 1218.86 633.382 1218.86 634.047V655H1213.42ZM1233.55 655.384C1231.56 655.384 1229.84 654.962 1228.39 654.118C1226.95 653.266 1225.84 652.081 1225.06 650.564C1224.27 649.038 1223.88 647.27 1223.88 645.259C1223.88 643.23 1224.27 641.457 1225.06 639.94C1225.84 638.415 1226.95 637.23 1228.39 636.386C1229.84 635.534 1231.56 635.108 1233.55 635.108C1235.53 635.108 1237.24 635.534 1238.68 636.386C1240.13 637.23 1241.25 638.415 1242.03 639.94C1242.82 641.457 1243.21 643.23 1243.21 645.259C1243.21 647.27 1242.82 649.038 1242.03 650.564C1241.25 652.081 1240.13 653.266 1238.68 654.118C1237.24 654.962 1235.53 655.384 1233.55 655.384ZM1233.57 651.165C1234.47 651.165 1235.23 650.909 1235.83 650.398C1236.44 649.878 1236.89 649.17 1237.2 648.276C1237.52 647.381 1237.67 646.362 1237.67 645.22C1237.67 644.078 1237.52 643.06 1237.2 642.165C1236.89 641.27 1236.44 640.562 1235.83 640.043C1235.23 639.523 1234.47 639.263 1233.57 639.263C1232.66 639.263 1231.89 639.523 1231.27 640.043C1230.66 640.562 1230.19 641.27 1229.88 642.165C1229.57 643.06 1229.42 644.078 1229.42 645.22C1229.42 646.362 1229.57 647.381 1229.88 648.276C1230.19 649.17 1230.66 649.878 1231.27 650.398C1231.89 650.909 1232.66 651.165 1233.57 651.165ZM1246.03 655V635.364H1251.31V638.79H1251.52C1251.87 637.571 1252.47 636.651 1253.32 636.028C1254.16 635.398 1255.13 635.082 1256.23 635.082C1256.51 635.082 1256.8 635.099 1257.12 635.134C1257.43 635.168 1257.71 635.214 1257.95 635.274V640.107C1257.69 640.03 1257.34 639.962 1256.89 639.902C1256.43 639.842 1256.02 639.812 1255.64 639.812C1254.84 639.812 1254.13 639.987 1253.5 640.337C1252.88 640.678 1252.38 641.155 1252.01 641.768C1251.66 642.382 1251.48 643.089 1251.48 643.891V655H1246.03ZM1260.04 655V635.364H1265.23V638.828H1265.46C1265.87 637.678 1266.55 636.77 1267.51 636.105C1268.46 635.44 1269.6 635.108 1270.93 635.108C1272.28 635.108 1273.43 635.445 1274.37 636.118C1275.32 636.783 1275.95 637.686 1276.26 638.828H1276.47C1276.87 637.703 1277.59 636.804 1278.64 636.131C1279.7 635.449 1280.95 635.108 1282.39 635.108C1284.22 635.108 1285.71 635.692 1286.85 636.859C1288 638.018 1288.58 639.663 1288.58 641.794V655H1283.14V642.868C1283.14 641.777 1282.85 640.959 1282.27 640.413C1281.69 639.868 1280.97 639.595 1280.1 639.595C1279.11 639.595 1278.34 639.911 1277.79 640.541C1277.23 641.163 1276.96 641.986 1276.96 643.009V655H1271.68V642.753C1271.68 641.79 1271.4 641.023 1270.84 640.452C1270.3 639.881 1269.58 639.595 1268.68 639.595C1268.08 639.595 1267.53 639.749 1267.05 640.055C1266.57 640.354 1266.19 640.776 1265.91 641.321C1265.63 641.858 1265.49 642.489 1265.49 643.213V655H1260.04ZM1297.76 655.371C1296.5 655.371 1295.39 655.153 1294.41 654.719C1293.43 654.276 1292.65 653.624 1292.08 652.763C1291.52 651.893 1291.24 650.811 1291.24 649.516C1291.24 648.425 1291.44 647.509 1291.84 646.767C1292.24 646.026 1292.78 645.429 1293.47 644.977C1294.16 644.526 1294.95 644.185 1295.83 643.955C1296.71 643.724 1297.64 643.562 1298.61 643.469C1299.76 643.349 1300.68 643.239 1301.38 643.136C1302.07 643.026 1302.58 642.864 1302.9 642.651C1303.21 642.437 1303.37 642.122 1303.37 641.705V641.628C1303.37 640.818 1303.11 640.192 1302.6 639.749C1302.1 639.305 1301.38 639.084 1300.45 639.084C1299.47 639.084 1298.69 639.301 1298.12 639.736C1297.54 640.162 1297.15 640.699 1296.96 641.347L1291.93 640.938C1292.18 639.744 1292.69 638.713 1293.44 637.844C1294.19 636.966 1295.15 636.293 1296.34 635.824C1297.53 635.347 1298.91 635.108 1300.48 635.108C1301.57 635.108 1302.62 635.236 1303.61 635.491C1304.62 635.747 1305.51 636.143 1306.28 636.68C1307.07 637.217 1307.69 637.908 1308.14 638.751C1308.59 639.587 1308.82 640.588 1308.82 641.756V655H1303.65V652.277H1303.5C1303.18 652.891 1302.76 653.432 1302.23 653.901C1301.7 654.361 1301.07 654.723 1300.33 654.987C1299.59 655.243 1298.73 655.371 1297.76 655.371ZM1299.32 651.612C1300.12 651.612 1300.83 651.455 1301.44 651.139C1302.05 650.815 1302.53 650.381 1302.88 649.835C1303.23 649.29 1303.41 648.672 1303.41 647.982V645.898C1303.24 646.009 1303 646.111 1302.7 646.205C1302.41 646.29 1302.09 646.371 1301.72 646.447C1301.35 646.516 1300.99 646.58 1300.62 646.639C1300.25 646.69 1299.92 646.737 1299.62 646.78C1298.98 646.874 1298.43 647.023 1297.95 647.227C1297.47 647.432 1297.1 647.709 1296.84 648.058C1296.57 648.399 1296.44 648.825 1296.44 649.337C1296.44 650.078 1296.71 650.645 1297.25 651.037C1297.79 651.42 1298.48 651.612 1299.32 651.612ZM1317.77 643.648V655H1312.32V635.364H1317.51V638.828H1317.74C1318.18 637.686 1318.9 636.783 1319.93 636.118C1320.95 635.445 1322.19 635.108 1323.65 635.108C1325.01 635.108 1326.2 635.406 1327.21 636.003C1328.23 636.599 1329.02 637.452 1329.58 638.56C1330.14 639.659 1330.42 640.972 1330.42 642.497V655H1324.98V643.469C1324.99 642.267 1324.68 641.33 1324.06 640.656C1323.43 639.974 1322.58 639.634 1321.49 639.634C1320.75 639.634 1320.11 639.791 1319.54 640.107C1318.99 640.422 1318.55 640.882 1318.24 641.487C1317.93 642.084 1317.78 642.804 1317.77 643.648ZM1342.87 655.384C1340.86 655.384 1339.13 654.957 1337.68 654.105C1336.24 653.244 1335.13 652.051 1334.35 650.526C1333.59 649 1333.2 647.244 1333.2 645.259C1333.2 643.247 1333.59 641.483 1334.37 639.966C1335.15 638.44 1336.26 637.251 1337.7 636.399C1339.14 635.538 1340.86 635.108 1342.84 635.108C1344.55 635.108 1346.05 635.419 1347.34 636.041C1348.63 636.663 1349.65 637.537 1350.4 638.662C1351.15 639.787 1351.56 641.108 1351.64 642.625H1346.5C1346.35 641.645 1345.97 640.857 1345.35 640.26C1344.73 639.655 1343.93 639.352 1342.93 639.352C1342.09 639.352 1341.35 639.582 1340.72 640.043C1340.1 640.494 1339.61 641.155 1339.26 642.024C1338.91 642.893 1338.74 643.946 1338.74 645.182C1338.74 646.435 1338.91 647.5 1339.25 648.378C1339.6 649.256 1340.09 649.925 1340.72 650.385C1341.35 650.845 1342.09 651.075 1342.93 651.075C1343.55 651.075 1344.11 650.947 1344.61 650.692C1345.11 650.436 1345.52 650.065 1345.85 649.58C1346.18 649.085 1346.4 648.493 1346.5 647.803H1351.64C1351.55 649.303 1351.14 650.624 1350.41 651.766C1349.69 652.899 1348.68 653.786 1347.41 654.425C1346.13 655.064 1344.61 655.384 1342.87 655.384ZM1363.35 655.384C1361.33 655.384 1359.59 654.974 1358.14 654.156C1356.69 653.33 1355.57 652.162 1354.79 650.653C1354 649.136 1353.61 647.342 1353.61 645.271C1353.61 643.251 1354 641.479 1354.79 639.953C1355.57 638.428 1356.68 637.239 1358.1 636.386C1359.53 635.534 1361.21 635.108 1363.14 635.108C1364.43 635.108 1365.64 635.317 1366.75 635.734C1367.88 636.143 1368.86 636.761 1369.69 637.588C1370.54 638.415 1371.19 639.455 1371.66 640.707C1372.13 641.952 1372.37 643.409 1372.37 645.08V646.575H1355.78V643.2H1367.24C1367.24 642.416 1367.07 641.722 1366.73 641.116C1366.39 640.511 1365.91 640.038 1365.31 639.697C1364.71 639.348 1364.02 639.173 1363.23 639.173C1362.4 639.173 1361.67 639.365 1361.03 639.749C1360.4 640.124 1359.9 640.631 1359.54 641.27C1359.19 641.901 1359 642.604 1358.99 643.379V646.588C1358.99 647.56 1359.17 648.399 1359.53 649.107C1359.9 649.814 1360.41 650.359 1361.08 650.743C1361.74 651.126 1362.53 651.318 1363.44 651.318C1364.05 651.318 1364.6 651.233 1365.1 651.062C1365.61 650.892 1366.04 650.636 1366.4 650.295C1366.75 649.955 1367.03 649.537 1367.21 649.043L1372.25 649.375C1371.99 650.585 1371.47 651.642 1370.68 652.545C1369.89 653.44 1368.88 654.139 1367.64 654.642C1366.4 655.136 1364.97 655.384 1363.35 655.384ZM1146.01 703.32C1144.52 703.32 1143.17 702.936 1141.96 702.169C1140.75 701.393 1139.8 700.256 1139.09 698.756C1138.39 697.247 1138.04 695.398 1138.04 693.207C1138.04 690.957 1138.41 689.087 1139.13 687.595C1139.86 686.095 1140.82 684.974 1142.02 684.233C1143.23 683.483 1144.56 683.108 1146 683.108C1147.1 683.108 1148.01 683.295 1148.74 683.67C1149.49 684.037 1150.08 684.497 1150.53 685.051C1150.99 685.597 1151.34 686.134 1151.58 686.662H1151.75V676.818H1157.18V703H1151.81V699.855H1151.58C1151.33 700.401 1150.96 700.942 1150.5 701.479C1150.04 702.007 1149.44 702.446 1148.69 702.795C1147.96 703.145 1147.07 703.32 1146.01 703.32ZM1147.73 698.986C1148.61 698.986 1149.35 698.747 1149.96 698.27C1150.57 697.784 1151.04 697.107 1151.37 696.237C1151.7 695.368 1151.86 694.349 1151.86 693.182C1151.86 692.014 1151.7 691 1151.38 690.139C1151.05 689.278 1150.59 688.614 1149.97 688.145C1149.36 687.676 1148.61 687.442 1147.73 687.442C1146.84 687.442 1146.09 687.685 1145.47 688.17C1144.86 688.656 1144.39 689.33 1144.08 690.19C1143.76 691.051 1143.61 692.048 1143.61 693.182C1143.61 694.324 1143.76 695.334 1144.08 696.212C1144.4 697.081 1144.87 697.763 1145.47 698.257C1146.09 698.743 1146.84 698.986 1147.73 698.986ZM1160.94 703V683.364H1166.39V703H1160.94ZM1163.68 680.832C1162.87 680.832 1162.17 680.564 1161.59 680.027C1161.02 679.482 1160.74 678.83 1160.74 678.071C1160.74 677.321 1161.02 676.678 1161.59 676.141C1162.17 675.595 1162.87 675.322 1163.68 675.322C1164.49 675.322 1165.18 675.595 1165.75 676.141C1166.33 676.678 1166.62 677.321 1166.62 678.071C1166.62 678.83 1166.33 679.482 1165.75 680.027C1165.18 680.564 1164.49 680.832 1163.68 680.832ZM1186.37 688.963L1181.38 689.27C1181.3 688.844 1181.11 688.46 1180.83 688.119C1180.55 687.77 1180.18 687.493 1179.72 687.288C1179.27 687.075 1178.73 686.969 1178.1 686.969C1177.25 686.969 1176.54 687.148 1175.96 687.506C1175.38 687.855 1175.09 688.324 1175.09 688.912C1175.09 689.381 1175.28 689.777 1175.65 690.101C1176.03 690.425 1176.67 690.685 1177.58 690.881L1181.14 691.597C1183.05 691.989 1184.47 692.619 1185.41 693.489C1186.35 694.358 1186.81 695.5 1186.81 696.915C1186.81 698.202 1186.43 699.331 1185.68 700.303C1184.93 701.274 1183.89 702.033 1182.58 702.578C1181.28 703.115 1179.77 703.384 1178.07 703.384C1175.47 703.384 1173.4 702.842 1171.86 701.76C1170.32 700.669 1169.42 699.186 1169.16 697.311L1174.52 697.03C1174.68 697.822 1175.07 698.428 1175.69 698.845C1176.31 699.254 1177.11 699.459 1178.08 699.459C1179.04 699.459 1179.8 699.276 1180.38 698.909C1180.97 698.534 1181.27 698.053 1181.28 697.464C1181.27 696.97 1181.06 696.565 1180.65 696.25C1180.24 695.926 1179.61 695.679 1178.76 695.509L1175.36 694.831C1173.44 694.447 1172.01 693.783 1171.08 692.837C1170.15 691.891 1169.68 690.685 1169.68 689.219C1169.68 687.957 1170.02 686.871 1170.71 685.959C1171.4 685.047 1172.36 684.344 1173.61 683.849C1174.86 683.355 1176.33 683.108 1178.01 683.108C1180.49 683.108 1182.44 683.632 1183.86 684.68C1185.29 685.729 1186.13 687.156 1186.37 688.963ZM1199.97 683.364V687.455H1188.14V683.364H1199.97ZM1190.83 678.659H1196.27V696.966C1196.27 697.469 1196.35 697.861 1196.5 698.142C1196.66 698.415 1196.87 698.607 1197.14 698.717C1197.42 698.828 1197.75 698.884 1198.11 698.884C1198.37 698.884 1198.63 698.862 1198.88 698.82C1199.14 698.768 1199.33 698.73 1199.47 698.705L1200.33 702.757C1200.05 702.842 1199.67 702.94 1199.18 703.051C1198.68 703.17 1198.08 703.243 1197.37 703.268C1196.06 703.32 1194.91 703.145 1193.92 702.744C1192.94 702.344 1192.18 701.722 1191.63 700.878C1191.09 700.034 1190.82 698.969 1190.83 697.682V678.659ZM1202.8 703V683.364H1208.08V686.79H1208.28C1208.64 685.571 1209.24 684.651 1210.08 684.028C1210.93 683.398 1211.9 683.082 1213 683.082C1213.27 683.082 1213.56 683.099 1213.88 683.134C1214.19 683.168 1214.47 683.214 1214.71 683.274V688.107C1214.45 688.03 1214.1 687.962 1213.65 687.902C1213.2 687.842 1212.78 687.812 1212.41 687.812C1211.61 687.812 1210.89 687.987 1210.26 688.337C1209.64 688.678 1209.14 689.155 1208.78 689.768C1208.42 690.382 1208.24 691.089 1208.24 691.891V703H1202.8ZM1216.81 703V683.364H1222.25V703H1216.81ZM1219.54 680.832C1218.73 680.832 1218.04 680.564 1217.46 680.027C1216.89 679.482 1216.6 678.83 1216.6 678.071C1216.6 677.321 1216.89 676.678 1217.46 676.141C1218.04 675.595 1218.73 675.322 1219.54 675.322C1220.35 675.322 1221.04 675.595 1221.61 676.141C1222.19 676.678 1222.48 677.321 1222.48 678.071C1222.48 678.83 1222.19 679.482 1221.61 680.027C1221.04 680.564 1220.35 680.832 1219.54 680.832ZM1226 703V676.818H1231.44V686.662H1231.61C1231.85 686.134 1232.19 685.597 1232.64 685.051C1233.1 684.497 1233.7 684.037 1234.43 683.67C1235.18 683.295 1236.1 683.108 1237.2 683.108C1238.63 683.108 1239.95 683.483 1241.16 684.233C1242.37 684.974 1243.34 686.095 1244.06 687.595C1244.79 689.087 1245.15 690.957 1245.15 693.207C1245.15 695.398 1244.79 697.247 1244.09 698.756C1243.39 700.256 1242.43 701.393 1241.22 702.169C1240.02 702.936 1238.67 703.32 1237.18 703.32C1236.13 703.32 1235.23 703.145 1234.49 702.795C1233.75 702.446 1233.15 702.007 1232.68 701.479C1232.21 700.942 1231.86 700.401 1231.61 699.855H1231.37V703H1226ZM1231.33 693.182C1231.33 694.349 1231.49 695.368 1231.81 696.237C1232.14 697.107 1232.61 697.784 1233.22 698.27C1233.83 698.747 1234.58 698.986 1235.46 698.986C1236.34 698.986 1237.09 698.743 1237.71 698.257C1238.32 697.763 1238.79 697.081 1239.1 696.212C1239.42 695.334 1239.59 694.324 1239.59 693.182C1239.59 692.048 1239.43 691.051 1239.11 690.19C1238.8 689.33 1238.33 688.656 1237.72 688.17C1237.11 687.685 1236.35 687.442 1235.46 687.442C1234.57 687.442 1233.82 687.676 1233.21 688.145C1232.6 688.614 1232.14 689.278 1231.81 690.139C1231.49 691 1231.33 692.014 1231.33 693.182ZM1260.65 694.639V683.364H1266.1V703H1260.87V699.433H1260.67C1260.22 700.584 1259.49 701.509 1258.45 702.207C1257.43 702.906 1256.18 703.256 1254.71 703.256C1253.4 703.256 1252.24 702.957 1251.24 702.361C1250.25 701.764 1249.47 700.916 1248.91 699.817C1248.35 698.717 1248.07 697.401 1248.06 695.866V683.364H1253.51V694.895C1253.52 696.054 1253.83 696.97 1254.44 697.643C1255.05 698.317 1255.88 698.653 1256.91 698.653C1257.56 698.653 1258.18 698.504 1258.75 698.206C1259.32 697.899 1259.78 697.447 1260.13 696.851C1260.49 696.254 1260.66 695.517 1260.65 694.639ZM1280.18 683.364V687.455H1268.36V683.364H1280.18ZM1271.04 678.659H1276.49V696.966C1276.49 697.469 1276.56 697.861 1276.72 698.142C1276.87 698.415 1277.08 698.607 1277.36 698.717C1277.64 698.828 1277.96 698.884 1278.33 698.884C1278.58 698.884 1278.84 698.862 1279.09 698.82C1279.35 698.768 1279.55 698.73 1279.68 698.705L1280.54 702.757C1280.27 702.842 1279.88 702.94 1279.39 703.051C1278.89 703.17 1278.29 703.243 1277.59 703.268C1276.27 703.32 1275.12 703.145 1274.13 702.744C1273.15 702.344 1272.39 701.722 1271.85 700.878C1271.3 700.034 1271.03 698.969 1271.04 697.682V678.659ZM1283.01 703V683.364H1288.45V703H1283.01ZM1285.74 680.832C1284.93 680.832 1284.24 680.564 1283.66 680.027C1283.09 679.482 1282.8 678.83 1282.8 678.071C1282.8 677.321 1283.09 676.678 1283.66 676.141C1284.24 675.595 1284.93 675.322 1285.74 675.322C1286.55 675.322 1287.24 675.595 1287.81 676.141C1288.39 676.678 1288.68 677.321 1288.68 678.071C1288.68 678.83 1288.39 679.482 1287.81 680.027C1287.24 680.564 1286.55 680.832 1285.74 680.832ZM1300.97 703.384C1298.98 703.384 1297.27 702.962 1295.82 702.118C1294.38 701.266 1293.26 700.081 1292.48 698.564C1291.7 697.038 1291.3 695.27 1291.3 693.259C1291.3 691.23 1291.7 689.457 1292.48 687.94C1293.26 686.415 1294.38 685.23 1295.82 684.386C1297.27 683.534 1298.98 683.108 1300.97 683.108C1302.95 683.108 1304.67 683.534 1306.11 684.386C1307.56 685.23 1308.67 686.415 1309.46 687.94C1310.24 689.457 1310.63 691.23 1310.63 693.259C1310.63 695.27 1310.24 697.038 1309.46 698.564C1308.67 700.081 1307.56 701.266 1306.11 702.118C1304.67 702.962 1302.95 703.384 1300.97 703.384ZM1300.99 699.165C1301.9 699.165 1302.65 698.909 1303.26 698.398C1303.86 697.878 1304.32 697.17 1304.62 696.276C1304.94 695.381 1305.1 694.362 1305.1 693.22C1305.1 692.078 1304.94 691.06 1304.62 690.165C1304.32 689.27 1303.86 688.562 1303.26 688.043C1302.65 687.523 1301.9 687.263 1300.99 687.263C1300.08 687.263 1299.32 687.523 1298.69 688.043C1298.08 688.562 1297.62 689.27 1297.3 690.165C1296.99 691.06 1296.84 692.078 1296.84 693.22C1296.84 694.362 1296.99 695.381 1297.3 696.276C1297.62 697.17 1298.08 697.878 1298.69 698.398C1299.32 698.909 1300.08 699.165 1300.99 699.165ZM1318.9 691.648V703H1313.45V683.364H1318.65V686.828H1318.88C1319.31 685.686 1320.04 684.783 1321.06 684.118C1322.08 683.445 1323.32 683.108 1324.78 683.108C1326.15 683.108 1327.33 683.406 1328.35 684.003C1329.36 684.599 1330.15 685.452 1330.71 686.56C1331.28 687.659 1331.56 688.972 1331.56 690.497V703H1326.11V691.469C1326.12 690.267 1325.81 689.33 1325.19 688.656C1324.57 687.974 1323.71 687.634 1322.62 687.634C1321.89 687.634 1321.24 687.791 1320.68 688.107C1320.12 688.422 1319.69 688.882 1319.37 689.487C1319.07 690.084 1318.91 690.804 1318.9 691.648ZM1353.3 683.364V687.455H1341.18V683.364H1353.3ZM1343.96 703V681.945C1343.96 680.521 1344.23 679.341 1344.79 678.403C1345.35 677.466 1346.12 676.763 1347.09 676.294C1348.06 675.825 1349.16 675.591 1350.4 675.591C1351.23 675.591 1352 675.655 1352.69 675.783C1353.39 675.911 1353.91 676.026 1354.25 676.128L1353.28 680.219C1353.06 680.151 1352.8 680.087 1352.48 680.027C1352.18 679.967 1351.86 679.938 1351.54 679.938C1350.74 679.938 1350.18 680.125 1349.86 680.5C1349.55 680.866 1349.39 681.382 1349.39 682.047V703H1343.96ZM1364.08 703.384C1362.09 703.384 1360.37 702.962 1358.93 702.118C1357.48 701.266 1356.37 700.081 1355.59 698.564C1354.8 697.038 1354.41 695.27 1354.41 693.259C1354.41 691.23 1354.8 689.457 1355.59 687.94C1356.37 686.415 1357.48 685.23 1358.93 684.386C1360.37 683.534 1362.09 683.108 1364.08 683.108C1366.06 683.108 1367.78 683.534 1369.22 684.386C1370.67 685.23 1371.78 686.415 1372.57 687.94C1373.35 689.457 1373.74 691.23 1373.74 693.259C1373.74 695.27 1373.35 697.038 1372.57 698.564C1371.78 700.081 1370.67 701.266 1369.22 702.118C1367.78 702.962 1366.06 703.384 1364.08 703.384ZM1364.1 699.165C1365.01 699.165 1365.76 698.909 1366.37 698.398C1366.97 697.878 1367.43 697.17 1367.73 696.276C1368.05 695.381 1368.21 694.362 1368.21 693.22C1368.21 692.078 1368.05 691.06 1367.73 690.165C1367.43 689.27 1366.97 688.562 1366.37 688.043C1365.76 687.523 1365.01 687.263 1364.1 687.263C1363.19 687.263 1362.42 687.523 1361.8 688.043C1361.19 688.562 1360.72 689.27 1360.41 690.165C1360.1 691.06 1359.95 692.078 1359.95 693.22C1359.95 694.362 1360.1 695.381 1360.41 696.276C1360.72 697.17 1361.19 697.878 1361.8 698.398C1362.42 698.909 1363.19 699.165 1364.1 699.165ZM1376.56 703V683.364H1381.84V686.79H1382.05C1382.41 685.571 1383.01 684.651 1383.85 684.028C1384.69 683.398 1385.67 683.082 1386.76 683.082C1387.04 683.082 1387.33 683.099 1387.65 683.134C1387.96 683.168 1388.24 683.214 1388.48 683.274V688.107C1388.22 688.03 1387.87 687.962 1387.42 687.902C1386.96 687.842 1386.55 687.812 1386.18 687.812C1385.38 687.812 1384.66 687.987 1384.03 688.337C1383.41 688.678 1382.91 689.155 1382.55 689.768C1382.19 690.382 1382.01 691.089 1382.01 691.891V703H1376.56Z" fill="black"/>
+<path d="M1140.14 758.364V731.364H1145.51V734.662H1145.75C1145.99 734.134 1146.33 733.597 1146.78 733.051C1147.24 732.497 1147.84 732.037 1148.57 731.67C1149.32 731.295 1150.24 731.108 1151.34 731.108C1152.77 731.108 1154.09 731.483 1155.3 732.233C1156.51 732.974 1157.48 734.095 1158.2 735.595C1158.92 737.087 1159.29 738.957 1159.29 741.207C1159.29 743.398 1158.93 745.247 1158.23 746.756C1157.53 748.256 1156.57 749.393 1155.36 750.169C1154.16 750.936 1152.81 751.32 1151.32 751.32C1150.27 751.32 1149.37 751.145 1148.63 750.795C1147.89 750.446 1147.29 750.007 1146.82 749.479C1146.35 748.942 1146 748.401 1145.75 747.855H1145.58V758.364H1140.14ZM1145.47 741.182C1145.47 742.349 1145.63 743.368 1145.95 744.237C1146.28 745.107 1146.75 745.784 1147.36 746.27C1147.97 746.747 1148.72 746.986 1149.6 746.986C1150.48 746.986 1151.23 746.743 1151.85 746.257C1152.46 745.763 1152.92 745.081 1153.24 744.212C1153.56 743.334 1153.73 742.324 1153.73 741.182C1153.73 740.048 1153.57 739.051 1153.25 738.19C1152.94 737.33 1152.47 736.656 1151.86 736.17C1151.25 735.685 1150.49 735.442 1149.6 735.442C1148.71 735.442 1147.96 735.676 1147.35 736.145C1146.74 736.614 1146.28 737.278 1145.95 738.139C1145.63 739 1145.47 740.014 1145.47 741.182ZM1171.15 751.384C1169.13 751.384 1167.39 750.974 1165.93 750.156C1164.48 749.33 1163.37 748.162 1162.58 746.653C1161.8 745.136 1161.41 743.342 1161.41 741.271C1161.41 739.251 1161.8 737.479 1162.58 735.953C1163.37 734.428 1164.47 733.239 1165.89 732.386C1167.32 731.534 1169 731.108 1170.93 731.108C1172.22 731.108 1173.43 731.317 1174.55 731.734C1175.67 732.143 1176.65 732.761 1177.49 733.588C1178.33 734.415 1178.99 735.455 1179.46 736.707C1179.93 737.952 1180.16 739.409 1180.16 741.08V742.575H1163.58V739.2H1175.03C1175.03 738.416 1174.86 737.722 1174.52 737.116C1174.18 736.511 1173.71 736.038 1173.1 735.697C1172.51 735.348 1171.81 735.173 1171.02 735.173C1170.19 735.173 1169.46 735.365 1168.82 735.749C1168.19 736.124 1167.69 736.631 1167.34 737.27C1166.98 737.901 1166.8 738.604 1166.79 739.379V742.588C1166.79 743.56 1166.97 744.399 1167.32 745.107C1167.69 745.814 1168.21 746.359 1168.87 746.743C1169.54 747.126 1170.32 747.318 1171.24 747.318C1171.84 747.318 1172.4 747.233 1172.9 747.062C1173.4 746.892 1173.83 746.636 1174.19 746.295C1174.55 745.955 1174.82 745.537 1175.01 745.043L1180.04 745.375C1179.79 746.585 1179.26 747.642 1178.47 748.545C1177.69 749.44 1176.67 750.139 1175.43 750.642C1174.19 751.136 1172.77 751.384 1171.15 751.384ZM1182.99 751V731.364H1188.27V734.79H1188.48C1188.84 733.571 1189.44 732.651 1190.28 732.028C1191.12 731.398 1192.1 731.082 1193.2 731.082C1193.47 731.082 1193.76 731.099 1194.08 731.134C1194.39 731.168 1194.67 731.214 1194.91 731.274V736.107C1194.65 736.03 1194.3 735.962 1193.85 735.902C1193.4 735.842 1192.98 735.812 1192.61 735.812C1191.81 735.812 1191.09 735.987 1190.46 736.337C1189.84 736.678 1189.34 737.155 1188.98 737.768C1188.62 738.382 1188.44 739.089 1188.44 739.891V751H1182.99ZM1208.43 731.364V735.455H1196.61V731.364H1208.43ZM1199.29 726.659H1204.74V744.966C1204.74 745.469 1204.81 745.861 1204.97 746.142C1205.12 746.415 1205.33 746.607 1205.61 746.717C1205.89 746.828 1206.21 746.884 1206.58 746.884C1206.83 746.884 1207.09 746.862 1207.35 746.82C1207.6 746.768 1207.8 746.73 1207.93 746.705L1208.79 750.757C1208.52 750.842 1208.13 750.94 1207.64 751.051C1207.15 751.17 1206.55 751.243 1205.84 751.268C1204.53 751.32 1203.37 751.145 1202.39 750.744C1201.41 750.344 1200.64 749.722 1200.1 748.878C1199.55 748.034 1199.28 746.969 1199.29 745.682V726.659ZM1223.85 742.639V731.364H1229.3V751H1224.07V747.433H1223.87C1223.42 748.584 1222.69 749.509 1221.65 750.207C1220.63 750.906 1219.38 751.256 1217.91 751.256C1216.6 751.256 1215.44 750.957 1214.44 750.361C1213.45 749.764 1212.67 748.916 1212.1 747.817C1211.55 746.717 1211.27 745.401 1211.26 743.866V731.364H1216.71V742.895C1216.71 744.054 1217.03 744.97 1217.64 745.643C1218.25 746.317 1219.08 746.653 1220.11 746.653C1220.76 746.653 1221.38 746.504 1221.95 746.206C1222.52 745.899 1222.98 745.447 1223.33 744.851C1223.69 744.254 1223.86 743.517 1223.85 742.639ZM1232.93 751V731.364H1238.21V734.79H1238.42C1238.78 733.571 1239.38 732.651 1240.22 732.028C1241.07 731.398 1242.04 731.082 1243.14 731.082C1243.41 731.082 1243.7 731.099 1244.02 731.134C1244.33 731.168 1244.61 731.214 1244.85 731.274V736.107C1244.59 736.03 1244.24 735.962 1243.79 735.902C1243.34 735.842 1242.92 735.812 1242.55 735.812C1241.75 735.812 1241.03 735.987 1240.4 736.337C1239.78 736.678 1239.28 737.155 1238.92 737.768C1238.56 738.382 1238.38 739.089 1238.38 739.891V751H1232.93ZM1247.05 751V724.818H1252.49V734.662H1252.66C1252.9 734.134 1253.24 733.597 1253.7 733.051C1254.16 732.497 1254.75 732.037 1255.49 731.67C1256.23 731.295 1257.15 731.108 1258.25 731.108C1259.68 731.108 1261 731.483 1262.21 732.233C1263.42 732.974 1264.39 734.095 1265.11 735.595C1265.84 737.087 1266.2 738.957 1266.2 741.207C1266.2 743.398 1265.84 745.247 1265.14 746.756C1264.44 748.256 1263.48 749.393 1262.27 750.169C1261.07 750.936 1259.73 751.32 1258.23 751.32C1257.18 751.32 1256.28 751.145 1255.54 750.795C1254.8 750.446 1254.2 750.007 1253.73 749.479C1253.27 748.942 1252.91 748.401 1252.66 747.855H1252.42V751H1247.05ZM1252.38 741.182C1252.38 742.349 1252.54 743.368 1252.86 744.237C1253.19 745.107 1253.66 745.784 1254.27 746.27C1254.88 746.747 1255.63 746.986 1256.51 746.986C1257.39 746.986 1258.14 746.743 1258.76 746.257C1259.37 745.763 1259.84 745.081 1260.15 744.212C1260.48 743.334 1260.64 742.324 1260.64 741.182C1260.64 740.048 1260.48 739.051 1260.16 738.19C1259.85 737.33 1259.38 736.656 1258.77 736.17C1258.16 735.685 1257.4 735.442 1256.51 735.442C1255.62 735.442 1254.87 735.676 1254.26 736.145C1253.65 736.614 1253.19 737.278 1252.86 738.139C1252.54 739 1252.38 740.014 1252.38 741.182ZM1274.71 751.371C1273.46 751.371 1272.34 751.153 1271.36 750.719C1270.38 750.276 1269.61 749.624 1269.04 748.763C1268.47 747.893 1268.19 746.811 1268.19 745.516C1268.19 744.425 1268.39 743.509 1268.79 742.767C1269.19 742.026 1269.74 741.429 1270.43 740.977C1271.12 740.526 1271.9 740.185 1272.78 739.955C1273.67 739.724 1274.6 739.562 1275.57 739.469C1276.71 739.349 1277.63 739.239 1278.33 739.136C1279.03 739.026 1279.54 738.864 1279.85 738.651C1280.17 738.437 1280.32 738.122 1280.32 737.705V737.628C1280.32 736.818 1280.07 736.192 1279.56 735.749C1279.05 735.305 1278.34 735.084 1277.41 735.084C1276.43 735.084 1275.65 735.301 1275.07 735.736C1274.49 736.162 1274.11 736.699 1273.92 737.347L1268.88 736.938C1269.14 735.744 1269.64 734.713 1270.39 733.844C1271.14 732.966 1272.11 732.293 1273.29 731.824C1274.49 731.347 1275.87 731.108 1277.43 731.108C1278.53 731.108 1279.57 731.236 1280.57 731.491C1281.57 731.747 1282.46 732.143 1283.24 732.68C1284.02 733.217 1284.64 733.908 1285.09 734.751C1285.54 735.587 1285.77 736.588 1285.77 737.756V751H1280.61V748.277H1280.45C1280.14 748.891 1279.71 749.432 1279.19 749.901C1278.66 750.361 1278.02 750.723 1277.28 750.987C1276.54 751.243 1275.68 751.371 1274.71 751.371ZM1276.27 747.612C1277.07 747.612 1277.78 747.455 1278.39 747.139C1279.01 746.815 1279.49 746.381 1279.84 745.835C1280.19 745.29 1280.36 744.672 1280.36 743.982V741.898C1280.19 742.009 1279.96 742.111 1279.66 742.205C1279.37 742.29 1279.04 742.371 1278.67 742.447C1278.31 742.516 1277.94 742.58 1277.58 742.639C1277.21 742.69 1276.88 742.737 1276.58 742.78C1275.94 742.874 1275.38 743.023 1274.9 743.227C1274.43 743.432 1274.06 743.709 1273.79 744.058C1273.53 744.399 1273.39 744.825 1273.39 745.337C1273.39 746.078 1273.66 746.645 1274.2 747.037C1274.75 747.42 1275.44 747.612 1276.27 747.612ZM1299.72 731.364V735.455H1287.89V731.364H1299.72ZM1290.58 726.659H1296.02V744.966C1296.02 745.469 1296.1 745.861 1296.26 746.142C1296.41 746.415 1296.62 746.607 1296.89 746.717C1297.18 746.828 1297.5 746.884 1297.87 746.884C1298.12 746.884 1298.38 746.862 1298.63 746.82C1298.89 746.768 1299.08 746.73 1299.22 746.705L1300.08 750.757C1299.8 750.842 1299.42 750.94 1298.93 751.051C1298.43 751.17 1297.83 751.243 1297.12 751.268C1295.81 751.32 1294.66 751.145 1293.67 750.744C1292.69 750.344 1291.93 749.722 1291.38 748.878C1290.84 748.034 1290.57 746.969 1290.58 745.682V726.659ZM1302.55 751V731.364H1307.99V751H1302.55ZM1305.28 728.832C1304.47 728.832 1303.78 728.564 1303.2 728.027C1302.63 727.482 1302.34 726.83 1302.34 726.071C1302.34 725.321 1302.63 724.678 1303.2 724.141C1303.78 723.595 1304.47 723.322 1305.28 723.322C1306.09 723.322 1306.78 723.595 1307.35 724.141C1307.93 724.678 1308.22 725.321 1308.22 726.071C1308.22 726.83 1307.93 727.482 1307.35 728.027C1306.78 728.564 1306.09 728.832 1305.28 728.832ZM1320.51 751.384C1318.52 751.384 1316.8 750.962 1315.36 750.118C1313.92 749.266 1312.8 748.081 1312.02 746.564C1311.24 745.038 1310.84 743.27 1310.84 741.259C1310.84 739.23 1311.24 737.457 1312.02 735.94C1312.8 734.415 1313.92 733.23 1315.36 732.386C1316.8 731.534 1318.52 731.108 1320.51 731.108C1322.49 731.108 1324.21 731.534 1325.65 732.386C1327.1 733.23 1328.21 734.415 1329 735.94C1329.78 737.457 1330.17 739.23 1330.17 741.259C1330.17 743.27 1329.78 745.038 1329 746.564C1328.21 748.081 1327.1 749.266 1325.65 750.118C1324.21 750.962 1322.49 751.384 1320.51 751.384ZM1320.53 747.165C1321.44 747.165 1322.19 746.909 1322.8 746.398C1323.4 745.878 1323.86 745.17 1324.16 744.276C1324.48 743.381 1324.64 742.362 1324.64 741.22C1324.64 740.078 1324.48 739.06 1324.16 738.165C1323.86 737.27 1323.4 736.562 1322.8 736.043C1322.19 735.523 1321.44 735.263 1320.53 735.263C1319.62 735.263 1318.85 735.523 1318.23 736.043C1317.62 736.562 1317.15 737.27 1316.84 738.165C1316.53 739.06 1316.38 740.078 1316.38 741.22C1316.38 742.362 1316.53 743.381 1316.84 744.276C1317.15 745.17 1317.62 745.878 1318.23 746.398C1318.85 746.909 1319.62 747.165 1320.53 747.165ZM1338.44 739.648V751H1332.99V731.364H1338.18V734.828H1338.41C1338.85 733.686 1339.58 732.783 1340.6 732.118C1341.62 731.445 1342.86 731.108 1344.32 731.108C1345.68 731.108 1346.87 731.406 1347.89 732.003C1348.9 732.599 1349.69 733.452 1350.25 734.56C1350.81 735.659 1351.1 736.972 1351.1 738.497V751H1345.65V739.469C1345.66 738.267 1345.35 737.33 1344.73 736.656C1344.11 735.974 1343.25 735.634 1342.16 735.634C1341.43 735.634 1340.78 735.791 1340.22 736.107C1339.66 736.422 1339.23 736.882 1338.91 737.487C1338.61 738.084 1338.45 738.804 1338.44 739.648ZM1366.9 751H1360.96L1370 724.818H1377.14L1386.16 751H1380.23L1373.67 730.801H1373.47L1366.9 751ZM1366.52 740.709H1380.54V745.03H1366.52V740.709Z" fill="#E6711C"/>
+<path d="M1673.25 655V628.818H1683.58C1685.56 628.818 1687.26 629.197 1688.65 629.956C1690.05 630.706 1691.12 631.75 1691.85 633.088C1692.59 634.418 1692.96 635.952 1692.96 637.69C1692.96 639.429 1692.59 640.963 1691.84 642.293C1691.09 643.622 1690 644.658 1688.58 645.399C1687.16 646.141 1685.45 646.511 1683.44 646.511H1676.85V642.075H1682.54C1683.61 642.075 1684.49 641.892 1685.18 641.526C1685.88 641.151 1686.4 640.635 1686.74 639.979C1687.09 639.314 1687.26 638.551 1687.26 637.69C1687.26 636.821 1687.09 636.062 1686.74 635.415C1686.4 634.759 1685.88 634.251 1685.18 633.893C1684.48 633.527 1683.59 633.344 1682.52 633.344H1678.78V655H1673.25ZM1704.37 655.384C1702.35 655.384 1700.61 654.974 1699.15 654.156C1697.7 653.33 1696.59 652.162 1695.8 650.653C1695.02 649.136 1694.63 647.342 1694.63 645.271C1694.63 643.251 1695.02 641.479 1695.8 639.953C1696.59 638.428 1697.69 637.239 1699.11 636.386C1700.55 635.534 1702.22 635.108 1704.15 635.108C1705.45 635.108 1706.65 635.317 1707.77 635.734C1708.89 636.143 1709.87 636.761 1710.71 637.588C1711.55 638.415 1712.21 639.455 1712.68 640.707C1713.15 641.952 1713.38 643.409 1713.38 645.08V646.575H1696.8V643.2H1708.25C1708.25 642.416 1708.08 641.722 1707.74 641.116C1707.4 640.511 1706.93 640.038 1706.32 639.697C1705.73 639.348 1705.03 639.173 1704.24 639.173C1703.41 639.173 1702.68 639.365 1702.04 639.749C1701.41 640.124 1700.92 640.631 1700.56 641.27C1700.2 641.901 1700.02 642.604 1700.01 643.379V646.588C1700.01 647.56 1700.19 648.399 1700.55 649.107C1700.91 649.814 1701.43 650.359 1702.09 650.743C1702.76 651.126 1703.55 651.318 1704.46 651.318C1705.06 651.318 1705.62 651.233 1706.12 651.062C1706.62 650.892 1707.05 650.636 1707.41 650.295C1707.77 649.955 1708.04 649.537 1708.23 649.043L1713.27 649.375C1713.01 650.585 1712.49 651.642 1711.69 652.545C1710.91 653.44 1709.9 654.139 1708.65 654.642C1707.41 655.136 1705.99 655.384 1704.37 655.384ZM1716.21 655V635.364H1721.49V638.79H1721.7C1722.06 637.571 1722.66 636.651 1723.5 636.028C1724.35 635.398 1725.32 635.082 1726.42 635.082C1726.69 635.082 1726.98 635.099 1727.3 635.134C1727.61 635.168 1727.89 635.214 1728.13 635.274V640.107C1727.87 640.03 1727.52 639.962 1727.07 639.902C1726.62 639.842 1726.2 639.812 1725.83 639.812C1725.03 639.812 1724.31 639.987 1723.68 640.337C1723.06 640.678 1722.56 641.155 1722.2 641.768C1721.84 642.382 1721.66 643.089 1721.66 643.891V655H1716.21ZM1741.77 635.364V639.455H1729.65V635.364H1741.77ZM1732.42 655V633.945C1732.42 632.521 1732.7 631.341 1733.26 630.403C1733.82 629.466 1734.58 628.763 1735.56 628.294C1736.53 627.825 1737.63 627.591 1738.87 627.591C1739.7 627.591 1740.47 627.655 1741.16 627.783C1741.85 627.911 1742.37 628.026 1742.72 628.128L1741.74 632.219C1741.53 632.151 1741.27 632.087 1740.95 632.027C1740.64 631.967 1740.33 631.938 1740.01 631.938C1739.2 631.938 1738.65 632.125 1738.33 632.5C1738.02 632.866 1737.86 633.382 1737.86 634.047V655H1732.42ZM1752.55 655.384C1750.56 655.384 1748.84 654.962 1747.39 654.118C1745.95 653.266 1744.84 652.081 1744.06 650.564C1743.27 649.038 1742.88 647.27 1742.88 645.259C1742.88 643.23 1743.27 641.457 1744.06 639.94C1744.84 638.415 1745.95 637.23 1747.39 636.386C1748.84 635.534 1750.56 635.108 1752.55 635.108C1754.53 635.108 1756.24 635.534 1757.68 636.386C1759.13 637.23 1760.25 638.415 1761.03 639.94C1761.82 641.457 1762.21 643.23 1762.21 645.259C1762.21 647.27 1761.82 649.038 1761.03 650.564C1760.25 652.081 1759.13 653.266 1757.68 654.118C1756.24 654.962 1754.53 655.384 1752.55 655.384ZM1752.57 651.165C1753.47 651.165 1754.23 650.909 1754.83 650.398C1755.44 649.878 1755.89 649.17 1756.2 648.276C1756.52 647.381 1756.67 646.362 1756.67 645.22C1756.67 644.078 1756.52 643.06 1756.2 642.165C1755.89 641.27 1755.44 640.562 1754.83 640.043C1754.23 639.523 1753.47 639.263 1752.57 639.263C1751.66 639.263 1750.89 639.523 1750.27 640.043C1749.66 640.562 1749.19 641.27 1748.88 642.165C1748.57 643.06 1748.42 644.078 1748.42 645.22C1748.42 646.362 1748.57 647.381 1748.88 648.276C1749.19 649.17 1749.66 649.878 1750.27 650.398C1750.89 650.909 1751.66 651.165 1752.57 651.165ZM1765.03 655V635.364H1770.31V638.79H1770.52C1770.87 637.571 1771.47 636.651 1772.32 636.028C1773.16 635.398 1774.13 635.082 1775.23 635.082C1775.51 635.082 1775.8 635.099 1776.12 635.134C1776.43 635.168 1776.71 635.214 1776.95 635.274V640.107C1776.69 640.03 1776.34 639.962 1775.89 639.902C1775.43 639.842 1775.02 639.812 1774.64 639.812C1773.84 639.812 1773.13 639.987 1772.5 640.337C1771.88 640.678 1771.38 641.155 1771.01 641.768C1770.66 642.382 1770.48 643.089 1770.48 643.891V655H1765.03ZM1779.04 655V635.364H1784.23V638.828H1784.46C1784.87 637.678 1785.55 636.77 1786.51 636.105C1787.46 635.44 1788.6 635.108 1789.93 635.108C1791.28 635.108 1792.43 635.445 1793.37 636.118C1794.32 636.783 1794.95 637.686 1795.26 638.828H1795.47C1795.87 637.703 1796.59 636.804 1797.64 636.131C1798.7 635.449 1799.95 635.108 1801.39 635.108C1803.22 635.108 1804.71 635.692 1805.85 636.859C1807 638.018 1807.58 639.663 1807.58 641.794V655H1802.14V642.868C1802.14 641.777 1801.85 640.959 1801.27 640.413C1800.69 639.868 1799.97 639.595 1799.1 639.595C1798.11 639.595 1797.34 639.911 1796.79 640.541C1796.23 641.163 1795.96 641.986 1795.96 643.009V655H1790.68V642.753C1790.68 641.79 1790.4 641.023 1789.84 640.452C1789.3 639.881 1788.58 639.595 1787.68 639.595C1787.08 639.595 1786.53 639.749 1786.05 640.055C1785.57 640.354 1785.19 640.776 1784.91 641.321C1784.63 641.858 1784.49 642.489 1784.49 643.213V655H1779.04ZM1816.76 655.371C1815.5 655.371 1814.39 655.153 1813.41 654.719C1812.43 654.276 1811.65 653.624 1811.08 652.763C1810.52 651.893 1810.24 650.811 1810.24 649.516C1810.24 648.425 1810.44 647.509 1810.84 646.767C1811.24 646.026 1811.78 645.429 1812.47 644.977C1813.16 644.526 1813.95 644.185 1814.83 643.955C1815.71 643.724 1816.64 643.562 1817.61 643.469C1818.76 643.349 1819.68 643.239 1820.38 643.136C1821.07 643.026 1821.58 642.864 1821.9 642.651C1822.21 642.437 1822.37 642.122 1822.37 641.705V641.628C1822.37 640.818 1822.11 640.192 1821.6 639.749C1821.1 639.305 1820.38 639.084 1819.45 639.084C1818.47 639.084 1817.69 639.301 1817.12 639.736C1816.54 640.162 1816.15 640.699 1815.96 641.347L1810.93 640.938C1811.18 639.744 1811.69 638.713 1812.44 637.844C1813.19 636.966 1814.15 636.293 1815.34 635.824C1816.53 635.347 1817.91 635.108 1819.48 635.108C1820.57 635.108 1821.62 635.236 1822.61 635.491C1823.62 635.747 1824.51 636.143 1825.28 636.68C1826.07 637.217 1826.69 637.908 1827.14 638.751C1827.59 639.587 1827.82 640.588 1827.82 641.756V655H1822.65V652.277H1822.5C1822.18 652.891 1821.76 653.432 1821.23 653.901C1820.7 654.361 1820.07 654.723 1819.33 654.987C1818.59 655.243 1817.73 655.371 1816.76 655.371ZM1818.32 651.612C1819.12 651.612 1819.83 651.455 1820.44 651.139C1821.05 650.815 1821.53 650.381 1821.88 649.835C1822.23 649.29 1822.41 648.672 1822.41 647.982V645.898C1822.24 646.009 1822 646.111 1821.7 646.205C1821.41 646.29 1821.09 646.371 1820.72 646.447C1820.35 646.516 1819.99 646.58 1819.62 646.639C1819.25 646.69 1818.92 646.737 1818.62 646.78C1817.98 646.874 1817.43 647.023 1816.95 647.227C1816.47 647.432 1816.1 647.709 1815.84 648.058C1815.57 648.399 1815.44 648.825 1815.44 649.337C1815.44 650.078 1815.71 650.645 1816.25 651.037C1816.79 651.42 1817.48 651.612 1818.32 651.612ZM1836.77 643.648V655H1831.32V635.364H1836.51V638.828H1836.74C1837.18 637.686 1837.9 636.783 1838.93 636.118C1839.95 635.445 1841.19 635.108 1842.65 635.108C1844.01 635.108 1845.2 635.406 1846.21 636.003C1847.23 636.599 1848.02 637.452 1848.58 638.56C1849.14 639.659 1849.42 640.972 1849.42 642.497V655H1843.98V643.469C1843.99 642.267 1843.68 641.33 1843.06 640.656C1842.43 639.974 1841.58 639.634 1840.49 639.634C1839.75 639.634 1839.11 639.791 1838.54 640.107C1837.99 640.422 1837.55 640.882 1837.24 641.487C1836.93 642.084 1836.78 642.804 1836.77 643.648ZM1861.87 655.384C1859.86 655.384 1858.13 654.957 1856.68 654.105C1855.24 653.244 1854.13 652.051 1853.35 650.526C1852.59 649 1852.2 647.244 1852.2 645.259C1852.2 643.247 1852.59 641.483 1853.37 639.966C1854.15 638.44 1855.26 637.251 1856.7 636.399C1858.14 635.538 1859.86 635.108 1861.84 635.108C1863.55 635.108 1865.05 635.419 1866.34 636.041C1867.63 636.663 1868.65 637.537 1869.4 638.662C1870.15 639.787 1870.56 641.108 1870.64 642.625H1865.5C1865.35 641.645 1864.97 640.857 1864.35 640.26C1863.73 639.655 1862.93 639.352 1861.93 639.352C1861.09 639.352 1860.35 639.582 1859.72 640.043C1859.1 640.494 1858.61 641.155 1858.26 642.024C1857.91 642.893 1857.74 643.946 1857.74 645.182C1857.74 646.435 1857.91 647.5 1858.25 648.378C1858.6 649.256 1859.09 649.925 1859.72 650.385C1860.35 650.845 1861.09 651.075 1861.93 651.075C1862.55 651.075 1863.11 650.947 1863.61 650.692C1864.11 650.436 1864.52 650.065 1864.85 649.58C1865.18 649.085 1865.4 648.493 1865.5 647.803H1870.64C1870.55 649.303 1870.14 650.624 1869.41 651.766C1868.69 652.899 1867.68 653.786 1866.41 654.425C1865.13 655.064 1863.61 655.384 1861.87 655.384ZM1882.35 655.384C1880.33 655.384 1878.59 654.974 1877.14 654.156C1875.69 653.33 1874.57 652.162 1873.79 650.653C1873 649.136 1872.61 647.342 1872.61 645.271C1872.61 643.251 1873 641.479 1873.79 639.953C1874.57 638.428 1875.68 637.239 1877.1 636.386C1878.53 635.534 1880.21 635.108 1882.14 635.108C1883.43 635.108 1884.64 635.317 1885.75 635.734C1886.88 636.143 1887.86 636.761 1888.69 637.588C1889.54 638.415 1890.19 639.455 1890.66 640.707C1891.13 641.952 1891.37 643.409 1891.37 645.08V646.575H1874.78V643.2H1886.24C1886.24 642.416 1886.07 641.722 1885.73 641.116C1885.39 640.511 1884.91 640.038 1884.31 639.697C1883.71 639.348 1883.02 639.173 1882.23 639.173C1881.4 639.173 1880.67 639.365 1880.03 639.749C1879.4 640.124 1878.9 640.631 1878.54 641.27C1878.19 641.901 1878 642.604 1877.99 643.379V646.588C1877.99 647.56 1878.17 648.399 1878.53 649.107C1878.9 649.814 1879.41 650.359 1880.08 650.743C1880.74 651.126 1881.53 651.318 1882.44 651.318C1883.05 651.318 1883.6 651.233 1884.1 651.062C1884.61 650.892 1885.04 650.636 1885.4 650.295C1885.75 649.955 1886.03 649.537 1886.21 649.043L1891.25 649.375C1890.99 650.585 1890.47 651.642 1889.68 652.545C1888.89 653.44 1887.88 654.139 1886.64 654.642C1885.4 655.136 1883.97 655.384 1882.35 655.384ZM1665.01 703.32C1663.52 703.32 1662.17 702.936 1660.96 702.169C1659.75 701.393 1658.8 700.256 1658.09 698.756C1657.39 697.247 1657.04 695.398 1657.04 693.207C1657.04 690.957 1657.41 689.087 1658.13 687.595C1658.86 686.095 1659.82 684.974 1661.02 684.233C1662.23 683.483 1663.56 683.108 1665 683.108C1666.1 683.108 1667.01 683.295 1667.74 683.67C1668.49 684.037 1669.08 684.497 1669.53 685.051C1669.99 685.597 1670.34 686.134 1670.58 686.662H1670.75V676.818H1676.18V703H1670.81V699.855H1670.58C1670.33 700.401 1669.96 700.942 1669.5 701.479C1669.04 702.007 1668.44 702.446 1667.69 702.795C1666.96 703.145 1666.07 703.32 1665.01 703.32ZM1666.73 698.986C1667.61 698.986 1668.35 698.747 1668.96 698.27C1669.57 697.784 1670.04 697.107 1670.37 696.237C1670.7 695.368 1670.86 694.349 1670.86 693.182C1670.86 692.014 1670.7 691 1670.38 690.139C1670.05 689.278 1669.59 688.614 1668.97 688.145C1668.36 687.676 1667.61 687.442 1666.73 687.442C1665.84 687.442 1665.09 687.685 1664.47 688.17C1663.86 688.656 1663.39 689.33 1663.08 690.19C1662.76 691.051 1662.61 692.048 1662.61 693.182C1662.61 694.324 1662.76 695.334 1663.08 696.212C1663.4 697.081 1663.87 697.763 1664.47 698.257C1665.09 698.743 1665.84 698.986 1666.73 698.986ZM1679.94 703V683.364H1685.39V703H1679.94ZM1682.68 680.832C1681.87 680.832 1681.17 680.564 1680.59 680.027C1680.02 679.482 1679.74 678.83 1679.74 678.071C1679.74 677.321 1680.02 676.678 1680.59 676.141C1681.17 675.595 1681.87 675.322 1682.68 675.322C1683.49 675.322 1684.18 675.595 1684.75 676.141C1685.33 676.678 1685.62 677.321 1685.62 678.071C1685.62 678.83 1685.33 679.482 1684.75 680.027C1684.18 680.564 1683.49 680.832 1682.68 680.832ZM1705.37 688.963L1700.38 689.27C1700.3 688.844 1700.11 688.46 1699.83 688.119C1699.55 687.77 1699.18 687.493 1698.72 687.288C1698.27 687.075 1697.73 686.969 1697.1 686.969C1696.25 686.969 1695.54 687.148 1694.96 687.506C1694.38 687.855 1694.09 688.324 1694.09 688.912C1694.09 689.381 1694.28 689.777 1694.65 690.101C1695.03 690.425 1695.67 690.685 1696.58 690.881L1700.14 691.597C1702.05 691.989 1703.47 692.619 1704.41 693.489C1705.35 694.358 1705.81 695.5 1705.81 696.915C1705.81 698.202 1705.43 699.331 1704.68 700.303C1703.93 701.274 1702.89 702.033 1701.58 702.578C1700.28 703.115 1698.77 703.384 1697.07 703.384C1694.47 703.384 1692.4 702.842 1690.86 701.76C1689.32 700.669 1688.42 699.186 1688.16 697.311L1693.52 697.03C1693.68 697.822 1694.07 698.428 1694.69 698.845C1695.31 699.254 1696.11 699.459 1697.08 699.459C1698.04 699.459 1698.8 699.276 1699.38 698.909C1699.97 698.534 1700.27 698.053 1700.28 697.464C1700.27 696.97 1700.06 696.565 1699.65 696.25C1699.24 695.926 1698.61 695.679 1697.76 695.509L1694.36 694.831C1692.44 694.447 1691.01 693.783 1690.08 692.837C1689.15 691.891 1688.68 690.685 1688.68 689.219C1688.68 687.957 1689.02 686.871 1689.71 685.959C1690.4 685.047 1691.36 684.344 1692.61 683.849C1693.86 683.355 1695.33 683.108 1697.01 683.108C1699.49 683.108 1701.44 683.632 1702.86 684.68C1704.29 685.729 1705.13 687.156 1705.37 688.963ZM1718.97 683.364V687.455H1707.14V683.364H1718.97ZM1709.83 678.659H1715.27V696.966C1715.27 697.469 1715.35 697.861 1715.5 698.142C1715.66 698.415 1715.87 698.607 1716.14 698.717C1716.42 698.828 1716.75 698.884 1717.11 698.884C1717.37 698.884 1717.63 698.862 1717.88 698.82C1718.14 698.768 1718.33 698.73 1718.47 698.705L1719.33 702.757C1719.05 702.842 1718.67 702.94 1718.18 703.051C1717.68 703.17 1717.08 703.243 1716.37 703.268C1715.06 703.32 1713.91 703.145 1712.92 702.744C1711.94 702.344 1711.18 701.722 1710.63 700.878C1710.09 700.034 1709.82 698.969 1709.83 697.682V678.659ZM1721.8 703V683.364H1727.08V686.79H1727.28C1727.64 685.571 1728.24 684.651 1729.08 684.028C1729.93 683.398 1730.9 683.082 1732 683.082C1732.27 683.082 1732.56 683.099 1732.88 683.134C1733.19 683.168 1733.47 683.214 1733.71 683.274V688.107C1733.45 688.03 1733.1 687.962 1732.65 687.902C1732.2 687.842 1731.78 687.812 1731.41 687.812C1730.61 687.812 1729.89 687.987 1729.26 688.337C1728.64 688.678 1728.14 689.155 1727.78 689.768C1727.42 690.382 1727.24 691.089 1727.24 691.891V703H1721.8ZM1735.81 703V683.364H1741.25V703H1735.81ZM1738.54 680.832C1737.73 680.832 1737.04 680.564 1736.46 680.027C1735.89 679.482 1735.6 678.83 1735.6 678.071C1735.6 677.321 1735.89 676.678 1736.46 676.141C1737.04 675.595 1737.73 675.322 1738.54 675.322C1739.35 675.322 1740.04 675.595 1740.61 676.141C1741.19 676.678 1741.48 677.321 1741.48 678.071C1741.48 678.83 1741.19 679.482 1740.61 680.027C1740.04 680.564 1739.35 680.832 1738.54 680.832ZM1745 703V676.818H1750.44V686.662H1750.61C1750.85 686.134 1751.19 685.597 1751.64 685.051C1752.1 684.497 1752.7 684.037 1753.43 683.67C1754.18 683.295 1755.1 683.108 1756.2 683.108C1757.63 683.108 1758.95 683.483 1760.16 684.233C1761.37 684.974 1762.34 686.095 1763.06 687.595C1763.79 689.087 1764.15 690.957 1764.15 693.207C1764.15 695.398 1763.79 697.247 1763.09 698.756C1762.39 700.256 1761.43 701.393 1760.22 702.169C1759.02 702.936 1757.67 703.32 1756.18 703.32C1755.13 703.32 1754.23 703.145 1753.49 702.795C1752.75 702.446 1752.15 702.007 1751.68 701.479C1751.21 700.942 1750.86 700.401 1750.61 699.855H1750.37V703H1745ZM1750.33 693.182C1750.33 694.349 1750.49 695.368 1750.81 696.237C1751.14 697.107 1751.61 697.784 1752.22 698.27C1752.83 698.747 1753.58 698.986 1754.46 698.986C1755.34 698.986 1756.09 698.743 1756.71 698.257C1757.32 697.763 1757.79 697.081 1758.1 696.212C1758.42 695.334 1758.59 694.324 1758.59 693.182C1758.59 692.048 1758.43 691.051 1758.11 690.19C1757.8 689.33 1757.33 688.656 1756.72 688.17C1756.11 687.685 1755.35 687.442 1754.46 687.442C1753.57 687.442 1752.82 687.676 1752.21 688.145C1751.6 688.614 1751.14 689.278 1750.81 690.139C1750.49 691 1750.33 692.014 1750.33 693.182ZM1779.65 694.639V683.364H1785.1V703H1779.87V699.433H1779.67C1779.22 700.584 1778.49 701.509 1777.45 702.207C1776.43 702.906 1775.18 703.256 1773.71 703.256C1772.4 703.256 1771.24 702.957 1770.24 702.361C1769.25 701.764 1768.47 700.916 1767.91 699.817C1767.35 698.717 1767.07 697.401 1767.06 695.866V683.364H1772.51V694.895C1772.52 696.054 1772.83 696.97 1773.44 697.643C1774.05 698.317 1774.88 698.653 1775.91 698.653C1776.56 698.653 1777.18 698.504 1777.75 698.206C1778.32 697.899 1778.78 697.447 1779.13 696.851C1779.49 696.254 1779.66 695.517 1779.65 694.639ZM1799.18 683.364V687.455H1787.36V683.364H1799.18ZM1790.04 678.659H1795.49V696.966C1795.49 697.469 1795.56 697.861 1795.72 698.142C1795.87 698.415 1796.08 698.607 1796.36 698.717C1796.64 698.828 1796.96 698.884 1797.33 698.884C1797.58 698.884 1797.84 698.862 1798.09 698.82C1798.35 698.768 1798.55 698.73 1798.68 698.705L1799.54 702.757C1799.27 702.842 1798.88 702.94 1798.39 703.051C1797.89 703.17 1797.29 703.243 1796.59 703.268C1795.27 703.32 1794.12 703.145 1793.13 702.744C1792.15 702.344 1791.39 701.722 1790.85 700.878C1790.3 700.034 1790.03 698.969 1790.04 697.682V678.659ZM1802.01 703V683.364H1807.45V703H1802.01ZM1804.74 680.832C1803.93 680.832 1803.24 680.564 1802.66 680.027C1802.09 679.482 1801.8 678.83 1801.8 678.071C1801.8 677.321 1802.09 676.678 1802.66 676.141C1803.24 675.595 1803.93 675.322 1804.74 675.322C1805.55 675.322 1806.24 675.595 1806.81 676.141C1807.39 676.678 1807.68 677.321 1807.68 678.071C1807.68 678.83 1807.39 679.482 1806.81 680.027C1806.24 680.564 1805.55 680.832 1804.74 680.832ZM1819.97 703.384C1817.98 703.384 1816.27 702.962 1814.82 702.118C1813.38 701.266 1812.26 700.081 1811.48 698.564C1810.7 697.038 1810.3 695.27 1810.3 693.259C1810.3 691.23 1810.7 689.457 1811.48 687.94C1812.26 686.415 1813.38 685.23 1814.82 684.386C1816.27 683.534 1817.98 683.108 1819.97 683.108C1821.95 683.108 1823.67 683.534 1825.11 684.386C1826.56 685.23 1827.67 686.415 1828.46 687.94C1829.24 689.457 1829.63 691.23 1829.63 693.259C1829.63 695.27 1829.24 697.038 1828.46 698.564C1827.67 700.081 1826.56 701.266 1825.11 702.118C1823.67 702.962 1821.95 703.384 1819.97 703.384ZM1819.99 699.165C1820.9 699.165 1821.65 698.909 1822.26 698.398C1822.86 697.878 1823.32 697.17 1823.62 696.276C1823.94 695.381 1824.1 694.362 1824.1 693.22C1824.1 692.078 1823.94 691.06 1823.62 690.165C1823.32 689.27 1822.86 688.562 1822.26 688.043C1821.65 687.523 1820.9 687.263 1819.99 687.263C1819.08 687.263 1818.32 687.523 1817.69 688.043C1817.08 688.562 1816.62 689.27 1816.3 690.165C1815.99 691.06 1815.84 692.078 1815.84 693.22C1815.84 694.362 1815.99 695.381 1816.3 696.276C1816.62 697.17 1817.08 697.878 1817.69 698.398C1818.32 698.909 1819.08 699.165 1819.99 699.165ZM1837.9 691.648V703H1832.45V683.364H1837.65V686.828H1837.88C1838.31 685.686 1839.04 684.783 1840.06 684.118C1841.08 683.445 1842.32 683.108 1843.78 683.108C1845.15 683.108 1846.33 683.406 1847.35 684.003C1848.36 684.599 1849.15 685.452 1849.71 686.56C1850.28 687.659 1850.56 688.972 1850.56 690.497V703H1845.11V691.469C1845.12 690.267 1844.81 689.33 1844.19 688.656C1843.57 687.974 1842.71 687.634 1841.62 687.634C1840.89 687.634 1840.24 687.791 1839.68 688.107C1839.12 688.422 1838.69 688.882 1838.37 689.487C1838.07 690.084 1837.91 690.804 1837.9 691.648ZM1872.3 683.364V687.455H1860.18V683.364H1872.3ZM1862.96 703V681.945C1862.96 680.521 1863.23 679.341 1863.79 678.403C1864.35 677.466 1865.12 676.763 1866.09 676.294C1867.06 675.825 1868.16 675.591 1869.4 675.591C1870.23 675.591 1871 675.655 1871.69 675.783C1872.39 675.911 1872.91 676.026 1873.25 676.128L1872.28 680.219C1872.06 680.151 1871.8 680.087 1871.48 680.027C1871.18 679.967 1870.86 679.938 1870.54 679.938C1869.74 679.938 1869.18 680.125 1868.86 680.5C1868.55 680.866 1868.39 681.382 1868.39 682.047V703H1862.96ZM1883.08 703.384C1881.09 703.384 1879.37 702.962 1877.93 702.118C1876.48 701.266 1875.37 700.081 1874.59 698.564C1873.8 697.038 1873.41 695.27 1873.41 693.259C1873.41 691.23 1873.8 689.457 1874.59 687.94C1875.37 686.415 1876.48 685.23 1877.93 684.386C1879.37 683.534 1881.09 683.108 1883.08 683.108C1885.06 683.108 1886.78 683.534 1888.22 684.386C1889.67 685.23 1890.78 686.415 1891.57 687.94C1892.35 689.457 1892.74 691.23 1892.74 693.259C1892.74 695.27 1892.35 697.038 1891.57 698.564C1890.78 700.081 1889.67 701.266 1888.22 702.118C1886.78 702.962 1885.06 703.384 1883.08 703.384ZM1883.1 699.165C1884.01 699.165 1884.76 698.909 1885.37 698.398C1885.97 697.878 1886.43 697.17 1886.73 696.276C1887.05 695.381 1887.21 694.362 1887.21 693.22C1887.21 692.078 1887.05 691.06 1886.73 690.165C1886.43 689.27 1885.97 688.562 1885.37 688.043C1884.76 687.523 1884.01 687.263 1883.1 687.263C1882.19 687.263 1881.42 687.523 1880.8 688.043C1880.19 688.562 1879.72 689.27 1879.41 690.165C1879.1 691.06 1878.95 692.078 1878.95 693.22C1878.95 694.362 1879.1 695.381 1879.41 696.276C1879.72 697.17 1880.19 697.878 1880.8 698.398C1881.42 698.909 1882.19 699.165 1883.1 699.165ZM1895.56 703V683.364H1900.84V686.79H1901.05C1901.41 685.571 1902.01 684.651 1902.85 684.028C1903.69 683.398 1904.67 683.082 1905.76 683.082C1906.04 683.082 1906.33 683.099 1906.65 683.134C1906.96 683.168 1907.24 683.214 1907.48 683.274V688.107C1907.22 688.03 1906.87 687.962 1906.42 687.902C1905.96 687.842 1905.55 687.812 1905.18 687.812C1904.38 687.812 1903.66 687.987 1903.03 688.337C1902.41 688.678 1901.91 689.155 1901.55 689.768C1901.19 690.382 1901.01 691.089 1901.01 691.891V703H1895.56Z" fill="black"/>
+<path d="M1660.7 758.364V731.364H1666.07V734.662H1666.31C1666.55 734.134 1666.9 733.597 1667.35 733.051C1667.81 732.497 1668.41 732.037 1669.14 731.67C1669.88 731.295 1670.8 731.108 1671.9 731.108C1673.33 731.108 1674.65 731.483 1675.86 732.233C1677.07 732.974 1678.04 734.095 1678.76 735.595C1679.49 737.087 1679.85 738.957 1679.85 741.207C1679.85 743.398 1679.5 745.247 1678.79 746.756C1678.09 748.256 1677.14 749.393 1675.93 750.169C1674.73 750.936 1673.38 751.32 1671.89 751.32C1670.83 751.32 1669.93 751.145 1669.19 750.795C1668.46 750.446 1667.86 750.007 1667.39 749.479C1666.92 748.942 1666.56 748.401 1666.31 747.855H1666.15V758.364H1660.7ZM1666.03 741.182C1666.03 742.349 1666.19 743.368 1666.52 744.237C1666.84 745.107 1667.31 745.784 1667.92 746.27C1668.54 746.747 1669.28 746.986 1670.16 746.986C1671.05 746.986 1671.8 746.743 1672.41 746.257C1673.02 745.763 1673.49 745.081 1673.8 744.212C1674.13 743.334 1674.29 742.324 1674.29 741.182C1674.29 740.048 1674.13 739.051 1673.82 738.19C1673.5 737.33 1673.04 736.656 1672.42 736.17C1671.81 735.685 1671.06 735.442 1670.16 735.442C1669.27 735.442 1668.52 735.676 1667.91 736.145C1667.31 736.614 1666.84 737.278 1666.52 738.139C1666.19 739 1666.03 740.014 1666.03 741.182ZM1691.71 751.384C1689.69 751.384 1687.95 750.974 1686.5 750.156C1685.05 749.33 1683.93 748.162 1683.15 746.653C1682.36 745.136 1681.97 743.342 1681.97 741.271C1681.97 739.251 1682.36 737.479 1683.15 735.953C1683.93 734.428 1685.03 733.239 1686.46 732.386C1687.89 731.534 1689.57 731.108 1691.49 731.108C1692.79 731.108 1694 731.317 1695.11 731.734C1696.24 732.143 1697.22 732.761 1698.05 733.588C1698.9 734.415 1699.55 735.455 1700.02 736.707C1700.49 737.952 1700.72 739.409 1700.72 741.08V742.575H1684.14V739.2H1695.6C1695.6 738.416 1695.43 737.722 1695.09 737.116C1694.75 736.511 1694.27 736.038 1693.67 735.697C1693.07 735.348 1692.38 735.173 1691.58 735.173C1690.76 735.173 1690.02 735.365 1689.38 735.749C1688.75 736.124 1688.26 736.631 1687.9 737.27C1687.54 737.901 1687.36 738.604 1687.35 739.379V742.588C1687.35 743.56 1687.53 744.399 1687.89 745.107C1688.26 745.814 1688.77 746.359 1689.44 746.743C1690.1 747.126 1690.89 747.318 1691.8 747.318C1692.41 747.318 1692.96 747.233 1693.46 747.062C1693.97 746.892 1694.4 746.636 1694.75 746.295C1695.11 745.955 1695.38 745.537 1695.57 745.043L1700.61 745.375C1700.35 746.585 1699.83 747.642 1699.04 748.545C1698.25 749.44 1697.24 750.139 1695.99 750.642C1694.76 751.136 1693.33 751.384 1691.71 751.384ZM1703.56 751V731.364H1708.84V734.79H1709.04C1709.4 733.571 1710 732.651 1710.84 732.028C1711.69 731.398 1712.66 731.082 1713.76 731.082C1714.03 731.082 1714.33 731.099 1714.64 731.134C1714.96 731.168 1715.23 731.214 1715.47 731.274V736.107C1715.22 736.03 1714.86 735.962 1714.41 735.902C1713.96 735.842 1713.55 735.812 1713.17 735.812C1712.37 735.812 1711.65 735.987 1711.02 736.337C1710.4 736.678 1709.91 737.155 1709.54 737.768C1709.18 738.382 1709 739.089 1709 739.891V751H1703.56ZM1729 731.364V735.455H1717.17V731.364H1729ZM1719.86 726.659H1725.3V744.966C1725.3 745.469 1725.38 745.861 1725.53 746.142C1725.69 746.415 1725.9 746.607 1726.17 746.717C1726.45 746.828 1726.78 746.884 1727.14 746.884C1727.4 746.884 1727.65 746.862 1727.91 746.82C1728.17 746.768 1728.36 746.73 1728.5 746.705L1729.36 750.757C1729.08 750.842 1728.7 750.94 1728.2 751.051C1727.71 751.17 1727.11 751.243 1726.4 751.268C1725.09 751.32 1723.94 751.145 1722.95 750.744C1721.97 750.344 1721.21 749.722 1720.66 748.878C1720.12 748.034 1719.85 746.969 1719.86 745.682V726.659ZM1744.42 742.639V731.364H1749.86V751H1744.63V747.433H1744.43C1743.99 748.584 1743.25 749.509 1742.22 750.207C1741.2 750.906 1739.95 751.256 1738.47 751.256C1737.16 751.256 1736.01 750.957 1735.01 750.361C1734.01 749.764 1733.23 748.916 1732.67 747.817C1732.11 746.717 1731.83 745.401 1731.82 743.866V731.364H1737.27V742.895C1737.28 744.054 1737.59 744.97 1738.2 745.643C1738.82 746.317 1739.64 746.653 1740.67 746.653C1741.33 746.653 1741.94 746.504 1742.51 746.206C1743.08 745.899 1743.54 745.447 1743.89 744.851C1744.25 744.254 1744.43 743.517 1744.42 742.639ZM1753.5 751V731.364H1758.78V734.79H1758.98C1759.34 733.571 1759.94 732.651 1760.79 732.028C1761.63 731.398 1762.6 731.082 1763.7 731.082C1763.97 731.082 1764.27 731.099 1764.58 731.134C1764.9 731.168 1765.18 731.214 1765.41 731.274V736.107C1765.16 736.03 1764.8 735.962 1764.35 735.902C1763.9 735.842 1763.49 735.812 1763.11 735.812C1762.31 735.812 1761.6 735.987 1760.97 736.337C1760.34 736.678 1759.85 737.155 1759.48 737.768C1759.12 738.382 1758.95 739.089 1758.95 739.891V751H1753.5ZM1767.61 751V724.818H1773.06V734.662H1773.22C1773.46 734.134 1773.81 733.597 1774.26 733.051C1774.72 732.497 1775.32 732.037 1776.05 731.67C1776.79 731.295 1777.71 731.108 1778.81 731.108C1780.24 731.108 1781.56 731.483 1782.77 732.233C1783.98 732.974 1784.95 734.095 1785.68 735.595C1786.4 737.087 1786.76 738.957 1786.76 741.207C1786.76 743.398 1786.41 745.247 1785.7 746.756C1785 748.256 1784.05 749.393 1782.84 750.169C1781.64 750.936 1780.29 751.32 1778.8 751.32C1777.74 751.32 1776.84 751.145 1776.1 750.795C1775.37 750.446 1774.77 750.007 1774.3 749.479C1773.83 748.942 1773.47 748.401 1773.22 747.855H1772.98V751H1767.61ZM1772.94 741.182C1772.94 742.349 1773.11 743.368 1773.43 744.237C1773.75 745.107 1774.22 745.784 1774.84 746.27C1775.45 746.747 1776.19 746.986 1777.07 746.986C1777.96 746.986 1778.71 746.743 1779.32 746.257C1779.94 745.763 1780.4 745.081 1780.72 744.212C1781.04 743.334 1781.2 742.324 1781.2 741.182C1781.2 740.048 1781.04 739.051 1780.73 738.19C1780.41 737.33 1779.95 736.656 1779.34 736.17C1778.72 735.685 1777.97 735.442 1777.07 735.442C1776.19 735.442 1775.44 735.676 1774.82 736.145C1774.22 736.614 1773.75 737.278 1773.43 738.139C1773.11 739 1772.94 740.014 1772.94 741.182ZM1795.28 751.371C1794.02 751.371 1792.91 751.153 1791.93 750.719C1790.95 750.276 1790.17 749.624 1789.6 748.763C1789.04 747.893 1788.76 746.811 1788.76 745.516C1788.76 744.425 1788.96 743.509 1789.36 742.767C1789.76 742.026 1790.3 741.429 1790.99 740.977C1791.68 740.526 1792.47 740.185 1793.35 739.955C1794.23 739.724 1795.16 739.562 1796.13 739.469C1797.27 739.349 1798.2 739.239 1798.89 739.136C1799.59 739.026 1800.1 738.864 1800.42 738.651C1800.73 738.437 1800.89 738.122 1800.89 737.705V737.628C1800.89 736.818 1800.63 736.192 1800.12 735.749C1799.62 735.305 1798.9 735.084 1797.97 735.084C1796.99 735.084 1796.21 735.301 1795.63 735.736C1795.05 736.162 1794.67 736.699 1794.48 737.347L1789.45 736.938C1789.7 735.744 1790.21 734.713 1790.96 733.844C1791.71 732.966 1792.67 732.293 1793.86 731.824C1795.05 731.347 1796.43 731.108 1798 731.108C1799.09 731.108 1800.13 731.236 1801.13 731.491C1802.14 731.747 1803.03 732.143 1803.8 732.68C1804.59 733.217 1805.21 733.908 1805.66 734.751C1806.11 735.587 1806.33 736.588 1806.33 737.756V751H1801.17V748.277H1801.02C1800.7 748.891 1800.28 749.432 1799.75 749.901C1799.22 750.361 1798.59 750.723 1797.85 750.987C1797.1 751.243 1796.25 751.371 1795.28 751.371ZM1796.84 747.612C1797.64 747.612 1798.34 747.455 1798.96 747.139C1799.57 746.815 1800.05 746.381 1800.4 745.835C1800.75 745.29 1800.93 744.672 1800.93 743.982V741.898C1800.76 742.009 1800.52 742.111 1800.22 742.205C1799.93 742.29 1799.61 742.371 1799.24 742.447C1798.87 742.516 1798.51 742.58 1798.14 742.639C1797.77 742.69 1797.44 742.737 1797.14 742.78C1796.5 742.874 1795.95 743.023 1795.47 743.227C1794.99 743.432 1794.62 743.709 1794.36 744.058C1794.09 744.399 1793.96 744.825 1793.96 745.337C1793.96 746.078 1794.23 746.645 1794.76 747.037C1795.31 747.42 1796 747.612 1796.84 747.612ZM1820.28 731.364V735.455H1808.46V731.364H1820.28ZM1811.14 726.659H1816.59V744.966C1816.59 745.469 1816.67 745.861 1816.82 746.142C1816.97 746.415 1817.19 746.607 1817.46 746.717C1817.74 746.828 1818.06 746.884 1818.43 746.884C1818.69 746.884 1818.94 746.862 1819.2 746.82C1819.45 746.768 1819.65 746.73 1819.79 746.705L1820.64 750.757C1820.37 750.842 1819.99 750.94 1819.49 751.051C1819 751.17 1818.4 751.243 1817.69 751.268C1816.38 751.32 1815.23 751.145 1814.24 750.744C1813.26 750.344 1812.49 749.722 1811.95 748.878C1811.4 748.034 1811.13 746.969 1811.14 745.682V726.659ZM1823.11 751V731.364H1828.56V751H1823.11ZM1825.85 728.832C1825.04 728.832 1824.34 728.564 1823.76 728.027C1823.19 727.482 1822.91 726.83 1822.91 726.071C1822.91 725.321 1823.19 724.678 1823.76 724.141C1824.34 723.595 1825.04 723.322 1825.85 723.322C1826.66 723.322 1827.35 723.595 1827.92 724.141C1828.5 724.678 1828.79 725.321 1828.79 726.071C1828.79 726.83 1828.5 727.482 1827.92 728.027C1827.35 728.564 1826.66 728.832 1825.85 728.832ZM1841.07 751.384C1839.09 751.384 1837.37 750.962 1835.92 750.118C1834.48 749.266 1833.37 748.081 1832.58 746.564C1831.8 745.038 1831.41 743.27 1831.41 741.259C1831.41 739.23 1831.8 737.457 1832.58 735.94C1833.37 734.415 1834.48 733.23 1835.92 732.386C1837.37 731.534 1839.09 731.108 1841.07 731.108C1843.06 731.108 1844.77 731.534 1846.21 732.386C1847.66 733.23 1848.78 734.415 1849.56 735.94C1850.35 737.457 1850.74 739.23 1850.74 741.259C1850.74 743.27 1850.35 745.038 1849.56 746.564C1848.78 748.081 1847.66 749.266 1846.21 750.118C1844.77 750.962 1843.06 751.384 1841.07 751.384ZM1841.1 747.165C1842 747.165 1842.76 746.909 1843.36 746.398C1843.97 745.878 1844.42 745.17 1844.73 744.276C1845.04 743.381 1845.2 742.362 1845.2 741.22C1845.2 740.078 1845.04 739.06 1844.73 738.165C1844.42 737.27 1843.97 736.562 1843.36 736.043C1842.76 735.523 1842 735.263 1841.1 735.263C1840.19 735.263 1839.42 735.523 1838.8 736.043C1838.18 736.562 1837.72 737.27 1837.4 738.165C1837.1 739.06 1836.94 740.078 1836.94 741.22C1836.94 742.362 1837.1 743.381 1837.4 744.276C1837.72 745.17 1838.18 745.878 1838.8 746.398C1839.42 746.909 1840.19 747.165 1841.1 747.165ZM1859 739.648V751H1853.56V731.364H1858.75V734.828H1858.98C1859.41 733.686 1860.14 732.783 1861.16 732.118C1862.19 731.445 1863.43 731.108 1864.89 731.108C1866.25 731.108 1867.44 731.406 1868.45 732.003C1869.47 732.599 1870.25 733.452 1870.82 734.56C1871.38 735.659 1871.66 736.972 1871.66 738.497V751H1866.21V739.469C1866.22 738.267 1865.92 737.33 1865.29 736.656C1864.67 735.974 1863.82 735.634 1862.72 735.634C1861.99 735.634 1861.34 735.791 1860.78 736.107C1860.23 736.422 1859.79 736.882 1859.48 737.487C1859.17 738.084 1859.01 738.804 1859 739.648ZM1882.95 751V724.818H1893.43C1895.36 724.818 1896.96 725.104 1898.25 725.675C1899.54 726.246 1900.5 727.038 1901.15 728.053C1901.8 729.058 1902.12 730.217 1902.12 731.53C1902.12 732.553 1901.92 733.452 1901.51 734.227C1901.1 734.994 1900.54 735.625 1899.82 736.119C1899.11 736.605 1898.31 736.95 1897.39 737.155V737.411C1898.39 737.453 1899.32 737.734 1900.19 738.254C1901.07 738.774 1901.78 739.503 1902.33 740.44C1902.87 741.369 1903.15 742.477 1903.15 743.764C1903.15 745.153 1902.8 746.393 1902.11 747.484C1901.43 748.567 1900.42 749.423 1899.08 750.054C1897.74 750.685 1896.09 751 1894.13 751H1882.95ZM1888.48 746.474H1893C1894.54 746.474 1895.66 746.18 1896.37 745.592C1897.08 744.996 1897.43 744.203 1897.43 743.214C1897.43 742.49 1897.26 741.851 1896.91 741.297C1896.56 740.743 1896.06 740.308 1895.41 739.993C1894.77 739.678 1894.01 739.52 1893.12 739.52H1888.48V746.474ZM1888.48 735.774H1892.59C1893.34 735.774 1894.02 735.642 1894.61 735.378C1895.2 735.105 1895.67 734.722 1896.01 734.227C1896.36 733.733 1896.54 733.141 1896.54 732.45C1896.54 731.504 1896.2 730.741 1895.53 730.162C1894.86 729.582 1893.92 729.293 1892.69 729.293H1888.48V735.774Z" fill="#5C0B4D"/>
+<rect x="1069" y="268" width="285.028" height="61.8182" rx="22" fill="white" stroke="black" stroke-width="4"/>
+<path d="M1098.35 312.384C1096.34 312.384 1094.61 311.957 1093.16 311.105C1091.72 310.244 1090.61 309.051 1089.83 307.526C1089.07 306 1088.68 304.244 1088.68 302.259C1088.68 300.247 1089.07 298.483 1089.85 296.966C1090.63 295.44 1091.74 294.251 1093.18 293.399C1094.62 292.538 1096.34 292.108 1098.32 292.108C1100.04 292.108 1101.54 292.419 1102.82 293.041C1104.11 293.663 1105.13 294.537 1105.88 295.662C1106.63 296.787 1107.04 298.108 1107.12 299.625H1101.98C1101.83 298.645 1101.45 297.857 1100.83 297.26C1100.21 296.655 1099.41 296.352 1098.41 296.352C1097.57 296.352 1096.83 296.582 1096.2 297.043C1095.58 297.494 1095.09 298.155 1094.74 299.024C1094.39 299.893 1094.22 300.946 1094.22 302.182C1094.22 303.435 1094.39 304.5 1094.73 305.378C1095.08 306.256 1095.57 306.925 1096.2 307.385C1096.83 307.845 1097.57 308.075 1098.41 308.075C1099.03 308.075 1099.59 307.947 1100.09 307.692C1100.59 307.436 1101 307.065 1101.33 306.58C1101.66 306.085 1101.88 305.493 1101.98 304.803H1107.12C1107.03 306.303 1106.62 307.624 1105.89 308.766C1105.17 309.899 1104.16 310.786 1102.89 311.425C1101.61 312.064 1100.1 312.384 1098.35 312.384ZM1118.76 312.384C1116.77 312.384 1115.05 311.962 1113.61 311.118C1112.16 310.266 1111.05 309.081 1110.27 307.564C1109.48 306.038 1109.09 304.27 1109.09 302.259C1109.09 300.23 1109.48 298.457 1110.27 296.94C1111.05 295.415 1112.16 294.23 1113.61 293.386C1115.05 292.534 1116.77 292.108 1118.76 292.108C1120.74 292.108 1122.46 292.534 1123.9 293.386C1125.35 294.23 1126.46 295.415 1127.25 296.94C1128.03 298.457 1128.42 300.23 1128.42 302.259C1128.42 304.27 1128.03 306.038 1127.25 307.564C1126.46 309.081 1125.35 310.266 1123.9 311.118C1122.46 311.962 1120.74 312.384 1118.76 312.384ZM1118.78 308.165C1119.69 308.165 1120.44 307.909 1121.05 307.398C1121.65 306.878 1122.11 306.17 1122.41 305.276C1122.73 304.381 1122.89 303.362 1122.89 302.22C1122.89 301.078 1122.73 300.06 1122.41 299.165C1122.11 298.27 1121.65 297.562 1121.05 297.043C1120.44 296.523 1119.69 296.263 1118.78 296.263C1117.87 296.263 1117.1 296.523 1116.48 297.043C1115.87 297.562 1115.4 298.27 1115.09 299.165C1114.78 300.06 1114.63 301.078 1114.63 302.22C1114.63 303.362 1114.78 304.381 1115.09 305.276C1115.4 306.17 1115.87 306.878 1116.48 307.398C1117.1 307.909 1117.87 308.165 1118.78 308.165ZM1131.24 312V292.364H1136.43V295.828H1136.66C1137.07 294.678 1137.75 293.77 1138.71 293.105C1139.66 292.44 1140.81 292.108 1142.14 292.108C1143.48 292.108 1144.63 292.445 1145.57 293.118C1146.52 293.783 1147.15 294.686 1147.47 295.828H1147.67C1148.07 294.703 1148.8 293.804 1149.84 293.131C1150.9 292.449 1152.15 292.108 1153.59 292.108C1155.42 292.108 1156.91 292.692 1158.05 293.859C1159.2 295.018 1159.78 296.663 1159.78 298.794V312H1154.34V299.868C1154.34 298.777 1154.05 297.959 1153.47 297.413C1152.9 296.868 1152.17 296.595 1151.3 296.595C1150.31 296.595 1149.54 296.911 1148.99 297.541C1148.43 298.163 1148.16 298.986 1148.16 300.009V312H1142.88V299.753C1142.88 298.79 1142.6 298.023 1142.05 297.452C1141.5 296.881 1140.78 296.595 1139.89 296.595C1139.28 296.595 1138.73 296.749 1138.25 297.055C1137.77 297.354 1137.39 297.776 1137.11 298.321C1136.83 298.858 1136.69 299.489 1136.69 300.213V312H1131.24ZM1163.36 319.364V292.364H1168.73V295.662H1168.97C1169.21 295.134 1169.55 294.597 1170.01 294.051C1170.47 293.497 1171.06 293.037 1171.8 292.67C1172.54 292.295 1173.46 292.108 1174.56 292.108C1175.99 292.108 1177.31 292.483 1178.52 293.233C1179.73 293.974 1180.7 295.095 1181.42 296.595C1182.15 298.087 1182.51 299.957 1182.51 302.207C1182.51 304.398 1182.16 306.247 1181.45 307.756C1180.75 309.256 1179.8 310.393 1178.58 311.169C1177.38 311.936 1176.04 312.32 1174.55 312.32C1173.49 312.32 1172.59 312.145 1171.85 311.795C1171.11 311.446 1170.51 311.007 1170.05 310.479C1169.58 309.942 1169.22 309.401 1168.97 308.855H1168.8V319.364H1163.36ZM1168.69 302.182C1168.69 303.349 1168.85 304.368 1169.18 305.237C1169.5 306.107 1169.97 306.784 1170.58 307.27C1171.2 307.747 1171.94 307.986 1172.82 307.986C1173.71 307.986 1174.46 307.743 1175.07 307.257C1175.68 306.763 1176.15 306.081 1176.46 305.212C1176.79 304.334 1176.95 303.324 1176.95 302.182C1176.95 301.048 1176.79 300.051 1176.48 299.19C1176.16 298.33 1175.7 297.656 1175.08 297.17C1174.47 296.685 1173.71 296.442 1172.82 296.442C1171.93 296.442 1171.18 296.676 1170.57 297.145C1169.96 297.614 1169.5 298.278 1169.18 299.139C1168.85 300 1168.69 301.014 1168.69 302.182ZM1191.02 312.371C1189.77 312.371 1188.65 312.153 1187.67 311.719C1186.69 311.276 1185.91 310.624 1185.34 309.763C1184.78 308.893 1184.5 307.811 1184.5 306.516C1184.5 305.425 1184.7 304.509 1185.1 303.767C1185.5 303.026 1186.05 302.429 1186.74 301.977C1187.43 301.526 1188.21 301.185 1189.09 300.955C1189.98 300.724 1190.9 300.562 1191.88 300.469C1193.02 300.349 1193.94 300.239 1194.64 300.136C1195.34 300.026 1195.84 299.864 1196.16 299.651C1196.47 299.437 1196.63 299.122 1196.63 298.705V298.628C1196.63 297.818 1196.38 297.192 1195.86 296.749C1195.36 296.305 1194.65 296.084 1193.72 296.084C1192.74 296.084 1191.96 296.301 1191.38 296.736C1190.8 297.162 1190.41 297.699 1190.23 298.347L1185.19 297.938C1185.45 296.744 1185.95 295.713 1186.7 294.844C1187.45 293.966 1188.42 293.293 1189.6 292.824C1190.79 292.347 1192.17 292.108 1193.74 292.108C1194.83 292.108 1195.88 292.236 1196.87 292.491C1197.88 292.747 1198.77 293.143 1199.55 293.68C1200.33 294.217 1200.95 294.908 1201.4 295.751C1201.85 296.587 1202.08 297.588 1202.08 298.756V312H1196.91V309.277H1196.76C1196.44 309.891 1196.02 310.432 1195.49 310.901C1194.97 311.361 1194.33 311.723 1193.59 311.987C1192.85 312.243 1191.99 312.371 1191.02 312.371ZM1192.58 308.612C1193.38 308.612 1194.09 308.455 1194.7 308.139C1195.32 307.815 1195.8 307.381 1196.15 306.835C1196.5 306.29 1196.67 305.672 1196.67 304.982V302.898C1196.5 303.009 1196.27 303.111 1195.97 303.205C1195.68 303.29 1195.35 303.371 1194.98 303.447C1194.62 303.516 1194.25 303.58 1193.88 303.639C1193.52 303.69 1193.18 303.737 1192.89 303.78C1192.25 303.874 1191.69 304.023 1191.21 304.227C1190.73 304.432 1190.36 304.709 1190.1 305.058C1189.83 305.399 1189.7 305.825 1189.7 306.337C1189.7 307.078 1189.97 307.645 1190.51 308.037C1191.05 308.42 1191.74 308.612 1192.58 308.612ZM1205.58 312V292.364H1210.86V295.79H1211.07C1211.43 294.571 1212.03 293.651 1212.87 293.028C1213.71 292.398 1214.69 292.082 1215.78 292.082C1216.06 292.082 1216.35 292.099 1216.67 292.134C1216.98 292.168 1217.26 292.214 1217.5 292.274V297.107C1217.24 297.03 1216.89 296.962 1216.44 296.902C1215.99 296.842 1215.57 296.812 1215.2 296.812C1214.4 296.812 1213.68 296.987 1213.05 297.337C1212.43 297.678 1211.93 298.155 1211.57 298.768C1211.21 299.382 1211.03 300.089 1211.03 300.891V312H1205.58ZM1224.63 312.371C1223.38 312.371 1222.26 312.153 1221.28 311.719C1220.3 311.276 1219.53 310.624 1218.95 309.763C1218.39 308.893 1218.11 307.811 1218.11 306.516C1218.11 305.425 1218.31 304.509 1218.71 303.767C1219.11 303.026 1219.66 302.429 1220.35 301.977C1221.04 301.526 1221.82 301.185 1222.7 300.955C1223.59 300.724 1224.52 300.562 1225.49 300.469C1226.63 300.349 1227.55 300.239 1228.25 300.136C1228.95 300.026 1229.45 299.864 1229.77 299.651C1230.08 299.437 1230.24 299.122 1230.24 298.705V298.628C1230.24 297.818 1229.99 297.192 1229.48 296.749C1228.97 296.305 1228.26 296.084 1227.33 296.084C1226.35 296.084 1225.57 296.301 1224.99 296.736C1224.41 297.162 1224.03 297.699 1223.84 298.347L1218.8 297.938C1219.06 296.744 1219.56 295.713 1220.31 294.844C1221.06 293.966 1222.03 293.293 1223.21 292.824C1224.4 292.347 1225.79 292.108 1227.35 292.108C1228.44 292.108 1229.49 292.236 1230.49 292.491C1231.49 292.747 1232.38 293.143 1233.16 293.68C1233.94 294.217 1234.56 294.908 1235.01 295.751C1235.46 296.587 1235.69 297.588 1235.69 298.756V312H1230.52V309.277H1230.37C1230.06 309.891 1229.63 310.432 1229.1 310.901C1228.58 311.361 1227.94 311.723 1227.2 311.987C1226.46 312.243 1225.6 312.371 1224.63 312.371ZM1226.19 308.612C1226.99 308.612 1227.7 308.455 1228.31 308.139C1228.93 307.815 1229.41 307.381 1229.76 306.835C1230.11 306.29 1230.28 305.672 1230.28 304.982V302.898C1230.11 303.009 1229.88 303.111 1229.58 303.205C1229.29 303.29 1228.96 303.371 1228.59 303.447C1228.23 303.516 1227.86 303.58 1227.49 303.639C1227.13 303.69 1226.8 303.737 1226.5 303.78C1225.86 303.874 1225.3 304.023 1224.82 304.227C1224.34 304.432 1223.97 304.709 1223.71 305.058C1223.45 305.399 1223.31 305.825 1223.31 306.337C1223.31 307.078 1223.58 307.645 1224.12 308.037C1224.66 308.42 1225.35 308.612 1226.19 308.612ZM1249.64 292.364V296.455H1237.81V292.364H1249.64ZM1240.5 287.659H1245.94V305.966C1245.94 306.469 1246.02 306.861 1246.17 307.142C1246.33 307.415 1246.54 307.607 1246.81 307.717C1247.09 307.828 1247.42 307.884 1247.78 307.884C1248.04 307.884 1248.3 307.862 1248.55 307.82C1248.81 307.768 1249 307.73 1249.14 307.705L1250 311.757C1249.72 311.842 1249.34 311.94 1248.85 312.051C1248.35 312.17 1247.75 312.243 1247.04 312.268C1245.73 312.32 1244.58 312.145 1243.59 311.744C1242.61 311.344 1241.85 310.722 1241.3 309.878C1240.76 309.034 1240.49 307.969 1240.5 306.682V287.659ZM1261.13 312.384C1259.14 312.384 1257.42 311.962 1255.98 311.118C1254.53 310.266 1253.42 309.081 1252.64 307.564C1251.85 306.038 1251.46 304.27 1251.46 302.259C1251.46 300.23 1251.85 298.457 1252.64 296.94C1253.42 295.415 1254.53 294.23 1255.98 293.386C1257.42 292.534 1259.14 292.108 1261.13 292.108C1263.11 292.108 1264.83 292.534 1266.27 293.386C1267.72 294.23 1268.83 295.415 1269.62 296.94C1270.4 298.457 1270.79 300.23 1270.79 302.259C1270.79 304.27 1270.4 306.038 1269.62 307.564C1268.83 309.081 1267.72 310.266 1266.27 311.118C1264.83 311.962 1263.11 312.384 1261.13 312.384ZM1261.15 308.165C1262.06 308.165 1262.81 307.909 1263.42 307.398C1264.02 306.878 1264.48 306.17 1264.78 305.276C1265.1 304.381 1265.26 303.362 1265.26 302.22C1265.26 301.078 1265.1 300.06 1264.78 299.165C1264.48 298.27 1264.02 297.562 1263.42 297.043C1262.81 296.523 1262.06 296.263 1261.15 296.263C1260.24 296.263 1259.47 296.523 1258.85 297.043C1258.24 297.562 1257.77 298.27 1257.46 299.165C1257.15 300.06 1257 301.078 1257 302.22C1257 303.362 1257.15 304.381 1257.46 305.276C1257.77 306.17 1258.24 306.878 1258.85 307.398C1259.47 307.909 1260.24 308.165 1261.15 308.165ZM1273.61 312V292.364H1278.89V295.79H1279.1C1279.46 294.571 1280.06 293.651 1280.9 293.028C1281.74 292.398 1282.72 292.082 1283.81 292.082C1284.09 292.082 1284.38 292.099 1284.7 292.134C1285.01 292.168 1285.29 292.214 1285.53 292.274V297.107C1285.27 297.03 1284.92 296.962 1284.47 296.902C1284.02 296.842 1283.6 296.812 1283.23 296.812C1282.43 296.812 1281.71 296.987 1281.08 297.337C1280.46 297.678 1279.96 298.155 1279.6 298.768C1279.24 299.382 1279.06 300.089 1279.06 300.891V312H1273.61ZM1288.56 312.332C1287.71 312.332 1286.99 312.034 1286.38 311.438C1285.79 310.832 1285.49 310.108 1285.49 309.264C1285.49 308.429 1285.79 307.713 1286.38 307.116C1286.99 306.52 1287.71 306.222 1288.56 306.222C1289.38 306.222 1290.09 306.52 1290.7 307.116C1291.32 307.713 1291.63 308.429 1291.63 309.264C1291.63 309.827 1291.48 310.342 1291.19 310.811C1290.91 311.271 1290.54 311.642 1290.08 311.923C1289.62 312.196 1289.11 312.332 1288.56 312.332ZM1295.38 319.364V292.364H1300.75V295.662H1300.99C1301.23 295.134 1301.57 294.597 1302.02 294.051C1302.48 293.497 1303.08 293.037 1303.81 292.67C1304.56 292.295 1305.48 292.108 1306.58 292.108C1308.01 292.108 1309.33 292.483 1310.54 293.233C1311.75 293.974 1312.72 295.095 1313.44 296.595C1314.16 298.087 1314.53 299.957 1314.53 302.207C1314.53 304.398 1314.17 306.247 1313.47 307.756C1312.77 309.256 1311.81 310.393 1310.6 311.169C1309.4 311.936 1308.05 312.32 1306.56 312.32C1305.51 312.32 1304.61 312.145 1303.86 311.795C1303.13 311.446 1302.53 311.007 1302.06 310.479C1301.59 309.942 1301.24 309.401 1300.99 308.855H1300.82V319.364H1295.38ZM1300.71 302.182C1300.71 303.349 1300.87 304.368 1301.19 305.237C1301.52 306.107 1301.99 306.784 1302.6 307.27C1303.21 307.747 1303.96 307.986 1304.84 307.986C1305.72 307.986 1306.47 307.743 1307.09 307.257C1307.7 306.763 1308.16 306.081 1308.48 305.212C1308.8 304.334 1308.97 303.324 1308.97 302.182C1308.97 301.048 1308.81 300.051 1308.49 299.19C1308.18 298.33 1307.71 297.656 1307.1 297.17C1306.49 296.685 1305.73 296.442 1304.84 296.442C1303.95 296.442 1303.2 296.676 1302.59 297.145C1301.98 297.614 1301.52 298.278 1301.19 299.139C1300.87 300 1300.71 301.014 1300.71 302.182ZM1320.17 319.364C1319.48 319.364 1318.83 319.308 1318.22 319.197C1317.63 319.095 1317.13 318.963 1316.74 318.801L1317.97 314.736C1318.61 314.932 1319.18 315.038 1319.69 315.055C1320.21 315.072 1320.66 314.953 1321.04 314.697C1321.42 314.442 1321.73 314.007 1321.97 313.393L1322.29 312.562L1315.25 292.364H1320.97L1325.04 306.784H1325.24L1329.35 292.364H1335.11L1327.48 314.122C1327.11 315.179 1326.61 316.099 1325.98 316.884C1325.36 317.676 1324.57 318.286 1323.62 318.712C1322.66 319.146 1321.51 319.364 1320.17 319.364Z" fill="black"/>
+<rect x="46" y="113" width="241.149" height="61.8182" rx="22" fill="#E6711C" stroke="black" stroke-width="4"/>
+<path d="M91.4928 137.364V141.455H79.3735V137.364H91.4928ZM82.1476 157V135.945C82.1476 134.521 82.4246 133.341 82.9786 132.403C83.5411 131.466 84.3081 130.763 85.2797 130.294C86.2513 129.825 87.355 129.591 88.5908 129.591C89.426 129.591 90.1888 129.655 90.8792 129.783C91.578 129.911 92.0979 130.026 92.4388 130.128L91.4672 134.219C91.2542 134.151 90.99 134.087 90.6746 134.027C90.3678 133.967 90.0525 133.938 89.7286 133.938C88.9275 133.938 88.3692 134.125 88.0539 134.5C87.7385 134.866 87.5809 135.382 87.5809 136.047V157H82.1476ZM106.692 148.639V137.364H112.138V157H106.91V153.433H106.705C106.262 154.584 105.525 155.509 104.493 156.207C103.471 156.906 102.222 157.256 100.748 157.256C99.4351 157.256 98.2803 156.957 97.2831 156.361C96.2859 155.764 95.5061 154.916 94.9436 153.817C94.3896 152.717 94.1084 151.401 94.0999 149.866V137.364H99.5459V148.895C99.5544 150.054 99.8655 150.97 100.479 151.643C101.093 152.317 101.915 152.653 102.946 152.653C103.603 152.653 104.216 152.504 104.787 152.206C105.358 151.899 105.819 151.447 106.168 150.851C106.526 150.254 106.701 149.517 106.692 148.639ZM121.22 145.648V157H115.774V137.364H120.965V140.828H121.195C121.63 139.686 122.358 138.783 123.381 138.118C124.404 137.445 125.644 137.108 127.101 137.108C128.465 137.108 129.654 137.406 130.668 138.003C131.682 138.599 132.47 139.452 133.033 140.56C133.595 141.659 133.877 142.972 133.877 144.497V157H128.431V145.469C128.439 144.267 128.132 143.33 127.51 142.656C126.888 141.974 126.031 141.634 124.941 141.634C124.208 141.634 123.56 141.791 122.997 142.107C122.443 142.422 122.009 142.882 121.693 143.487C121.387 144.084 121.229 144.804 121.22 145.648ZM146.321 157.384C144.31 157.384 142.58 156.957 141.131 156.105C139.69 155.244 138.582 154.051 137.807 152.526C137.04 151 136.656 149.244 136.656 147.259C136.656 145.247 137.044 143.483 137.82 141.966C138.604 140.44 139.716 139.251 141.156 138.399C142.597 137.538 144.31 137.108 146.296 137.108C148.009 137.108 149.509 137.419 150.796 138.041C152.082 138.663 153.101 139.537 153.851 140.662C154.601 141.787 155.014 143.108 155.091 144.625H149.952C149.807 143.645 149.423 142.857 148.801 142.26C148.188 141.655 147.382 141.352 146.385 141.352C145.541 141.352 144.804 141.582 144.173 142.043C143.551 142.494 143.065 143.155 142.716 144.024C142.367 144.893 142.192 145.946 142.192 147.182C142.192 148.435 142.362 149.5 142.703 150.378C143.053 151.256 143.543 151.925 144.173 152.385C144.804 152.845 145.541 153.075 146.385 153.075C147.007 153.075 147.565 152.947 148.06 152.692C148.563 152.436 148.976 152.065 149.3 151.58C149.632 151.085 149.849 150.493 149.952 149.803H155.091C155.006 151.303 154.597 152.624 153.864 153.766C153.139 154.899 152.138 155.786 150.859 156.425C149.581 157.064 148.068 157.384 146.321 157.384ZM168.302 137.364V141.455H156.477V137.364H168.302ZM159.162 132.659H164.608V150.966C164.608 151.469 164.685 151.861 164.838 152.142C164.991 152.415 165.204 152.607 165.477 152.717C165.758 152.828 166.082 152.884 166.449 152.884C166.704 152.884 166.96 152.862 167.216 152.82C167.471 152.768 167.667 152.73 167.804 152.705L168.66 156.757C168.388 156.842 168.004 156.94 167.51 157.051C167.015 157.17 166.415 157.243 165.707 157.268C164.395 157.32 163.244 157.145 162.256 156.744C161.275 156.344 160.513 155.722 159.967 154.878C159.422 154.034 159.153 152.969 159.162 151.682V132.659ZM179.791 157.384C177.805 157.384 176.088 156.962 174.639 156.118C173.199 155.266 172.087 154.081 171.303 152.564C170.519 151.038 170.126 149.27 170.126 147.259C170.126 145.23 170.519 143.457 171.303 141.94C172.087 140.415 173.199 139.23 174.639 138.386C176.088 137.534 177.805 137.108 179.791 137.108C181.777 137.108 183.49 137.534 184.93 138.386C186.379 139.23 187.496 140.415 188.28 141.94C189.064 143.457 189.456 145.23 189.456 147.259C189.456 149.27 189.064 151.038 188.28 152.564C187.496 154.081 186.379 155.266 184.93 156.118C183.49 156.962 181.777 157.384 179.791 157.384ZM179.817 153.165C180.72 153.165 181.474 152.909 182.08 152.398C182.685 151.878 183.141 151.17 183.447 150.276C183.763 149.381 183.92 148.362 183.92 147.22C183.92 146.078 183.763 145.06 183.447 144.165C183.141 143.27 182.685 142.562 182.08 142.043C181.474 141.523 180.72 141.263 179.817 141.263C178.905 141.263 178.138 141.523 177.516 142.043C176.902 142.562 176.438 143.27 176.122 144.165C175.815 145.06 175.662 146.078 175.662 147.22C175.662 148.362 175.815 149.381 176.122 150.276C176.438 151.17 176.902 151.878 177.516 152.398C178.138 152.909 178.905 153.165 179.817 153.165ZM192.277 157V137.364H197.557V140.79H197.762C198.12 139.571 198.72 138.651 199.564 138.028C200.408 137.398 201.379 137.082 202.479 137.082C202.752 137.082 203.046 137.099 203.361 137.134C203.676 137.168 203.953 137.214 204.192 137.274V142.107C203.936 142.03 203.583 141.962 203.131 141.902C202.679 141.842 202.266 141.812 201.891 141.812C201.09 141.812 200.374 141.987 199.743 142.337C199.121 142.678 198.627 143.155 198.26 143.768C197.902 144.382 197.723 145.089 197.723 145.891V157H192.277ZM207.221 157.332C206.377 157.332 205.653 157.034 205.048 156.438C204.451 155.832 204.153 155.108 204.153 154.264C204.153 153.429 204.451 152.713 205.048 152.116C205.653 151.52 206.377 151.222 207.221 151.222C208.039 151.222 208.755 151.52 209.369 152.116C209.982 152.713 210.289 153.429 210.289 154.264C210.289 154.827 210.144 155.342 209.854 155.811C209.573 156.271 209.202 156.642 208.742 156.923C208.282 157.196 207.775 157.332 207.221 157.332ZM214.04 164.364V137.364H219.41V140.662H219.653C219.891 140.134 220.236 139.597 220.688 139.051C221.148 138.497 221.745 138.037 222.478 137.67C223.219 137.295 224.14 137.108 225.239 137.108C226.671 137.108 227.992 137.483 229.202 138.233C230.412 138.974 231.38 140.095 232.104 141.595C232.829 143.087 233.191 144.957 233.191 147.207C233.191 149.398 232.837 151.247 232.13 152.756C231.431 154.256 230.476 155.393 229.266 156.169C228.064 156.936 226.718 157.32 225.226 157.32C224.17 157.32 223.27 157.145 222.529 156.795C221.796 156.446 221.195 156.007 220.726 155.479C220.258 154.942 219.9 154.401 219.653 153.855H219.486V164.364H214.04ZM219.371 147.182C219.371 148.349 219.533 149.368 219.857 150.237C220.181 151.107 220.65 151.784 221.263 152.27C221.877 152.747 222.623 152.986 223.501 152.986C224.387 152.986 225.137 152.743 225.751 152.257C226.364 151.763 226.829 151.081 227.144 150.212C227.468 149.334 227.63 148.324 227.63 147.182C227.63 146.048 227.472 145.051 227.157 144.19C226.841 143.33 226.377 142.656 225.763 142.17C225.15 141.685 224.395 141.442 223.501 141.442C222.614 141.442 221.864 141.676 221.251 142.145C220.645 142.614 220.181 143.278 219.857 144.139C219.533 145 219.371 146.014 219.371 147.182ZM238.831 164.364C238.141 164.364 237.493 164.308 236.888 164.197C236.291 164.095 235.797 163.963 235.405 163.801L236.632 159.736C237.271 159.932 237.847 160.038 238.358 160.055C238.878 160.072 239.325 159.953 239.7 159.697C240.084 159.442 240.395 159.007 240.634 158.393L240.953 157.562L233.909 137.364H239.636L243.702 151.784H243.906L248.01 137.364H253.776L246.143 159.122C245.777 160.179 245.278 161.099 244.648 161.884C244.026 162.676 243.237 163.286 242.283 163.712C241.328 164.146 240.178 164.364 238.831 164.364Z" fill="white"/>
+<rect x="4" y="2" width="456" height="62" rx="22" fill="#E6711C" stroke="black" stroke-width="4"/>
+<path d="M84.3929 46V26.3636H89.6727V29.7898H89.8773C90.2352 28.571 90.8361 27.6506 91.6798 27.0284C92.5236 26.3977 93.4952 26.0824 94.5946 26.0824C94.8673 26.0824 95.1614 26.0994 95.4767 26.1335C95.792 26.1676 96.069 26.2145 96.3077 26.2741V31.1065C96.052 31.0298 95.6983 30.9616 95.2466 30.902C94.7949 30.8423 94.3815 30.8125 94.0065 30.8125C93.2054 30.8125 92.4895 30.9872 91.8588 31.3366C91.2367 31.6776 90.7423 32.1548 90.3759 32.7685C90.0179 33.3821 89.8389 34.0895 89.8389 34.8906V46H84.3929ZM98.4034 46V26.3636H103.849V46H98.4034ZM101.139 23.8324C100.33 23.8324 99.6349 23.5639 99.0554 23.027C98.4843 22.4815 98.1988 21.8295 98.1988 21.071C98.1988 20.321 98.4843 19.6776 99.0554 19.1406C99.6349 18.5952 100.33 18.3224 101.139 18.3224C101.949 18.3224 102.639 18.5952 103.21 19.1406C103.79 19.6776 104.08 20.321 104.08 21.071C104.08 21.8295 103.79 22.4815 103.21 23.027C102.639 23.5639 101.949 23.8324 101.139 23.8324ZM112.938 34.6477V46H107.492V26.3636H112.682V29.8281H112.912C113.347 28.6861 114.076 27.7827 115.098 27.1179C116.121 26.4446 117.361 26.108 118.819 26.108C120.182 26.108 121.371 26.4062 122.385 27.0028C123.4 27.5994 124.188 28.4517 124.75 29.5597C125.313 30.6591 125.594 31.9716 125.594 33.4972V46H120.148V34.4688C120.157 33.267 119.85 32.3295 119.228 31.6562C118.606 30.9744 117.749 30.6335 116.658 30.6335C115.925 30.6335 115.277 30.7912 114.715 31.1065C114.161 31.4219 113.726 31.8821 113.411 32.4872C113.104 33.0838 112.947 33.804 112.938 34.6477ZM138.013 53.7727C136.249 53.7727 134.736 53.5298 133.475 53.044C132.222 52.5668 131.225 51.9148 130.483 51.0881C129.742 50.2614 129.26 49.3324 129.039 48.3011L134.076 47.6236C134.229 48.0156 134.472 48.3821 134.804 48.723C135.137 49.0639 135.576 49.3366 136.121 49.5412C136.675 49.7543 137.348 49.8608 138.141 49.8608C139.326 49.8608 140.301 49.571 141.068 48.9915C141.844 48.4205 142.232 47.4616 142.232 46.1151V42.5227H142.002C141.763 43.0682 141.405 43.5838 140.928 44.0696C140.451 44.5554 139.837 44.9517 139.087 45.2585C138.337 45.5653 137.442 45.7188 136.402 45.7188C134.928 45.7188 133.586 45.3778 132.375 44.696C131.174 44.0057 130.215 42.9531 129.499 41.5384C128.791 40.1151 128.438 38.3168 128.438 36.1435C128.438 33.919 128.8 32.0611 129.524 30.5696C130.249 29.0781 131.212 27.9616 132.414 27.2202C133.624 26.4787 134.949 26.108 136.39 26.108C137.489 26.108 138.409 26.2955 139.151 26.6705C139.892 27.0369 140.489 27.4972 140.941 28.0511C141.401 28.5966 141.755 29.1335 142.002 29.6619H142.206V26.3636H147.614V46.1918C147.614 47.8622 147.205 49.2599 146.387 50.3849C145.568 51.5099 144.435 52.3537 142.986 52.9162C141.546 53.4872 139.888 53.7727 138.013 53.7727ZM138.128 41.6278C139.006 41.6278 139.747 41.4105 140.353 40.9759C140.966 40.5327 141.435 39.902 141.759 39.0838C142.091 38.2571 142.257 37.2685 142.257 36.1179C142.257 34.9673 142.095 33.9702 141.772 33.1264C141.448 32.2741 140.979 31.6136 140.365 31.1449C139.752 30.6761 139.006 30.4418 138.128 30.4418C137.233 30.4418 136.479 30.6847 135.865 31.1705C135.252 31.6477 134.787 32.3125 134.472 33.1648C134.157 34.017 133.999 35.0014 133.999 36.1179C133.999 37.2514 134.157 38.2315 134.472 39.0582C134.796 39.8764 135.26 40.5114 135.865 40.9631C136.479 41.4062 137.233 41.6278 138.128 41.6278ZM167.566 31.9631L162.58 32.2699C162.495 31.8437 162.312 31.4602 162.03 31.1193C161.749 30.7699 161.378 30.4929 160.918 30.2884C160.466 30.0753 159.925 29.9688 159.295 29.9688C158.451 29.9688 157.739 30.1477 157.16 30.5057C156.58 30.8551 156.29 31.3239 156.29 31.9119C156.29 32.3807 156.478 32.777 156.853 33.1009C157.228 33.4247 157.871 33.6847 158.783 33.8807L162.337 34.5966C164.246 34.9886 165.67 35.6193 166.607 36.4886C167.545 37.358 168.013 38.5 168.013 39.9148C168.013 41.2017 167.634 42.331 166.875 43.3026C166.125 44.2741 165.094 45.0327 163.782 45.5781C162.478 46.1151 160.973 46.3835 159.269 46.3835C156.67 46.3835 154.598 45.8423 153.056 44.7599C151.522 43.669 150.623 42.1861 150.358 40.3111L155.715 40.0298C155.877 40.8224 156.269 41.4276 156.891 41.8452C157.513 42.2543 158.31 42.4588 159.282 42.4588C160.236 42.4588 161.003 42.2756 161.583 41.9091C162.171 41.5341 162.469 41.0526 162.478 40.4645C162.469 39.9702 162.26 39.5653 161.851 39.25C161.442 38.9261 160.812 38.679 159.959 38.5085L156.559 37.831C154.641 37.4474 153.214 36.7827 152.276 35.8366C151.347 34.8906 150.883 33.6847 150.883 32.2188C150.883 30.9574 151.223 29.8707 151.905 28.9588C152.596 28.0469 153.563 27.3438 154.807 26.8494C156.06 26.3551 157.526 26.108 159.205 26.108C161.685 26.108 163.637 26.6321 165.06 27.6804C166.492 28.7287 167.327 30.1562 167.566 31.9631ZM182.126 18.5909L173.688 49.9375H168.997L177.434 18.5909H182.126ZM200.368 31.9631L195.382 32.2699C195.297 31.8437 195.114 31.4602 194.832 31.1193C194.551 30.7699 194.18 30.4929 193.72 30.2884C193.269 30.0753 192.727 29.9688 192.097 29.9688C191.253 29.9688 190.541 30.1477 189.962 30.5057C189.382 30.8551 189.092 31.3239 189.092 31.9119C189.092 32.3807 189.28 32.777 189.655 33.1009C190.03 33.4247 190.673 33.6847 191.585 33.8807L195.139 34.5966C197.048 34.9886 198.472 35.6193 199.409 36.4886C200.347 37.358 200.815 38.5 200.815 39.9148C200.815 41.2017 200.436 42.331 199.678 43.3026C198.928 44.2741 197.896 45.0327 196.584 45.5781C195.28 46.1151 193.776 46.3835 192.071 46.3835C189.472 46.3835 187.401 45.8423 185.858 44.7599C184.324 43.669 183.425 42.1861 183.161 40.3111L188.517 40.0298C188.679 40.8224 189.071 41.4276 189.693 41.8452C190.315 42.2543 191.112 42.4588 192.084 42.4588C193.038 42.4588 193.805 42.2756 194.385 41.9091C194.973 41.5341 195.271 41.0526 195.28 40.4645C195.271 39.9702 195.063 39.5653 194.654 39.25C194.244 38.9261 193.614 38.679 192.761 38.5085L189.361 37.831C187.443 37.4474 186.016 36.7827 185.078 35.8366C184.149 34.8906 183.685 33.6847 183.685 32.2188C183.685 30.9574 184.026 29.8707 184.707 28.9588C185.398 28.0469 186.365 27.3438 187.609 26.8494C188.862 26.3551 190.328 26.108 192.007 26.108C194.487 26.108 196.439 26.6321 197.862 27.6804C199.294 28.7287 200.129 30.1562 200.368 31.9631ZM212.474 46.3835C210.454 46.3835 208.715 45.9744 207.258 45.1562C205.809 44.3295 204.692 43.1619 203.908 41.6534C203.124 40.1364 202.732 38.3423 202.732 36.2713C202.732 34.2514 203.124 32.4787 203.908 30.9531C204.692 29.4276 205.796 28.2386 207.219 27.3864C208.651 26.5341 210.33 26.108 212.256 26.108C213.552 26.108 214.758 26.3168 215.874 26.7344C216.999 27.1435 217.979 27.7614 218.815 28.5881C219.658 29.4148 220.315 30.4545 220.783 31.7074C221.252 32.9517 221.486 34.4091 221.486 36.0795V37.5753H204.905V34.2003H216.36C216.36 33.4162 216.19 32.7216 215.849 32.1165C215.508 31.5114 215.035 31.0384 214.43 30.6974C213.833 30.348 213.138 30.1733 212.346 30.1733C211.519 30.1733 210.786 30.3651 210.147 30.7486C209.516 31.1236 209.022 31.6307 208.664 32.2699C208.306 32.9006 208.123 33.6037 208.114 34.3793V37.5881C208.114 38.5597 208.293 39.3991 208.651 40.1065C209.018 40.8139 209.533 41.3594 210.198 41.7429C210.863 42.1264 211.651 42.3182 212.563 42.3182C213.168 42.3182 213.722 42.233 214.225 42.0625C214.728 41.892 215.158 41.6364 215.516 41.2955C215.874 40.9545 216.147 40.5369 216.334 40.0426L221.371 40.375C221.116 41.5852 220.592 42.642 219.799 43.5455C219.015 44.4403 218.001 45.1392 216.756 45.642C215.521 46.1364 214.093 46.3835 212.474 46.3835ZM224.32 53.3636V26.3636H229.69V29.6619H229.933C230.171 29.1335 230.516 28.5966 230.968 28.0511C231.428 27.4972 232.025 27.0369 232.758 26.6705C233.499 26.2955 234.42 26.108 235.519 26.108C236.951 26.108 238.272 26.483 239.482 27.233C240.693 27.9744 241.66 29.0952 242.384 30.5952C243.109 32.0866 243.471 33.9574 243.471 36.2074C243.471 38.3977 243.117 40.2472 242.41 41.7557C241.711 43.2557 240.756 44.3935 239.546 45.169C238.345 45.9361 236.998 46.3196 235.506 46.3196C234.45 46.3196 233.551 46.1449 232.809 45.7955C232.076 45.446 231.475 45.0071 231.006 44.4787C230.538 43.9418 230.18 43.4006 229.933 42.8551H229.766V53.3636H224.32ZM229.651 36.1818C229.651 37.3494 229.813 38.3679 230.137 39.2372C230.461 40.1065 230.93 40.7841 231.543 41.2699C232.157 41.7472 232.903 41.9858 233.781 41.9858C234.667 41.9858 235.417 41.7429 236.031 41.2571C236.644 40.7628 237.109 40.081 237.424 39.2116C237.748 38.3338 237.91 37.3239 237.91 36.1818C237.91 35.0483 237.752 34.0511 237.437 33.1903C237.122 32.3295 236.657 31.6562 236.043 31.1705C235.43 30.6847 234.676 30.4418 233.781 30.4418C232.894 30.4418 232.144 30.6761 231.531 31.1449C230.926 31.6136 230.461 32.2784 230.137 33.1392C229.813 34 229.651 35.0142 229.651 36.1818ZM251.981 46.3707C250.728 46.3707 249.612 46.1534 248.632 45.7188C247.652 45.2756 246.876 44.6236 246.305 43.7628C245.742 42.8935 245.461 41.8111 245.461 40.5156C245.461 39.4247 245.661 38.5085 246.062 37.767C246.463 37.0256 247.008 36.429 247.698 35.9773C248.389 35.5256 249.173 35.1847 250.051 34.9545C250.937 34.7244 251.866 34.5625 252.838 34.4688C253.98 34.3494 254.9 34.2386 255.599 34.1364C256.298 34.0256 256.805 33.8636 257.12 33.6506C257.436 33.4375 257.593 33.1222 257.593 32.7045V32.6278C257.593 31.8182 257.338 31.1918 256.826 30.7486C256.323 30.3054 255.608 30.0838 254.679 30.0838C253.698 30.0838 252.919 30.3011 252.339 30.7358C251.759 31.1619 251.376 31.6989 251.188 32.3466L246.152 31.9375C246.407 30.7443 246.91 29.7131 247.66 28.8438C248.41 27.9659 249.377 27.2926 250.562 26.8239C251.755 26.3466 253.136 26.108 254.704 26.108C255.795 26.108 256.839 26.2358 257.836 26.4915C258.842 26.7472 259.733 27.1435 260.508 27.6804C261.292 28.2173 261.91 28.9077 262.362 29.7514C262.813 30.5866 263.039 31.5881 263.039 32.7557V46H257.875V43.277H257.721C257.406 43.8906 256.984 44.4318 256.456 44.9006C255.927 45.3608 255.292 45.723 254.551 45.9872C253.809 46.2429 252.953 46.3707 251.981 46.3707ZM253.541 42.6122C254.342 42.6122 255.049 42.4545 255.663 42.1392C256.277 41.8153 256.758 41.3807 257.108 40.8352C257.457 40.2898 257.632 39.6719 257.632 38.9815V36.8977C257.461 37.0085 257.227 37.1108 256.929 37.2045C256.639 37.2898 256.311 37.3707 255.944 37.4474C255.578 37.5156 255.211 37.5795 254.845 37.6392C254.478 37.6903 254.146 37.7372 253.848 37.7798C253.208 37.8736 252.65 38.0227 252.173 38.2273C251.696 38.4318 251.325 38.7088 251.061 39.0582C250.796 39.3991 250.664 39.8253 250.664 40.3366C250.664 41.0781 250.933 41.6449 251.47 42.0369C252.015 42.4205 252.706 42.6122 253.541 42.6122ZM266.544 46V26.3636H271.824V29.7898H272.029C272.387 28.571 272.988 27.6506 273.831 27.0284C274.675 26.3977 275.647 26.0824 276.746 26.0824C277.019 26.0824 277.313 26.0994 277.628 26.1335C277.944 26.1676 278.221 26.2145 278.459 26.2741V31.1065C278.204 31.0298 277.85 30.9616 277.398 30.902C276.946 30.8423 276.533 30.8125 276.158 30.8125C275.357 30.8125 274.641 30.9872 274.01 31.3366C273.388 31.6776 272.894 32.1548 272.527 32.7685C272.169 33.3821 271.99 34.0895 271.99 34.8906V46H266.544ZM285.592 46.3707C284.339 46.3707 283.223 46.1534 282.242 45.7188C281.262 45.2756 280.487 44.6236 279.916 43.7628C279.353 42.8935 279.072 41.8111 279.072 40.5156C279.072 39.4247 279.272 38.5085 279.673 37.767C280.073 37.0256 280.619 36.429 281.309 35.9773C282 35.5256 282.784 35.1847 283.661 34.9545C284.548 34.7244 285.477 34.5625 286.448 34.4688C287.59 34.3494 288.511 34.2386 289.21 34.1364C289.909 34.0256 290.416 33.8636 290.731 33.6506C291.046 33.4375 291.204 33.1222 291.204 32.7045V32.6278C291.204 31.8182 290.948 31.1918 290.437 30.7486C289.934 30.3054 289.218 30.0838 288.289 30.0838C287.309 30.0838 286.529 30.3011 285.95 30.7358C285.37 31.1619 284.987 31.6989 284.799 32.3466L279.762 31.9375C280.018 30.7443 280.521 29.7131 281.271 28.8438C282.021 27.9659 282.988 27.2926 284.173 26.8239C285.366 26.3466 286.747 26.108 288.315 26.108C289.406 26.108 290.45 26.2358 291.447 26.4915C292.453 26.7472 293.343 27.1435 294.119 27.6804C294.903 28.2173 295.521 28.9077 295.973 29.7514C296.424 30.5866 296.65 31.5881 296.65 32.7557V46H291.485V43.277H291.332C291.017 43.8906 290.595 44.4318 290.066 44.9006C289.538 45.3608 288.903 45.723 288.161 45.9872C287.42 46.2429 286.563 46.3707 285.592 46.3707ZM287.152 42.6122C287.953 42.6122 288.66 42.4545 289.274 42.1392C289.887 41.8153 290.369 41.3807 290.718 40.8352C291.068 40.2898 291.242 39.6719 291.242 38.9815V36.8977C291.072 37.0085 290.838 37.1108 290.539 37.2045C290.25 37.2898 289.921 37.3707 289.555 37.4474C289.188 37.5156 288.822 37.5795 288.456 37.6392C288.089 37.6903 287.757 37.7372 287.458 37.7798C286.819 37.8736 286.261 38.0227 285.784 38.2273C285.306 38.4318 284.936 38.7088 284.671 39.0582C284.407 39.3991 284.275 39.8253 284.275 40.3366C284.275 41.0781 284.544 41.6449 285.081 42.0369C285.626 42.4205 286.316 42.6122 287.152 42.6122ZM300.258 46V19.8182H305.704V29.6619H305.87C306.108 29.1335 306.454 28.5966 306.905 28.0511C307.365 27.4972 307.962 27.0369 308.695 26.6705C309.436 26.2955 310.357 26.108 311.456 26.108C312.888 26.108 314.209 26.483 315.419 27.233C316.63 27.9744 317.597 29.0952 318.321 30.5952C319.046 32.0866 319.408 33.9574 319.408 36.2074C319.408 38.3977 319.054 40.2472 318.347 41.7557C317.648 43.2557 316.694 44.3935 315.483 45.169C314.282 45.9361 312.935 46.3196 311.444 46.3196C310.387 46.3196 309.488 46.1449 308.746 45.7955C308.013 45.446 307.412 45.0071 306.944 44.4787C306.475 43.9418 306.117 43.4006 305.87 42.8551H305.627V46H300.258ZM305.588 36.1818C305.588 37.3494 305.75 38.3679 306.074 39.2372C306.398 40.1065 306.867 40.7841 307.481 41.2699C308.094 41.7472 308.84 41.9858 309.718 41.9858C310.604 41.9858 311.354 41.7429 311.968 41.2571C312.581 40.7628 313.046 40.081 313.361 39.2116C313.685 38.3338 313.847 37.3239 313.847 36.1818C313.847 35.0483 313.689 34.0511 313.374 33.1903C313.059 32.3295 312.594 31.6562 311.981 31.1705C311.367 30.6847 310.613 30.4418 309.718 30.4418C308.831 30.4418 308.081 30.6761 307.468 31.1449C306.863 31.6136 306.398 32.2784 306.074 33.1392C305.75 34 305.588 35.0142 305.588 36.1818ZM322.322 46V26.3636H327.768V46H322.322ZM325.058 23.8324C324.248 23.8324 323.554 23.5639 322.974 23.027C322.403 22.4815 322.117 21.8295 322.117 21.071C322.117 20.321 322.403 19.6776 322.974 19.1406C323.554 18.5952 324.248 18.3224 325.058 18.3224C325.867 18.3224 326.558 18.5952 327.129 19.1406C327.708 19.6776 327.998 20.321 327.998 21.071C327.998 21.8295 327.708 22.4815 327.129 23.027C326.558 23.5639 325.867 23.8324 325.058 23.8324ZM336.857 19.8182V46H331.411V19.8182H336.857ZM340.499 46V26.3636H345.945V46H340.499ZM343.235 23.8324C342.425 23.8324 341.731 23.5639 341.151 23.027C340.58 22.4815 340.295 21.8295 340.295 21.071C340.295 20.321 340.58 19.6776 341.151 19.1406C341.731 18.5952 342.425 18.3224 343.235 18.3224C344.045 18.3224 344.735 18.5952 345.306 19.1406C345.886 19.6776 346.175 20.321 346.175 21.071C346.175 21.8295 345.886 22.4815 345.306 23.027C344.735 23.5639 344.045 23.8324 343.235 23.8324ZM360.032 26.3636V30.4545H348.207V26.3636H360.032ZM350.892 21.6591H356.338V39.9659C356.338 40.4687 356.414 40.8608 356.568 41.142C356.721 41.4148 356.934 41.6065 357.207 41.7173C357.488 41.8281 357.812 41.8835 358.179 41.8835C358.434 41.8835 358.69 41.8622 358.946 41.8196C359.201 41.7685 359.397 41.7301 359.534 41.7045L360.39 45.7571C360.118 45.8423 359.734 45.9403 359.24 46.0511C358.745 46.1705 358.145 46.2429 357.437 46.2685C356.125 46.3196 354.974 46.1449 353.985 45.7443C353.005 45.3437 352.243 44.7216 351.697 43.8778C351.152 43.0341 350.883 41.9687 350.892 40.6818V21.6591ZM366.222 53.3636C365.532 53.3636 364.884 53.3082 364.279 53.1974C363.682 53.0952 363.188 52.9631 362.796 52.8011L364.023 48.7358C364.662 48.9318 365.238 49.0384 365.749 49.0554C366.269 49.0724 366.716 48.9531 367.091 48.6974C367.475 48.4418 367.786 48.0071 368.025 47.3935L368.344 46.5625L361.3 26.3636H367.028L371.093 40.7841H371.297L375.401 26.3636H381.167L373.535 48.1222C373.168 49.179 372.67 50.0994 372.039 50.8835C371.417 51.6761 370.628 52.2855 369.674 52.7116C368.719 53.1463 367.569 53.3636 366.222 53.3636Z" fill="white"/>
+<rect x="1451" y="528" width="144" height="156" rx="6" fill="#D9D9D9" stroke="black" stroke-width="4"/>
+<path d="M1531.5 554.78L1513.5 562.706V557.528L1525.82 552.581L1525.66 552.849V552.21L1525.82 552.479L1513.5 547.531V542.354L1531.5 550.28V554.78ZM1529.06 583.591L1520.63 614.938H1515.93L1524.37 583.591H1529.06ZM1513.5 650.78V646.28L1531.5 638.354V643.531L1519.18 648.479L1519.34 648.21V648.849L1519.18 648.581L1531.5 653.528V658.706L1513.5 650.78Z" fill="black"/>
+<path d="M1526.19 465.375H1514.56C1514.6 461.375 1514.96 458.104 1515.62 455.562C1516.33 452.979 1517.48 450.625 1519.06 448.5C1520.65 446.375 1522.75 443.958 1525.38 441.25C1527.29 439.292 1529.04 437.458 1530.62 435.75C1532.25 434 1533.56 432.125 1534.56 430.125C1535.56 428.083 1536.06 425.646 1536.06 422.812C1536.06 419.938 1535.54 417.458 1534.5 415.375C1533.5 413.292 1532 411.688 1530 410.562C1528.04 409.438 1525.6 408.875 1522.69 408.875C1520.27 408.875 1517.98 409.312 1515.81 410.188C1513.65 411.062 1511.9 412.417 1510.56 414.25C1509.23 416.042 1508.54 418.396 1508.5 421.312H1496.94C1497.02 416.604 1498.19 412.562 1500.44 409.188C1502.73 405.812 1505.81 403.229 1509.69 401.438C1513.56 399.646 1517.9 398.75 1522.69 398.75C1527.98 398.75 1532.48 399.708 1536.19 401.625C1539.94 403.542 1542.79 406.292 1544.75 409.875C1546.71 413.417 1547.69 417.625 1547.69 422.5C1547.69 426.25 1546.92 429.708 1545.38 432.875C1543.88 436 1541.94 438.938 1539.56 441.688C1537.19 444.438 1534.67 447.062 1532 449.562C1529.71 451.688 1528.17 454.083 1527.38 456.75C1526.58 459.417 1526.19 462.292 1526.19 465.375ZM1514.06 485.188C1514.06 483.312 1514.65 481.729 1515.81 480.438C1516.98 479.146 1518.67 478.5 1520.88 478.5C1523.12 478.5 1524.83 479.146 1526 480.438C1527.17 481.729 1527.75 483.312 1527.75 485.188C1527.75 486.979 1527.17 488.521 1526 489.812C1524.83 491.104 1523.12 491.75 1520.88 491.75C1518.67 491.75 1516.98 491.104 1515.81 489.812C1514.65 488.521 1514.06 486.979 1514.06 485.188Z" fill="black"/>
+<mask id="mask103_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="536" y="854" width="112" height="114">
+<path d="M536 967.037H647.004V854H536V967.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask103_13_16078)">
+<mask id="mask104_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask104_13_16078)">
+<path d="M632.723 910.52L627.2 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask105_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask105_13_16078)">
+<path d="M632.723 910.52L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask106_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask106_13_16078)">
+<path d="M632.723 910.52L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask107_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask107_13_16078)">
+<path d="M632.723 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask108_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask108_13_16078)">
+<path d="M627.2 889.532L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask109_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask109_13_16078)">
+<path d="M627.2 889.532L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask110_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask110_13_16078)">
+<path d="M627.2 889.532L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask111_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask111_13_16078)">
+<path d="M612.112 874.168L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask112_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask112_13_16078)">
+<path d="M570.89 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask113_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask113_13_16078)">
+<path d="M570.891 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask114_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask114_13_16078)">
+<path d="M570.89 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask115_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask115_13_16078)">
+<path d="M555.802 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask116_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask116_13_16078)">
+<path d="M555.802 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask117_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask117_13_16078)">
+<path d="M555.802 889.532L570.89 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask118_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask118_13_16078)">
+<path d="M550.28 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask119_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask119_13_16078)">
+<path d="M570.891 946.872L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask120_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask120_13_16078)">
+<path d="M570.891 946.872H612.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask121_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask121_13_16078)">
+<path d="M570.891 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask122_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask122_13_16078)">
+<path d="M591.501 952.495L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask123_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask123_13_16078)">
+<path d="M591.501 952.495L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask124_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask124_13_16078)">
+<path d="M612.112 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask125_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask125_13_16078)">
+<path d="M632.723 910.52L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask126_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask126_13_16078)">
+<path d="M632.723 910.52L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask127_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask127_13_16078)">
+<path d="M632.723 910.52L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask128_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask128_13_16078)">
+<path d="M632.723 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask129_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask129_13_16078)">
+<path d="M632.723 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask130_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask130_13_16078)">
+<path d="M632.723 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask131_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask131_13_16078)">
+<path d="M632.723 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask132_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask132_13_16078)">
+<path d="M627.2 889.532H555.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask133_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask133_13_16078)">
+<path d="M627.2 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask134_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask134_13_16078)">
+<path d="M627.2 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask135_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask135_13_16078)">
+<path d="M627.2 889.532L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask136_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask136_13_16078)">
+<path d="M627.2 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask137_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask137_13_16078)">
+<path d="M627.2 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask138_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask138_13_16078)">
+<path d="M627.2 889.532V931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask139_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask139_13_16078)">
+<path d="M612.112 874.168H570.891" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask140_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask140_13_16078)">
+<path d="M612.112 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask141_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask141_13_16078)">
+<path d="M612.112 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask142_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask142_13_16078)">
+<path d="M612.112 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask143_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask143_13_16078)">
+<path d="M612.112 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask144_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask144_13_16078)">
+<path d="M612.112 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask145_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask145_13_16078)">
+<path d="M612.112 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask146_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask146_13_16078)">
+<path d="M612.112 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask147_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask147_13_16078)">
+<path d="M591.501 868.544L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask148_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask148_13_16078)">
+<path d="M591.501 868.544L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask149_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask149_13_16078)">
+<path d="M591.501 868.544L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask150_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask150_13_16078)">
+<path d="M591.501 868.544L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask151_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask151_13_16078)">
+<path d="M591.501 868.544L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask152_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask152_13_16078)">
+<path d="M591.501 868.544V952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask153_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask153_13_16078)">
+<path d="M591.501 868.544L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask154_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask154_13_16078)">
+<path d="M591.501 868.544L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask155_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask155_13_16078)">
+<path d="M570.891 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask156_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask156_13_16078)">
+<path d="M570.891 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask157_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask157_13_16078)">
+<path d="M570.891 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask158_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask158_13_16078)">
+<path d="M570.891 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask159_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask159_13_16078)">
+<path d="M555.802 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask160_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask160_13_16078)">
+<path d="M555.802 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask161_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask161_13_16078)">
+<path d="M555.802 889.532L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask162_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask162_13_16078)">
+<path d="M550.28 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask163_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask163_13_16078)">
+<path d="M550.28 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask164_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask164_13_16078)">
+<path d="M550.28 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask165_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask165_13_16078)">
+<path d="M550.28 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask166_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask166_13_16078)">
+<path d="M555.802 931.508L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask167_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask167_13_16078)">
+<path d="M555.802 931.508L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask168_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask168_13_16078)">
+<path d="M555.802 931.508L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask169_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask169_13_16078)">
+<path d="M555.802 931.508L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask170_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask170_13_16078)">
+<mask id="mask171_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="627" y="905" width="11" height="11">
+<path d="M627.766 915.568H637.68V905.472H627.766V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask171_13_16078)">
+<path d="M632.723 915.045C633.901 915.045 635.032 914.568 635.865 913.72C636.699 912.871 637.167 911.72 637.167 910.52C637.167 909.32 636.699 908.168 635.865 907.32C635.032 906.471 633.901 905.994 632.723 905.994C631.544 905.994 630.414 906.471 629.58 907.32C628.747 908.168 628.279 909.32 628.279 910.52C628.279 911.72 628.747 912.871 629.58 913.72C630.414 914.568 631.544 915.045 632.723 915.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask172_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask172_13_16078)">
+<mask id="mask173_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="884" width="11" height="11">
+<path d="M622.243 894.58H632.157V884.484H622.243V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask173_13_16078)">
+<path d="M627.2 894.057C628.379 894.057 629.509 893.58 630.343 892.732C631.176 891.883 631.644 890.732 631.644 889.532C631.644 888.332 631.176 887.181 630.343 886.332C629.509 885.483 628.379 885.007 627.2 885.007C626.022 885.007 624.891 885.483 624.058 886.332C623.224 887.181 622.756 888.332 622.756 889.532C622.756 890.732 623.224 891.883 624.058 892.732C624.891 893.58 626.022 894.057 627.2 894.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask174_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask174_13_16078)">
+<mask id="mask175_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="869" width="11" height="11">
+<path d="M607.155 879.215H617.069V869.12H607.155V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask175_13_16078)">
+<path d="M612.112 878.693C613.291 878.693 614.421 878.216 615.254 877.367C616.088 876.519 616.556 875.368 616.556 874.168C616.556 872.967 616.088 871.816 615.254 870.968C614.421 870.119 613.291 869.642 612.112 869.642C610.933 869.642 609.803 870.119 608.97 870.968C608.136 871.816 607.668 872.967 607.668 874.168C607.668 875.368 608.136 876.519 608.97 877.367C609.803 878.216 610.933 878.693 612.112 878.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask176_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask176_13_16078)">
+<mask id="mask177_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="863" width="11" height="11">
+<path d="M586.544 873.592H596.458V863.496H586.544V873.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask177_13_16078)">
+<path d="M591.501 873.069C592.68 873.069 593.81 872.592 594.644 871.744C595.477 870.895 595.945 869.744 595.945 868.544C595.945 867.344 595.477 866.193 594.644 865.344C593.81 864.495 592.68 864.019 591.501 864.019C590.323 864.019 589.192 864.495 588.359 865.344C587.526 866.193 587.057 867.344 587.057 868.544C587.057 869.744 587.526 870.895 588.359 871.744C589.192 872.592 590.323 873.069 591.501 873.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask178_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask178_13_16078)">
+<mask id="mask179_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="869" width="11" height="11">
+<path d="M565.933 879.215H575.848V869.12H565.933V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask179_13_16078)">
+<path d="M570.891 878.693C572.069 878.693 573.2 878.216 574.033 877.367C574.866 876.519 575.334 875.368 575.334 874.168C575.334 872.967 574.866 871.816 574.033 870.968C573.2 870.119 572.069 869.642 570.891 869.642C569.712 869.642 568.581 870.119 567.748 870.968C566.915 871.816 566.447 872.967 566.447 874.168C566.447 875.368 566.915 876.519 567.748 877.367C568.581 878.216 569.712 878.693 570.891 878.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask180_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask180_13_16078)">
+<mask id="mask181_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="884" width="11" height="11">
+<path d="M550.845 894.58H560.76V884.484H550.845V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask181_13_16078)">
+<path d="M555.802 894.057C556.981 894.057 558.111 893.58 558.945 892.732C559.778 891.883 560.246 890.732 560.246 889.532C560.246 888.332 559.778 887.181 558.945 886.332C558.111 885.483 556.981 885.007 555.802 885.007C554.624 885.007 553.493 885.483 552.66 886.332C551.827 887.181 551.358 888.332 551.358 889.532C551.358 890.732 551.827 891.883 552.66 892.732C553.493 893.58 554.624 894.057 555.802 894.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask182_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask182_13_16078)">
+<mask id="mask183_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="545" y="905" width="11" height="11">
+<path d="M545.323 915.568H555.237V905.472H545.323V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask183_13_16078)">
+<path d="M550.28 915.045C551.458 915.045 552.589 914.568 553.422 913.72C554.255 912.871 554.724 911.72 554.724 910.52C554.724 909.32 554.255 908.168 553.422 907.32C552.589 906.471 551.458 905.994 550.28 905.994C549.101 905.994 547.971 906.471 547.137 907.32C546.304 908.168 545.836 909.32 545.836 910.52C545.836 911.72 546.304 912.871 547.137 913.72C547.971 914.568 549.101 915.045 550.28 915.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask184_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask184_13_16078)">
+<mask id="mask185_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="926" width="11" height="11">
+<path d="M550.845 936.555H560.76V926.46H550.845V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask185_13_16078)">
+<path d="M555.802 936.033C556.981 936.033 558.111 935.556 558.945 934.708C559.778 933.859 560.246 932.708 560.246 931.508C560.246 930.308 559.778 929.156 558.945 928.308C558.111 927.459 556.981 926.982 555.802 926.982C554.624 926.982 553.493 927.459 552.66 928.308C551.827 929.156 551.358 930.308 551.358 931.508C551.358 932.708 551.827 933.859 552.66 934.708C553.493 935.556 554.624 936.033 555.802 936.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask186_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask186_13_16078)">
+<mask id="mask187_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="941" width="11" height="11">
+<path d="M565.933 951.92H575.848V941.824H565.933V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask187_13_16078)">
+<path d="M570.891 951.397C572.069 951.397 573.2 950.92 574.033 950.072C574.866 949.223 575.334 948.072 575.334 946.872C575.334 945.672 574.866 944.521 574.033 943.672C573.2 942.823 572.069 942.347 570.891 942.347C569.712 942.347 568.581 942.823 567.748 943.672C566.915 944.521 566.447 945.672 566.447 946.872C566.447 948.072 566.915 949.223 567.748 950.072C568.581 950.92 569.712 951.397 570.891 951.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask188_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask188_13_16078)">
+<mask id="mask189_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="947" width="11" height="11">
+<path d="M586.544 957.543H596.458V947.448H586.544V957.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask189_13_16078)">
+<path d="M591.501 957.021C592.68 957.021 593.81 956.544 594.644 955.695C595.477 954.847 595.945 953.696 595.945 952.496C595.945 951.295 595.477 950.144 594.644 949.296C593.81 948.447 592.68 947.97 591.501 947.97C590.323 947.97 589.192 948.447 588.359 949.296C587.526 950.144 587.057 951.295 587.057 952.496C587.057 953.696 587.526 954.847 588.359 955.695C589.192 956.544 590.323 957.021 591.501 957.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask190_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask190_13_16078)">
+<mask id="mask191_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="941" width="11" height="11">
+<path d="M607.155 951.92H617.069V941.824H607.155V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask191_13_16078)">
+<path d="M612.112 951.397C613.291 951.397 614.421 950.92 615.254 950.072C616.088 949.223 616.556 948.072 616.556 946.872C616.556 945.672 616.088 944.521 615.254 943.672C614.421 942.823 613.291 942.347 612.112 942.347C610.933 942.347 609.803 942.823 608.97 943.672C608.136 944.521 607.668 945.672 607.668 946.872C607.668 948.072 608.136 949.223 608.97 950.072C609.803 950.92 610.933 951.397 612.112 951.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask192_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask192_13_16078)">
+<mask id="mask193_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="926" width="11" height="11">
+<path d="M622.243 936.555H632.157V926.46H622.243V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask193_13_16078)">
+<path d="M627.2 936.033C628.379 936.033 629.509 935.556 630.343 934.708C631.176 933.859 631.644 932.708 631.644 931.508C631.644 930.308 631.176 929.156 630.343 928.308C629.509 927.459 628.379 926.982 627.2 926.982C626.022 926.982 624.891 927.459 624.058 928.308C623.224 929.156 622.756 930.308 622.756 931.508C622.756 932.708 623.224 933.859 624.058 934.708C624.891 935.556 626.022 936.033 627.2 936.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask194_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask194_13_16078)">
+<path d="M632.767 907.274C632.36 907.274 632.066 907.389 631.795 907.642C631.388 908.057 631.117 908.885 631.117 909.737C631.117 910.542 631.343 911.394 631.682 911.808C631.953 912.13 632.315 912.291 632.721 912.291C633.083 912.291 633.399 912.176 633.648 911.923C634.077 911.532 634.349 910.68 634.349 909.783C634.349 908.287 633.693 907.274 632.767 907.274ZM632.744 907.458C633.332 907.458 633.648 908.287 633.648 909.806C633.648 911.325 633.354 912.107 632.721 912.107C632.111 912.107 631.795 911.325 631.795 909.806C631.795 908.264 632.111 907.458 632.744 907.458Z" fill="white"/>
+</g>
+<mask id="mask195_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask195_13_16078)">
+<path d="M627.489 886.291L626.201 886.959V887.051C626.292 887.005 626.359 886.982 626.405 886.982C626.518 886.913 626.653 886.89 626.721 886.89C626.879 886.89 626.947 887.005 626.947 887.235V890.549C626.947 890.779 626.879 890.94 626.766 891.009C626.653 891.078 626.563 891.101 626.246 891.101V891.216H628.235V891.101C627.67 891.101 627.557 891.032 627.557 890.687V886.291H627.489Z" fill="white"/>
+</g>
+<mask id="mask196_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask196_13_16078)">
+<path d="M613.737 874.859L613.624 874.813C613.376 875.228 613.285 875.297 612.946 875.297H611.251L612.449 874.008C613.082 873.34 613.353 872.788 613.353 872.213C613.353 871.476 612.788 870.924 612.042 870.924C611.635 870.924 611.274 871.085 611.003 871.361C610.777 871.614 610.664 871.844 610.551 872.374L610.686 872.397C610.98 871.683 611.251 871.453 611.726 871.453C612.336 871.453 612.743 871.868 612.743 872.489C612.743 873.064 612.426 873.732 611.816 874.376L610.551 875.757V875.849H613.33L613.737 874.859Z" fill="white"/>
+</g>
+<mask id="mask197_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask197_13_16078)">
+<path d="M590.821 867.811C591.227 867.811 591.386 867.834 591.566 867.903C592.018 868.065 592.29 868.479 592.29 868.985C592.29 869.583 591.883 870.067 591.363 870.067C591.16 870.067 591.024 870.021 590.753 869.837C590.527 869.698 590.414 869.652 590.301 869.652C590.12 869.652 590.03 869.768 590.03 869.906C590.03 870.159 590.323 870.32 590.821 870.32C591.386 870.32 591.951 870.136 592.29 869.837C592.629 869.537 592.809 869.123 592.809 868.64C592.809 868.249 592.696 867.926 592.493 867.696C592.335 867.535 592.199 867.443 591.883 867.305C592.38 866.96 592.561 866.684 592.561 866.292C592.561 865.694 592.109 865.303 591.453 865.303C591.092 865.303 590.775 865.418 590.527 865.648C590.301 865.855 590.188 866.039 590.03 866.477L590.143 866.5C590.436 865.97 590.753 865.74 591.205 865.74C591.679 865.74 591.996 866.062 591.996 866.523C591.996 866.776 591.883 867.029 591.702 867.213C591.499 867.443 591.295 867.558 590.821 867.719V867.811Z" fill="white"/>
+</g>
+<mask id="mask198_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask198_13_16078)">
+<path d="M572.492 874.169H571.746V870.924H571.43L569.192 874.169V874.629H571.204V875.849H571.746V874.629H572.492V874.169ZM571.204 874.169H569.463L571.204 871.66V874.169Z" fill="white"/>
+</g>
+<mask id="mask199_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask199_13_16078)">
+<path d="M555.299 886.959H556.722C556.835 886.959 556.858 886.959 556.881 886.89L557.152 886.245L557.084 886.199C556.971 886.36 556.903 886.383 556.745 886.383H555.253L554.485 888.109C554.462 888.132 554.462 888.132 554.462 888.156C554.462 888.179 554.508 888.202 554.553 888.202C554.779 888.202 555.073 888.271 555.366 888.363C556.18 888.616 556.564 889.076 556.564 889.812C556.564 890.503 556.135 891.055 555.57 891.055C555.434 891.055 555.299 890.986 555.095 890.848C554.869 890.664 554.688 890.595 554.553 890.595C554.349 890.595 554.236 890.687 554.236 890.871C554.236 891.147 554.575 891.308 555.118 891.308C555.705 891.308 556.225 891.124 556.587 890.756C556.926 890.411 557.061 889.997 557.061 889.444C557.061 888.915 556.926 888.593 556.564 888.225C556.27 887.902 555.841 887.741 555.005 887.58L555.299 886.959Z" fill="white"/>
+</g>
+<mask id="mask200_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask200_13_16078)">
+<path d="M551.677 907.205C550.863 907.274 550.457 907.412 549.937 907.803C549.146 908.356 548.739 909.184 548.739 910.174C548.739 910.795 548.92 911.44 549.236 911.808C549.507 912.13 549.892 912.291 550.344 912.291C551.225 912.291 551.835 911.601 551.835 910.611C551.835 909.668 551.315 909.069 550.502 909.069C550.185 909.069 550.027 909.138 549.575 909.414C549.779 908.31 550.57 907.504 551.7 907.32L551.677 907.205ZM550.231 909.414C550.841 909.414 551.202 909.944 551.202 910.841C551.202 911.647 550.909 912.107 550.411 912.107C549.779 912.107 549.394 911.417 549.394 910.289C549.394 909.898 549.462 909.714 549.598 909.599C549.756 909.483 549.982 909.414 550.231 909.414Z" fill="white"/>
+</g>
+<mask id="mask201_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask201_13_16078)">
+<path d="M557.22 928.355H554.575L554.146 929.436L554.282 929.482C554.575 928.999 554.711 928.907 555.118 928.907H556.655L555.253 933.257H555.705L557.22 928.47V928.355Z" fill="white"/>
+</g>
+<mask id="mask202_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask202_13_16078)">
+<path d="M571.181 945.839C571.882 945.471 572.13 945.149 572.13 944.666C572.13 944.067 571.633 943.63 570.91 943.63C570.119 943.63 569.554 944.113 569.554 944.781C569.554 945.241 569.689 945.471 570.435 946.139C569.667 946.737 569.509 946.967 569.509 947.45C569.509 948.164 570.074 948.647 570.887 948.647C571.746 948.647 572.288 948.187 572.288 947.427C572.288 946.852 572.04 946.507 571.181 945.839ZM571.045 946.599C571.565 946.99 571.746 947.243 571.746 947.657C571.746 948.118 571.43 948.463 570.955 948.463C570.413 948.463 570.051 948.026 570.051 947.404C570.051 946.921 570.209 946.622 570.616 946.277L571.045 946.599ZM570.978 945.724C570.345 945.287 570.074 944.965 570.074 944.551C570.074 944.136 570.39 943.837 570.842 943.837C571.339 943.837 571.656 944.159 571.656 944.643C571.656 945.057 571.452 945.402 571.045 945.678C571 945.701 571 945.701 570.978 945.724Z" fill="white"/>
+</g>
+<mask id="mask203_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask203_13_16078)">
+<path d="M590.143 954.337C590.934 954.245 591.34 954.107 591.815 953.739C592.561 953.187 593.013 952.289 593.013 951.299C593.013 950.103 592.335 949.251 591.408 949.251C590.572 949.251 589.939 949.988 589.939 950.977C589.939 951.852 590.436 952.45 591.227 952.45C591.612 952.45 591.905 952.335 592.29 952.036C591.996 953.21 591.205 953.992 590.12 954.199L590.143 954.337ZM592.312 951.576C592.312 951.737 592.267 951.806 592.199 951.875C591.996 952.036 591.725 952.128 591.476 952.128C590.934 952.128 590.595 951.576 590.595 950.724C590.595 950.31 590.708 949.873 590.843 949.665C590.979 949.527 591.16 949.458 591.363 949.458C591.973 949.458 592.312 950.08 592.312 951.299V951.576Z" fill="white"/>
+</g>
+<mask id="mask204_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask204_13_16078)">
+<path d="M610.613 943.63L609.324 944.297V944.39C609.415 944.343 609.483 944.32 609.528 944.32C609.641 944.251 609.776 944.228 609.844 944.228C610.002 944.228 610.07 944.343 610.07 944.574V947.888C610.07 948.118 610.002 948.279 609.889 948.348C609.776 948.417 609.686 948.44 609.37 948.44V948.555H611.358V948.44C610.793 948.44 610.68 948.371 610.68 948.026V943.63H610.613ZM613.941 943.63C613.534 943.63 613.24 943.745 612.969 943.998C612.562 944.413 612.291 945.241 612.291 946.093C612.291 946.898 612.517 947.75 612.856 948.164C613.127 948.486 613.489 948.647 613.895 948.647C614.257 948.647 614.573 948.532 614.822 948.279C615.251 947.888 615.523 947.036 615.523 946.139C615.523 944.643 614.867 943.63 613.941 943.63ZM613.918 943.814C614.506 943.814 614.822 944.643 614.822 946.162C614.822 947.68 614.528 948.463 613.895 948.463C613.285 948.463 612.969 947.68 612.969 946.162C612.969 944.62 613.285 943.814 613.918 943.814Z" fill="white"/>
+</g>
+<mask id="mask205_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask205_13_16078)">
+<path d="M625.698 928.263L624.41 928.93V929.022C624.5 928.976 624.568 928.953 624.613 928.953C624.726 928.884 624.862 928.861 624.93 928.861C625.088 928.861 625.156 928.976 625.156 929.206V932.52C625.156 932.75 625.088 932.911 624.975 932.981C624.862 933.05 624.772 933.073 624.455 933.073V933.188H626.444V933.073C625.879 933.073 625.766 933.004 625.766 932.658V928.263H625.698ZM629.28 928.263L627.992 928.93V929.022C628.083 928.976 628.15 928.953 628.196 928.953C628.309 928.884 628.444 928.861 628.512 928.861C628.67 928.861 628.738 928.976 628.738 929.206V932.52C628.738 932.75 628.67 932.911 628.557 932.981C628.444 933.05 628.354 933.073 628.037 933.073V933.188H630.026V933.073C629.461 933.073 629.348 933.004 629.348 932.658V928.263H629.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask206_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="476" width="112" height="114">
+<path d="M303 589.037H414.004V476H303V589.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask206_13_16078)">
+<mask id="mask207_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask207_13_16078)">
+<path d="M399.723 532.52L394.2 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask208_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask208_13_16078)">
+<path d="M399.723 532.52L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask209_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask209_13_16078)">
+<path d="M399.723 532.52L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask210_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask210_13_16078)">
+<path d="M399.723 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask211_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask211_13_16078)">
+<path d="M394.2 511.532L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask212_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask212_13_16078)">
+<path d="M394.2 511.532L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask213_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask213_13_16078)">
+<path d="M394.2 511.532L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask214_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask214_13_16078)">
+<path d="M379.112 496.168L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask215_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask215_13_16078)">
+<path d="M337.89 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask216_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask216_13_16078)">
+<path d="M337.89 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask217_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask217_13_16078)">
+<path d="M337.891 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask218_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask218_13_16078)">
+<path d="M322.802 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask219_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask219_13_16078)">
+<path d="M322.802 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask220_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask220_13_16078)">
+<path d="M322.802 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask221_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask221_13_16078)">
+<path d="M317.28 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask222_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask222_13_16078)">
+<path d="M337.891 568.872L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask223_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask223_13_16078)">
+<path d="M337.891 568.872H379.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask224_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask224_13_16078)">
+<path d="M337.891 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask225_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask225_13_16078)">
+<path d="M358.501 574.495L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask226_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask226_13_16078)">
+<path d="M358.501 574.495L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask227_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask227_13_16078)">
+<path d="M379.112 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask228_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask228_13_16078)">
+<path d="M399.723 532.52L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask229_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask229_13_16078)">
+<path d="M399.723 532.52L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask230_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask230_13_16078)">
+<path d="M399.723 532.52L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask231_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask231_13_16078)">
+<path d="M399.723 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask232_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask232_13_16078)">
+<path d="M399.723 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask233_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask233_13_16078)">
+<path d="M399.723 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask234_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask234_13_16078)">
+<path d="M399.723 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask235_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask235_13_16078)">
+<path d="M394.2 511.532H322.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask236_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask236_13_16078)">
+<path d="M394.2 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask237_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask237_13_16078)">
+<path d="M394.2 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask238_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask238_13_16078)">
+<path d="M394.2 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask239_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask239_13_16078)">
+<path d="M394.2 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask240_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask240_13_16078)">
+<path d="M394.2 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask241_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask241_13_16078)">
+<path d="M394.2 511.532V553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask242_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask242_13_16078)">
+<path d="M379.112 496.168H337.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask243_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask243_13_16078)">
+<path d="M379.112 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask244_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask244_13_16078)">
+<path d="M379.112 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask245_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask245_13_16078)">
+<path d="M379.112 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask246_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask246_13_16078)">
+<path d="M379.112 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask247_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask247_13_16078)">
+<path d="M379.112 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask248_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask248_13_16078)">
+<path d="M379.112 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask249_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask249_13_16078)">
+<path d="M379.112 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask250_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask250_13_16078)">
+<path d="M358.501 490.544L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask251_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask251_13_16078)">
+<path d="M358.501 490.544L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask252_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask252_13_16078)">
+<path d="M358.501 490.544L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask253_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask253_13_16078)">
+<path d="M358.501 490.544L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask254_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask254_13_16078)">
+<path d="M358.501 490.544L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask255_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask255_13_16078)">
+<path d="M358.501 490.544V574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask256_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask256_13_16078)">
+<path d="M358.501 490.544L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask257_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask257_13_16078)">
+<path d="M358.501 490.544L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask258_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask258_13_16078)">
+<path d="M337.89 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask259_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask259_13_16078)">
+<path d="M337.89 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask260_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask260_13_16078)">
+<path d="M337.89 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask261_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask261_13_16078)">
+<path d="M337.89 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask262_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask262_13_16078)">
+<path d="M322.802 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask263_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask263_13_16078)">
+<path d="M322.802 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask264_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask264_13_16078)">
+<path d="M322.802 511.532L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask265_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask265_13_16078)">
+<path d="M317.28 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask266_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask266_13_16078)">
+<path d="M317.28 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask267_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask267_13_16078)">
+<path d="M317.28 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask268_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask268_13_16078)">
+<path d="M317.28 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask269_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask269_13_16078)">
+<path d="M322.802 553.508L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask270_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask270_13_16078)">
+<path d="M322.802 553.508L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask271_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask271_13_16078)">
+<path d="M322.802 553.508L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask272_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask272_13_16078)">
+<path d="M322.802 553.508L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask273_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask273_13_16078)">
+<mask id="mask274_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="527" width="11" height="11">
+<path d="M394.766 537.568H404.68V527.472H394.766V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask274_13_16078)">
+<path d="M399.723 537.045C400.901 537.045 402.032 536.568 402.865 535.72C403.699 534.871 404.167 533.72 404.167 532.52C404.167 531.32 403.699 530.168 402.865 529.32C402.032 528.471 400.901 527.994 399.723 527.994C398.544 527.994 397.414 528.471 396.58 529.32C395.747 530.168 395.279 531.32 395.279 532.52C395.279 533.72 395.747 534.871 396.58 535.72C397.414 536.568 398.544 537.045 399.723 537.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask275_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask275_13_16078)">
+<mask id="mask276_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="506" width="11" height="11">
+<path d="M389.243 516.58H399.157V506.484H389.243V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask276_13_16078)">
+<path d="M394.2 516.057C395.379 516.057 396.509 515.58 397.343 514.732C398.176 513.883 398.644 512.732 398.644 511.532C398.644 510.332 398.176 509.181 397.343 508.332C396.509 507.483 395.379 507.007 394.2 507.007C393.022 507.007 391.891 507.483 391.058 508.332C390.224 509.181 389.756 510.332 389.756 511.532C389.756 512.732 390.224 513.883 391.058 514.732C391.891 515.58 393.022 516.057 394.2 516.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask277_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask277_13_16078)">
+<mask id="mask278_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="491" width="11" height="11">
+<path d="M374.155 501.215H384.069V491.12H374.155V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask278_13_16078)">
+<path d="M379.112 500.693C380.291 500.693 381.421 500.216 382.254 499.367C383.088 498.519 383.556 497.368 383.556 496.168C383.556 494.967 383.088 493.816 382.254 492.968C381.421 492.119 380.291 491.642 379.112 491.642C377.933 491.642 376.803 492.119 375.97 492.968C375.136 493.816 374.668 494.967 374.668 496.168C374.668 497.368 375.136 498.519 375.97 499.367C376.803 500.216 377.933 500.693 379.112 500.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask279_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask279_13_16078)">
+<mask id="mask280_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="485" width="11" height="11">
+<path d="M353.544 495.592H363.458V485.496H353.544V495.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask280_13_16078)">
+<path d="M358.501 495.069C359.68 495.069 360.81 494.592 361.644 493.744C362.477 492.895 362.945 491.744 362.945 490.544C362.945 489.344 362.477 488.193 361.644 487.344C360.81 486.495 359.68 486.019 358.501 486.019C357.323 486.019 356.192 486.495 355.359 487.344C354.526 488.193 354.057 489.344 354.057 490.544C354.057 491.744 354.526 492.895 355.359 493.744C356.192 494.592 357.323 495.069 358.501 495.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask281_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask281_13_16078)">
+<mask id="mask282_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="491" width="11" height="11">
+<path d="M332.933 501.215H342.848V491.12H332.933V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask282_13_16078)">
+<path d="M337.891 500.693C339.069 500.693 340.2 500.216 341.033 499.367C341.866 498.519 342.334 497.368 342.334 496.168C342.334 494.967 341.866 493.816 341.033 492.968C340.2 492.119 339.069 491.642 337.891 491.642C336.712 491.642 335.581 492.119 334.748 492.968C333.915 493.816 333.447 494.967 333.447 496.168C333.447 497.368 333.915 498.519 334.748 499.367C335.581 500.216 336.712 500.693 337.891 500.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask283_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask283_13_16078)">
+<mask id="mask284_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="506" width="11" height="11">
+<path d="M317.845 516.58H327.76V506.484H317.845V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask284_13_16078)">
+<path d="M322.802 516.057C323.981 516.057 325.111 515.58 325.945 514.732C326.778 513.883 327.246 512.732 327.246 511.532C327.246 510.332 326.778 509.181 325.945 508.332C325.111 507.483 323.981 507.007 322.802 507.007C321.624 507.007 320.493 507.483 319.66 508.332C318.827 509.181 318.358 510.332 318.358 511.532C318.358 512.732 318.827 513.883 319.66 514.732C320.493 515.58 321.624 516.057 322.802 516.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask285_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask285_13_16078)">
+<mask id="mask286_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="527" width="11" height="11">
+<path d="M312.323 537.568H322.237V527.472H312.323V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask286_13_16078)">
+<path d="M317.28 537.045C318.458 537.045 319.589 536.568 320.422 535.72C321.255 534.871 321.724 533.72 321.724 532.52C321.724 531.32 321.255 530.168 320.422 529.32C319.589 528.471 318.458 527.994 317.28 527.994C316.101 527.994 314.971 528.471 314.137 529.32C313.304 530.168 312.836 531.32 312.836 532.52C312.836 533.72 313.304 534.871 314.137 535.72C314.971 536.568 316.101 537.045 317.28 537.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask287_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask287_13_16078)">
+<mask id="mask288_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="548" width="11" height="11">
+<path d="M317.845 558.555H327.76V548.46H317.845V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask288_13_16078)">
+<path d="M322.802 558.033C323.981 558.033 325.111 557.556 325.945 556.708C326.778 555.859 327.246 554.708 327.246 553.508C327.246 552.308 326.778 551.156 325.945 550.308C325.111 549.459 323.981 548.982 322.802 548.982C321.624 548.982 320.493 549.459 319.66 550.308C318.827 551.156 318.358 552.308 318.358 553.508C318.358 554.708 318.827 555.859 319.66 556.708C320.493 557.556 321.624 558.033 322.802 558.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask289_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask289_13_16078)">
+<mask id="mask290_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="563" width="11" height="11">
+<path d="M332.933 573.92H342.848V563.824H332.933V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask290_13_16078)">
+<path d="M337.891 573.397C339.069 573.397 340.2 572.92 341.033 572.072C341.866 571.223 342.334 570.072 342.334 568.872C342.334 567.672 341.866 566.521 341.033 565.672C340.2 564.823 339.069 564.347 337.891 564.347C336.712 564.347 335.581 564.823 334.748 565.672C333.915 566.521 333.447 567.672 333.447 568.872C333.447 570.072 333.915 571.223 334.748 572.072C335.581 572.92 336.712 573.397 337.891 573.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask291_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask291_13_16078)">
+<mask id="mask292_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="569" width="11" height="11">
+<path d="M353.544 579.543H363.458V569.448H353.544V579.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask292_13_16078)">
+<path d="M358.501 579.021C359.68 579.021 360.81 578.544 361.644 577.695C362.477 576.847 362.945 575.696 362.945 574.496C362.945 573.295 362.477 572.144 361.644 571.296C360.81 570.447 359.68 569.97 358.501 569.97C357.323 569.97 356.192 570.447 355.359 571.296C354.526 572.144 354.057 573.295 354.057 574.496C354.057 575.696 354.526 576.847 355.359 577.695C356.192 578.544 357.323 579.021 358.501 579.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask293_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask293_13_16078)">
+<mask id="mask294_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="563" width="11" height="11">
+<path d="M374.155 573.92H384.069V563.824H374.155V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask294_13_16078)">
+<path d="M379.112 573.397C380.291 573.397 381.421 572.92 382.254 572.072C383.088 571.223 383.556 570.072 383.556 568.872C383.556 567.672 383.088 566.521 382.254 565.672C381.421 564.823 380.291 564.347 379.112 564.347C377.933 564.347 376.803 564.823 375.97 565.672C375.136 566.521 374.668 567.672 374.668 568.872C374.668 570.072 375.136 571.223 375.97 572.072C376.803 572.92 377.933 573.397 379.112 573.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask295_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask295_13_16078)">
+<mask id="mask296_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="548" width="11" height="11">
+<path d="M389.243 558.555H399.157V548.46H389.243V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask296_13_16078)">
+<path d="M394.2 558.033C395.379 558.033 396.509 557.556 397.343 556.708C398.176 555.859 398.644 554.708 398.644 553.508C398.644 552.308 398.176 551.156 397.343 550.308C396.509 549.459 395.379 548.982 394.2 548.982C393.022 548.982 391.891 549.459 391.058 550.308C390.224 551.156 389.756 552.308 389.756 553.508C389.756 554.708 390.224 555.859 391.058 556.708C391.891 557.556 393.022 558.033 394.2 558.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask297_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask297_13_16078)">
+<path d="M399.767 529.274C399.36 529.274 399.066 529.389 398.795 529.642C398.388 530.057 398.117 530.885 398.117 531.737C398.117 532.542 398.343 533.394 398.682 533.808C398.953 534.13 399.315 534.291 399.721 534.291C400.083 534.291 400.399 534.176 400.648 533.923C401.077 533.532 401.349 532.68 401.349 531.783C401.349 530.287 400.693 529.274 399.767 529.274ZM399.744 529.458C400.332 529.458 400.648 530.287 400.648 531.806C400.648 533.325 400.354 534.107 399.721 534.107C399.111 534.107 398.795 533.325 398.795 531.806C398.795 530.264 399.111 529.458 399.744 529.458Z" fill="white"/>
+</g>
+<mask id="mask298_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask298_13_16078)">
+<path d="M394.489 508.291L393.201 508.959V509.051C393.292 509.005 393.359 508.982 393.405 508.982C393.518 508.913 393.653 508.89 393.721 508.89C393.879 508.89 393.947 509.005 393.947 509.235V512.549C393.947 512.779 393.879 512.94 393.766 513.009C393.653 513.078 393.563 513.101 393.246 513.101V513.216H395.235V513.101C394.67 513.101 394.557 513.032 394.557 512.687V508.291H394.489Z" fill="white"/>
+</g>
+<mask id="mask299_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask299_13_16078)">
+<path d="M380.737 496.859L380.624 496.813C380.376 497.228 380.285 497.297 379.946 497.297H378.251L379.449 496.008C380.082 495.34 380.353 494.788 380.353 494.213C380.353 493.476 379.788 492.924 379.042 492.924C378.635 492.924 378.274 493.085 378.003 493.361C377.777 493.614 377.664 493.844 377.551 494.374L377.686 494.397C377.98 493.683 378.251 493.453 378.726 493.453C379.336 493.453 379.743 493.868 379.743 494.489C379.743 495.064 379.426 495.732 378.816 496.376L377.551 497.757V497.849H380.33L380.737 496.859Z" fill="white"/>
+</g>
+<mask id="mask300_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask300_13_16078)">
+<path d="M357.821 489.811C358.227 489.811 358.386 489.834 358.566 489.903C359.018 490.065 359.29 490.479 359.29 490.985C359.29 491.583 358.883 492.067 358.363 492.067C358.16 492.067 358.024 492.021 357.753 491.837C357.527 491.698 357.414 491.652 357.301 491.652C357.12 491.652 357.03 491.768 357.03 491.906C357.03 492.159 357.323 492.32 357.821 492.32C358.386 492.32 358.951 492.136 359.29 491.837C359.629 491.537 359.809 491.123 359.809 490.64C359.809 490.249 359.696 489.926 359.493 489.696C359.335 489.535 359.199 489.443 358.883 489.305C359.38 488.96 359.561 488.684 359.561 488.292C359.561 487.694 359.109 487.303 358.453 487.303C358.092 487.303 357.775 487.418 357.527 487.648C357.301 487.855 357.188 488.039 357.03 488.477L357.143 488.5C357.436 487.97 357.753 487.74 358.205 487.74C358.679 487.74 358.996 488.062 358.996 488.523C358.996 488.776 358.883 489.029 358.702 489.213C358.499 489.443 358.295 489.558 357.821 489.719V489.811Z" fill="white"/>
+</g>
+<mask id="mask301_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask301_13_16078)">
+<path d="M339.492 496.169H338.746V492.924H338.43L336.192 496.169V496.629H338.204V497.849H338.746V496.629H339.492V496.169ZM338.204 496.169H336.463L338.204 493.66V496.169Z" fill="white"/>
+</g>
+<mask id="mask302_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask302_13_16078)">
+<path d="M322.299 508.959H323.722C323.835 508.959 323.858 508.959 323.881 508.89L324.152 508.245L324.084 508.199C323.971 508.36 323.903 508.383 323.745 508.383H322.253L321.485 510.109C321.462 510.132 321.462 510.132 321.462 510.156C321.462 510.179 321.508 510.202 321.553 510.202C321.779 510.202 322.073 510.271 322.366 510.363C323.18 510.616 323.564 511.076 323.564 511.812C323.564 512.503 323.135 513.055 322.57 513.055C322.434 513.055 322.299 512.986 322.095 512.848C321.869 512.664 321.688 512.595 321.553 512.595C321.349 512.595 321.236 512.687 321.236 512.871C321.236 513.147 321.575 513.308 322.118 513.308C322.705 513.308 323.225 513.124 323.587 512.756C323.926 512.411 324.061 511.997 324.061 511.444C324.061 510.915 323.926 510.593 323.564 510.225C323.27 509.902 322.841 509.741 322.005 509.58L322.299 508.959Z" fill="white"/>
+</g>
+<mask id="mask303_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask303_13_16078)">
+<path d="M318.677 529.205C317.863 529.274 317.457 529.412 316.937 529.803C316.146 530.356 315.739 531.184 315.739 532.174C315.739 532.795 315.92 533.44 316.236 533.808C316.507 534.13 316.892 534.291 317.344 534.291C318.225 534.291 318.835 533.601 318.835 532.611C318.835 531.668 318.315 531.069 317.502 531.069C317.185 531.069 317.027 531.138 316.575 531.414C316.779 530.31 317.57 529.504 318.7 529.32L318.677 529.205ZM317.231 531.414C317.841 531.414 318.202 531.944 318.202 532.841C318.202 533.647 317.909 534.107 317.411 534.107C316.779 534.107 316.394 533.417 316.394 532.289C316.394 531.898 316.462 531.714 316.598 531.599C316.756 531.483 316.982 531.414 317.231 531.414Z" fill="white"/>
+</g>
+<mask id="mask304_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask304_13_16078)">
+<path d="M324.22 550.355H321.575L321.146 551.436L321.282 551.482C321.575 550.999 321.711 550.907 322.118 550.907H323.655L322.253 555.257H322.705L324.22 550.47V550.355Z" fill="white"/>
+</g>
+<mask id="mask305_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask305_13_16078)">
+<path d="M338.181 567.839C338.882 567.471 339.13 567.149 339.13 566.666C339.13 566.067 338.633 565.63 337.91 565.63C337.119 565.63 336.554 566.113 336.554 566.781C336.554 567.241 336.689 567.471 337.435 568.139C336.667 568.737 336.509 568.967 336.509 569.45C336.509 570.164 337.074 570.647 337.887 570.647C338.746 570.647 339.288 570.187 339.288 569.427C339.288 568.852 339.04 568.507 338.181 567.839ZM338.045 568.599C338.565 568.99 338.746 569.243 338.746 569.657C338.746 570.118 338.43 570.463 337.955 570.463C337.413 570.463 337.051 570.026 337.051 569.404C337.051 568.921 337.209 568.622 337.616 568.277L338.045 568.599ZM337.978 567.724C337.345 567.287 337.074 566.965 337.074 566.551C337.074 566.136 337.39 565.837 337.842 565.837C338.339 565.837 338.656 566.159 338.656 566.643C338.656 567.057 338.452 567.402 338.045 567.678C338 567.701 338 567.701 337.978 567.724Z" fill="white"/>
+</g>
+<mask id="mask306_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask306_13_16078)">
+<path d="M357.143 576.337C357.934 576.245 358.34 576.107 358.815 575.739C359.561 575.187 360.013 574.289 360.013 573.299C360.013 572.103 359.335 571.251 358.408 571.251C357.572 571.251 356.939 571.988 356.939 572.977C356.939 573.852 357.436 574.45 358.227 574.45C358.612 574.45 358.905 574.335 359.29 574.036C358.996 575.21 358.205 575.992 357.12 576.199L357.143 576.337ZM359.312 573.576C359.312 573.737 359.267 573.806 359.199 573.875C358.996 574.036 358.725 574.128 358.476 574.128C357.934 574.128 357.595 573.576 357.595 572.724C357.595 572.31 357.708 571.873 357.843 571.665C357.979 571.527 358.16 571.458 358.363 571.458C358.973 571.458 359.312 572.08 359.312 573.299V573.576Z" fill="white"/>
+</g>
+<mask id="mask307_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask307_13_16078)">
+<path d="M377.613 565.63L376.324 566.297V566.39C376.415 566.343 376.483 566.32 376.528 566.32C376.641 566.251 376.776 566.228 376.844 566.228C377.002 566.228 377.07 566.343 377.07 566.574V569.888C377.07 570.118 377.002 570.279 376.889 570.348C376.776 570.417 376.686 570.44 376.37 570.44V570.555H378.358V570.44C377.793 570.44 377.68 570.371 377.68 570.026V565.63H377.613ZM380.941 565.63C380.534 565.63 380.24 565.745 379.969 565.998C379.562 566.413 379.291 567.241 379.291 568.093C379.291 568.898 379.517 569.75 379.856 570.164C380.127 570.486 380.489 570.647 380.895 570.647C381.257 570.647 381.573 570.532 381.822 570.279C382.251 569.888 382.523 569.036 382.523 568.139C382.523 566.643 381.867 565.63 380.941 565.63ZM380.918 565.814C381.506 565.814 381.822 566.643 381.822 568.162C381.822 569.68 381.528 570.463 380.895 570.463C380.285 570.463 379.969 569.68 379.969 568.162C379.969 566.62 380.285 565.814 380.918 565.814Z" fill="white"/>
+</g>
+<mask id="mask308_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask308_13_16078)">
+<path d="M392.698 550.263L391.41 550.93V551.022C391.5 550.976 391.568 550.953 391.613 550.953C391.726 550.884 391.862 550.861 391.93 550.861C392.088 550.861 392.156 550.976 392.156 551.206V554.52C392.156 554.75 392.088 554.911 391.975 554.981C391.862 555.05 391.772 555.073 391.455 555.073V555.188H393.444V555.073C392.879 555.073 392.766 555.004 392.766 554.658V550.263H392.698ZM396.28 550.263L394.992 550.93V551.022C395.083 550.976 395.15 550.953 395.196 550.953C395.309 550.884 395.444 550.861 395.512 550.861C395.67 550.861 395.738 550.976 395.738 551.206V554.52C395.738 554.75 395.67 554.911 395.557 554.981C395.444 555.05 395.354 555.073 395.037 555.073V555.188H397.026V555.073C396.461 555.073 396.348 555.004 396.348 554.658V550.263H396.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask309_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="353" width="112" height="114">
+<path d="M303 466.037H414.004V353H303V466.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask309_13_16078)">
+<mask id="mask310_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask310_13_16078)">
+<path d="M325.821 393.354L343.54 378.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask311_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask311_13_16078)">
+<path d="M325.821 393.354L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask312_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask312_13_16078)">
+<path d="M325.821 393.354L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask313_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask313_13_16078)">
+<path d="M325.821 393.354L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask314_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask314_13_16078)">
+<path d="M343.54 378.382L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask315_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask315_13_16078)">
+<path d="M343.54 378.382L326.523 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask316_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask316_13_16078)">
+<path d="M343.54 378.382L377.366 389.755" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask317_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask317_13_16078)">
+<path d="M317.28 375.666L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask318_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask318_13_16078)">
+<path d="M377.366 389.755L381.612 412.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask319_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask319_13_16078)">
+<path d="M377.366 389.754L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask320_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask320_13_16078)">
+<path d="M377.366 389.755L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask321_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask321_13_16078)">
+<path d="M381.612 412.102L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask322_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask322_13_16078)">
+<path d="M381.612 412.102L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask323_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask323_13_16078)">
+<path d="M381.612 412.102L354.356 435.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask324_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask324_13_16078)">
+<path d="M397.614 391.444L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask325_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask325_13_16078)">
+<path d="M354.356 435.307L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask326_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask326_13_16078)">
+<path d="M354.356 435.307L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask327_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask327_13_16078)">
+<path d="M354.356 435.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask328_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask328_13_16078)">
+<path d="M332.308 427.895L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask329_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask329_13_16078)">
+<path d="M332.308 427.895L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask330_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask330_13_16078)">
+<path d="M330.975 447.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask331_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask331_13_16078)">
+<mask id="mask332_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="388" width="11" height="11">
+<path d="M320.864 398.402H330.778V388.307H320.864V398.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask332_13_16078)">
+<path d="M325.821 397.88C326.999 397.88 328.13 397.403 328.963 396.554C329.797 395.706 330.265 394.555 330.265 393.354C330.265 392.154 329.797 391.003 328.963 390.155C328.13 389.306 326.999 388.829 325.821 388.829C324.642 388.829 323.512 389.306 322.678 390.155C321.845 391.003 321.377 392.154 321.377 393.354C321.377 394.555 321.845 395.706 322.678 396.554C323.512 397.403 324.642 397.88 325.821 397.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask333_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask333_13_16078)">
+<mask id="mask334_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="373" width="11" height="11">
+<path d="M338.583 383.429H348.497V373.334H338.583V383.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask334_13_16078)">
+<path d="M343.54 382.907C344.719 382.907 345.849 382.43 346.683 381.581C347.516 380.733 347.984 379.582 347.984 378.382C347.984 377.181 347.516 376.03 346.683 375.182C345.849 374.333 344.719 373.856 343.54 373.856C342.362 373.856 341.231 374.333 340.398 375.182C339.565 376.03 339.096 377.181 339.096 378.382C339.096 379.582 339.565 380.733 340.398 381.581C341.231 382.43 342.362 382.907 343.54 382.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask335_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask335_13_16078)">
+<mask id="mask336_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="370" width="11" height="11">
+<path d="M312.323 380.714H322.237V370.618H312.323V380.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask336_13_16078)">
+<path d="M317.28 380.191C318.458 380.191 319.589 379.714 320.422 378.866C321.255 378.017 321.724 376.866 321.724 375.666C321.724 374.466 321.255 373.315 320.422 372.466C319.589 371.617 318.458 371.141 317.28 371.141C316.101 371.141 314.971 371.617 314.137 372.466C313.304 373.315 312.836 374.466 312.836 375.666C312.836 376.866 313.304 378.017 314.137 378.866C314.971 379.714 316.101 380.191 317.28 380.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask337_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask337_13_16078)">
+<mask id="mask338_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="321" y="362" width="11" height="11">
+<path d="M321.566 372.592H331.481V362.496H321.566V372.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask338_13_16078)">
+<path d="M326.524 372.069C327.702 372.069 328.833 371.592 329.666 370.744C330.499 369.895 330.967 368.744 330.967 367.544C330.967 366.344 330.499 365.193 329.666 364.344C328.833 363.495 327.702 363.019 326.524 363.019C325.345 363.019 324.214 363.495 323.381 364.344C322.548 365.193 322.08 366.344 322.08 367.544C322.08 368.744 322.548 369.895 323.381 370.744C324.214 371.592 325.345 372.069 326.524 372.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask339_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask339_13_16078)">
+<mask id="mask340_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="372" y="384" width="11" height="11">
+<path d="M372.409 394.802H382.323V384.707H372.409V394.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask340_13_16078)">
+<path d="M377.366 394.28C378.544 394.28 379.675 393.803 380.508 392.954C381.342 392.106 381.81 390.955 381.81 389.755C381.81 388.554 381.342 387.403 380.508 386.555C379.675 385.706 378.544 385.229 377.366 385.229C376.187 385.229 375.057 385.706 374.223 386.555C373.39 387.403 372.922 388.554 372.922 389.755C372.922 390.955 373.39 392.106 374.223 392.954C375.057 393.803 376.187 394.28 377.366 394.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask341_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask341_13_16078)">
+<mask id="mask342_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="376" y="407" width="11" height="11">
+<path d="M376.655 417.15H386.569V407.054H376.655V417.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask342_13_16078)">
+<path d="M381.612 416.628C382.791 416.628 383.921 416.151 384.755 415.302C385.588 414.453 386.056 413.302 386.056 412.102C386.056 410.902 385.588 409.751 384.755 408.902C383.921 408.054 382.791 407.577 381.612 407.577C380.434 407.577 379.303 408.054 378.47 408.902C377.637 409.751 377.168 410.902 377.168 412.102C377.168 413.302 377.637 414.453 378.47 415.302C379.303 416.151 380.434 416.628 381.612 416.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask343_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask343_13_16078)">
+<mask id="mask344_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="386" width="11" height="11">
+<path d="M392.657 396.492H402.571V386.396H392.657V396.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask344_13_16078)">
+<path d="M397.614 395.969C398.792 395.969 399.923 395.492 400.756 394.644C401.59 393.795 402.058 392.644 402.058 391.444C402.058 390.244 401.59 389.093 400.756 388.244C399.923 387.395 398.792 386.919 397.614 386.919C396.435 386.919 395.305 387.395 394.471 388.244C393.638 389.093 393.17 390.244 393.17 391.444C393.17 392.644 393.638 393.795 394.471 394.644C395.305 395.492 396.435 395.969 397.614 395.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask345_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask345_13_16078)">
+<mask id="mask346_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="398" width="11" height="11">
+<path d="M394.766 408.201H404.68V398.105H394.766V408.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask346_13_16078)">
+<path d="M399.723 407.679C400.901 407.679 402.032 407.202 402.865 406.353C403.699 405.504 404.167 404.353 404.167 403.153C404.167 401.953 403.699 400.802 402.865 399.953C402.032 399.105 400.901 398.628 399.723 398.628C398.544 398.628 397.414 399.105 396.58 399.953C395.747 400.802 395.279 401.953 395.279 403.153C395.279 404.353 395.747 405.504 396.58 406.353C397.414 407.202 398.544 407.679 399.723 407.679Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask347_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask347_13_16078)">
+<mask id="mask348_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="349" y="430" width="11" height="11">
+<path d="M349.399 440.354H359.313V430.259H349.399V440.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask348_13_16078)">
+<path d="M354.356 439.832C355.535 439.832 356.665 439.355 357.499 438.506C358.332 437.658 358.8 436.507 358.8 435.307C358.8 434.106 358.332 432.955 357.499 432.107C356.665 431.258 355.535 430.781 354.356 430.781C353.178 430.781 352.047 431.258 351.214 432.107C350.38 432.955 349.912 434.106 349.912 435.307C349.912 436.507 350.38 437.658 351.214 438.506C352.047 439.355 353.178 439.832 354.356 439.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask349_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask349_13_16078)">
+<mask id="mask350_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="327" y="422" width="11" height="11">
+<path d="M327.351 432.943H337.265V422.847H327.351V432.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask350_13_16078)">
+<path d="M332.308 432.42C333.486 432.42 334.617 431.943 335.45 431.095C336.283 430.246 336.752 429.095 336.752 427.895C336.752 426.695 336.283 425.544 335.45 424.695C334.617 423.846 333.486 423.37 332.308 423.37C331.129 423.37 329.999 423.846 329.165 424.695C328.332 425.544 327.864 426.695 327.864 427.895C327.864 429.095 328.332 430.246 329.165 431.095C329.999 431.943 331.129 432.42 332.308 432.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask351_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask351_13_16078)">
+<mask id="mask352_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="326" y="442" width="10" height="11">
+<path d="M326.018 452.355H335.932V442.259H326.018V452.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask352_13_16078)">
+<path d="M330.975 451.832C332.154 451.832 333.284 451.355 334.117 450.507C334.951 449.658 335.419 448.507 335.419 447.307C335.419 446.107 334.951 444.955 334.117 444.107C333.284 443.258 332.154 442.781 330.975 442.781C329.796 442.781 328.666 443.258 327.833 444.107C326.999 444.955 326.531 446.107 326.531 447.307C326.531 448.507 326.999 449.658 327.833 450.507C328.666 451.355 329.796 451.832 330.975 451.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask353_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask353_13_16078)">
+<mask id="mask354_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="337" y="446" width="11" height="11">
+<path d="M337.811 456.543H347.726V446.448H337.811V456.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask354_13_16078)">
+<path d="M342.769 456.021C343.947 456.021 345.078 455.544 345.911 454.695C346.744 453.847 347.213 452.696 347.213 451.496C347.213 450.295 346.744 449.144 345.911 448.296C345.078 447.447 343.947 446.97 342.769 446.97C341.59 446.97 340.459 447.447 339.626 448.296C338.793 449.144 338.325 450.295 338.325 451.496C338.325 452.696 338.793 453.847 339.626 454.695C340.459 455.544 341.59 456.021 342.769 456.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask355_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask355_13_16078)">
+<path d="M325.86 390.113C325.453 390.113 325.159 390.228 324.888 390.481C324.481 390.895 324.21 391.724 324.21 392.575C324.21 393.381 324.436 394.232 324.775 394.646C325.046 394.969 325.408 395.13 325.815 395.13C326.177 395.13 326.493 395.015 326.742 394.762C327.171 394.37 327.442 393.519 327.442 392.621C327.442 391.125 326.787 390.113 325.86 390.113ZM325.838 390.297C326.425 390.297 326.742 391.125 326.742 392.644C326.742 394.163 326.448 394.946 325.815 394.946C325.205 394.946 324.888 394.163 324.888 392.644C324.888 391.102 325.205 390.297 325.838 390.297Z" fill="white"/>
+</g>
+<mask id="mask356_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask356_13_16078)">
+<path d="M343.833 375.137L342.545 375.804V375.896C342.635 375.85 342.703 375.827 342.748 375.827C342.861 375.758 342.997 375.735 343.065 375.735C343.223 375.735 343.291 375.85 343.291 376.08V379.394C343.291 379.624 343.223 379.785 343.11 379.854C342.997 379.923 342.906 379.946 342.59 379.946V380.062H344.579V379.946C344.014 379.946 343.901 379.877 343.901 379.532V375.137H343.833Z" fill="white"/>
+</g>
+<mask id="mask357_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask357_13_16078)">
+<path d="M318.905 376.356L318.792 376.31C318.543 376.725 318.453 376.794 318.114 376.794H316.419L317.617 375.505C318.249 374.837 318.521 374.285 318.521 373.71C318.521 372.973 317.956 372.421 317.21 372.421C316.803 372.421 316.441 372.582 316.17 372.858C315.944 373.111 315.831 373.342 315.718 373.871L315.854 373.894C316.148 373.18 316.419 372.95 316.893 372.95C317.504 372.95 317.91 373.365 317.91 373.986C317.91 374.561 317.594 375.229 316.984 375.873L315.718 377.254V377.346H318.498L318.905 376.356Z" fill="white"/>
+</g>
+<mask id="mask358_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask358_13_16078)">
+<path d="M325.843 366.811C326.25 366.811 326.408 366.834 326.589 366.903C327.041 367.065 327.312 367.479 327.312 367.985C327.312 368.583 326.905 369.067 326.386 369.067C326.182 369.067 326.047 369.021 325.775 368.837C325.549 368.699 325.436 368.652 325.323 368.652C325.143 368.652 325.052 368.768 325.052 368.906C325.052 369.159 325.346 369.32 325.843 369.32C326.408 369.32 326.973 369.136 327.312 368.837C327.651 368.537 327.832 368.123 327.832 367.64C327.832 367.249 327.719 366.926 327.516 366.696C327.357 366.535 327.222 366.443 326.905 366.305C327.403 365.96 327.583 365.684 327.583 365.292C327.583 364.694 327.131 364.303 326.476 364.303C326.114 364.303 325.798 364.418 325.549 364.648C325.323 364.855 325.21 365.039 325.052 365.477L325.165 365.5C325.459 364.97 325.775 364.74 326.227 364.74C326.702 364.74 327.018 365.062 327.018 365.523C327.018 365.776 326.905 366.029 326.725 366.213C326.521 366.443 326.318 366.558 325.843 366.719V366.811Z" fill="white"/>
+</g>
+<mask id="mask359_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask359_13_16078)">
+<path d="M378.965 389.756H378.219V386.511H377.903L375.665 389.756V390.216H377.677V391.436H378.219V390.216H378.965V389.756ZM377.677 389.756H375.937L377.677 387.248V389.756Z" fill="white"/>
+</g>
+<mask id="mask360_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask360_13_16078)">
+<path d="M381.112 409.525H382.536C382.649 409.525 382.671 409.525 382.694 409.456L382.965 408.811L382.897 408.765C382.784 408.927 382.717 408.95 382.558 408.95H381.067L380.298 410.676C380.276 410.699 380.276 410.699 380.276 410.722C380.276 410.745 380.321 410.768 380.366 410.768C380.592 410.768 380.886 410.837 381.18 410.929C381.993 411.182 382.378 411.642 382.378 412.379C382.378 413.069 381.948 413.621 381.383 413.621C381.248 413.621 381.112 413.552 380.909 413.414C380.683 413.23 380.502 413.161 380.366 413.161C380.163 413.161 380.05 413.253 380.05 413.437C380.05 413.713 380.389 413.874 380.931 413.874C381.519 413.874 382.039 413.69 382.4 413.322C382.739 412.977 382.875 412.563 382.875 412.01C382.875 411.481 382.739 411.159 382.378 410.791C382.084 410.468 381.654 410.307 380.818 410.146L381.112 409.525Z" fill="white"/>
+</g>
+<mask id="mask361_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask361_13_16078)">
+<path d="M399.011 388.134C398.198 388.203 397.791 388.341 397.271 388.732C396.48 389.284 396.073 390.113 396.073 391.102C396.073 391.724 396.254 392.368 396.57 392.736C396.842 393.059 397.226 393.22 397.678 393.22C398.559 393.22 399.17 392.529 399.17 391.54C399.17 390.596 398.65 389.998 397.836 389.998C397.52 389.998 397.361 390.067 396.909 390.343C397.113 389.238 397.904 388.433 399.034 388.249L399.011 388.134ZM397.565 390.343C398.175 390.343 398.537 390.872 398.537 391.77C398.537 392.575 398.243 393.036 397.746 393.036C397.113 393.036 396.729 392.345 396.729 391.217C396.729 390.826 396.796 390.642 396.932 390.527C397.09 390.412 397.316 390.343 397.565 390.343Z" fill="white"/>
+</g>
+<mask id="mask362_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask362_13_16078)">
+<path d="M401.141 400.003H398.497L398.068 401.085L398.203 401.131C398.497 400.647 398.633 400.555 399.04 400.555H400.576L399.175 404.905H399.627L401.141 400.118V400.003Z" fill="white"/>
+</g>
+<mask id="mask363_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask363_13_16078)">
+<path d="M354.647 434.27C355.348 433.902 355.596 433.58 355.596 433.097C355.596 432.498 355.099 432.061 354.376 432.061C353.585 432.061 353.02 432.544 353.02 433.212C353.02 433.672 353.155 433.902 353.901 434.57C353.133 435.168 352.975 435.398 352.975 435.881C352.975 436.595 353.54 437.078 354.353 437.078C355.212 437.078 355.755 436.618 355.755 435.858C355.755 435.283 355.506 434.938 354.647 434.27ZM354.512 435.03C355.031 435.421 355.212 435.674 355.212 436.088C355.212 436.549 354.896 436.894 354.421 436.894C353.879 436.894 353.517 436.457 353.517 435.835C353.517 435.352 353.675 435.053 354.082 434.708L354.512 435.03ZM354.444 434.155C353.811 433.718 353.54 433.396 353.54 432.982C353.54 432.567 353.856 432.268 354.308 432.268C354.805 432.268 355.122 432.59 355.122 433.074C355.122 433.488 354.918 433.833 354.512 434.109C354.466 434.132 354.466 434.132 354.444 434.155Z" fill="white"/>
+</g>
+<mask id="mask364_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask364_13_16078)">
+<path d="M330.945 429.737C331.736 429.645 332.143 429.507 332.618 429.138C333.363 428.586 333.815 427.688 333.815 426.699C333.815 425.502 333.137 424.651 332.211 424.651C331.375 424.651 330.742 425.387 330.742 426.377C330.742 427.251 331.239 427.85 332.03 427.85C332.414 427.85 332.708 427.734 333.092 427.435C332.798 428.609 332.007 429.391 330.923 429.599L330.945 429.737ZM333.115 426.975C333.115 427.136 333.07 427.205 333.002 427.274C332.798 427.435 332.527 427.527 332.279 427.527C331.736 427.527 331.397 426.975 331.397 426.124C331.397 425.709 331.51 425.272 331.646 425.065C331.781 424.927 331.962 424.858 332.166 424.858C332.776 424.858 333.115 425.479 333.115 426.699V426.975Z" fill="white"/>
+</g>
+<mask id="mask365_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask365_13_16078)">
+<path d="M329.476 444.063L328.188 444.73V444.822C328.278 444.776 328.346 444.753 328.391 444.753C328.504 444.684 328.64 444.661 328.708 444.661C328.866 444.661 328.934 444.776 328.934 445.006V448.32C328.934 448.55 328.866 448.711 328.753 448.781C328.64 448.85 328.55 448.873 328.233 448.873V448.988H330.222V448.873C329.657 448.873 329.544 448.804 329.544 448.458V444.063H329.476ZM332.804 444.063C332.397 444.063 332.103 444.178 331.832 444.431C331.425 444.845 331.154 445.674 331.154 446.525C331.154 447.331 331.38 448.182 331.719 448.596C331.99 448.919 332.352 449.08 332.759 449.08C333.12 449.08 333.437 448.965 333.685 448.711C334.115 448.32 334.386 447.469 334.386 446.571C334.386 445.075 333.731 444.063 332.804 444.063ZM332.781 444.247C333.369 444.247 333.685 445.075 333.685 446.594C333.685 448.113 333.392 448.896 332.759 448.896C332.149 448.896 331.832 448.113 331.832 446.594C331.832 445.052 332.149 444.247 332.781 444.247Z" fill="white"/>
+</g>
+<mask id="mask366_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask366_13_16078)">
+<path d="M341.268 448.251L339.98 448.919V449.011C340.07 448.965 340.138 448.942 340.183 448.942C340.296 448.873 340.432 448.85 340.499 448.85C340.658 448.85 340.725 448.965 340.725 449.195V452.509C340.725 452.739 340.658 452.9 340.545 452.969C340.432 453.038 340.341 453.061 340.025 453.061V453.176H342.014V453.061C341.449 453.061 341.336 452.992 341.336 452.647V448.251H341.268ZM344.85 448.251L343.562 448.919V449.011C343.652 448.965 343.72 448.942 343.765 448.942C343.878 448.873 344.014 448.85 344.082 448.85C344.24 448.85 344.308 448.965 344.308 449.195V452.509C344.308 452.739 344.24 452.9 344.127 452.969C344.014 453.038 343.923 453.061 343.607 453.061V453.176H345.596V453.061C345.031 453.061 344.918 452.992 344.918 452.647V448.251H344.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask367_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="760" y="857" width="112" height="114">
+<path d="M760 970.037H871.004V857H760V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask367_13_16078)">
+<mask id="mask368_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask368_13_16078)">
+<path d="M782.821 897.354L800.54 882.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask369_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask369_13_16078)">
+<path d="M782.821 897.354L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask370_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask370_13_16078)">
+<path d="M782.821 897.354L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask371_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask371_13_16078)">
+<path d="M782.821 897.354L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask372_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask372_13_16078)">
+<path d="M800.54 882.382L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask373_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask373_13_16078)">
+<path d="M800.54 882.382L783.523 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask374_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask374_13_16078)">
+<path d="M800.54 882.382L834.366 893.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask375_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask375_13_16078)">
+<path d="M774.28 879.666L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask376_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask376_13_16078)">
+<path d="M834.366 893.754L838.612 916.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask377_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask377_13_16078)">
+<path d="M834.366 893.754L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask378_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask378_13_16078)">
+<path d="M834.366 893.754L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask379_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask379_13_16078)">
+<path d="M838.612 916.102L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask380_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask380_13_16078)">
+<path d="M838.612 916.102L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask381_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask381_13_16078)">
+<path d="M838.612 916.102L811.356 939.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask382_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask382_13_16078)">
+<path d="M854.614 895.444L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask383_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask383_13_16078)">
+<path d="M811.356 939.307L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask384_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask384_13_16078)">
+<path d="M811.356 939.306L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask385_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask385_13_16078)">
+<path d="M811.356 939.306L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask386_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask386_13_16078)">
+<path d="M789.308 931.895L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask387_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask387_13_16078)">
+<path d="M789.308 931.895L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask388_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask388_13_16078)">
+<path d="M787.975 951.307L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask389_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask389_13_16078)">
+<mask id="mask390_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="777" y="892" width="11" height="11">
+<path d="M777.864 902.402H787.778V892.307H777.864V902.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask390_13_16078)">
+<path d="M782.821 901.88C783.999 901.88 785.13 901.403 785.963 900.554C786.797 899.706 787.265 898.555 787.265 897.354C787.265 896.154 786.797 895.003 785.963 894.155C785.13 893.306 783.999 892.829 782.821 892.829C781.642 892.829 780.512 893.306 779.678 894.155C778.845 895.003 778.377 896.154 778.377 897.354C778.377 898.555 778.845 899.706 779.678 900.554C780.512 901.403 781.642 901.88 782.821 901.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask391_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask391_13_16078)">
+<mask id="mask392_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="795" y="877" width="11" height="11">
+<path d="M795.583 887.429H805.497V877.334H795.583V887.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask392_13_16078)">
+<path d="M800.54 886.907C801.719 886.907 802.849 886.43 803.683 885.581C804.516 884.733 804.984 883.582 804.984 882.382C804.984 881.181 804.516 880.03 803.683 879.182C802.849 878.333 801.719 877.856 800.54 877.856C799.362 877.856 798.231 878.333 797.398 879.182C796.565 880.03 796.096 881.181 796.096 882.382C796.096 883.582 796.565 884.733 797.398 885.581C798.231 886.43 799.362 886.907 800.54 886.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask393_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask393_13_16078)">
+<mask id="mask394_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="769" y="874" width="11" height="11">
+<path d="M769.323 884.714H779.237V874.618H769.323V884.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask394_13_16078)">
+<path d="M774.28 884.191C775.458 884.191 776.589 883.714 777.422 882.866C778.256 882.017 778.724 880.866 778.724 879.666C778.724 878.466 778.256 877.315 777.422 876.466C776.589 875.617 775.458 875.141 774.28 875.141C773.101 875.141 771.971 875.617 771.137 876.466C770.304 877.315 769.836 878.466 769.836 879.666C769.836 880.866 770.304 882.017 771.137 882.866C771.971 883.714 773.101 884.191 774.28 884.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask395_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask395_13_16078)">
+<mask id="mask396_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="778" y="866" width="11" height="11">
+<path d="M778.566 876.592H788.481V866.496H778.566V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask396_13_16078)">
+<path d="M783.524 876.069C784.702 876.069 785.833 875.592 786.666 874.744C787.499 873.895 787.968 872.744 787.968 871.544C787.968 870.344 787.499 869.193 786.666 868.344C785.833 867.495 784.702 867.019 783.524 867.019C782.345 867.019 781.215 867.495 780.381 868.344C779.548 869.193 779.08 870.344 779.08 871.544C779.08 872.744 779.548 873.895 780.381 874.744C781.215 875.592 782.345 876.069 783.524 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask397_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask397_13_16078)">
+<mask id="mask398_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="829" y="888" width="11" height="11">
+<path d="M829.409 898.802H839.323V888.707H829.409V898.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask398_13_16078)">
+<path d="M834.366 898.28C835.544 898.28 836.675 897.803 837.508 896.954C838.342 896.106 838.81 894.955 838.81 893.754C838.81 892.554 838.342 891.403 837.508 890.555C836.675 889.706 835.544 889.229 834.366 889.229C833.187 889.229 832.057 889.706 831.223 890.555C830.39 891.403 829.922 892.554 829.922 893.754C829.922 894.955 830.39 896.106 831.223 896.954C832.057 897.803 833.187 898.28 834.366 898.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask399_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask399_13_16078)">
+<mask id="mask400_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="833" y="911" width="11" height="11">
+<path d="M833.655 921.15H843.57V911.054H833.655V921.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask400_13_16078)">
+<path d="M838.612 920.628C839.791 920.628 840.921 920.151 841.755 919.302C842.588 918.453 843.056 917.302 843.056 916.102C843.056 914.902 842.588 913.751 841.755 912.902C840.921 912.054 839.791 911.577 838.612 911.577C837.434 911.577 836.303 912.054 835.47 912.902C834.637 913.751 834.168 914.902 834.168 916.102C834.168 917.302 834.637 918.453 835.47 919.302C836.303 920.151 837.434 920.628 838.612 920.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask401_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask401_13_16078)">
+<mask id="mask402_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="849" y="890" width="11" height="11">
+<path d="M849.657 900.492H859.571V890.396H849.657V900.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask402_13_16078)">
+<path d="M854.614 899.969C855.792 899.969 856.923 899.492 857.756 898.644C858.59 897.795 859.058 896.644 859.058 895.444C859.058 894.244 858.59 893.093 857.756 892.244C856.923 891.395 855.792 890.919 854.614 890.919C853.435 890.919 852.305 891.395 851.471 892.244C850.638 893.093 850.17 894.244 850.17 895.444C850.17 896.644 850.638 897.795 851.471 898.644C852.305 899.492 853.435 899.969 854.614 899.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask403_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask403_13_16078)">
+<mask id="mask404_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="851" y="902" width="11" height="11">
+<path d="M851.766 912.201H861.68V902.105H851.766V912.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask404_13_16078)">
+<path d="M856.723 911.678C857.901 911.678 859.032 911.202 859.865 910.353C860.699 909.504 861.167 908.353 861.167 907.153C861.167 905.953 860.699 904.802 859.865 903.953C859.032 903.105 857.901 902.628 856.723 902.628C855.544 902.628 854.414 903.105 853.58 903.953C852.747 904.802 852.279 905.953 852.279 907.153C852.279 908.353 852.747 909.504 853.58 910.353C854.414 911.202 855.544 911.678 856.723 911.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask405_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask405_13_16078)">
+<mask id="mask406_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="806" y="934" width="11" height="11">
+<path d="M806.399 944.354H816.313V934.259H806.399V944.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask406_13_16078)">
+<path d="M811.356 943.832C812.535 943.832 813.665 943.355 814.499 942.506C815.332 941.658 815.8 940.507 815.8 939.307C815.8 938.106 815.332 936.955 814.499 936.107C813.665 935.258 812.535 934.781 811.356 934.781C810.178 934.781 809.047 935.258 808.214 936.107C807.38 936.955 806.912 938.106 806.912 939.307C806.912 940.507 807.38 941.658 808.214 942.506C809.047 943.355 810.178 943.832 811.356 943.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask407_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask407_13_16078)">
+<mask id="mask408_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="784" y="926" width="11" height="11">
+<path d="M784.351 936.943H794.265V926.847H784.351V936.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask408_13_16078)">
+<path d="M789.308 936.42C790.486 936.42 791.617 935.943 792.45 935.095C793.283 934.246 793.752 933.095 793.752 931.895C793.752 930.695 793.283 929.544 792.45 928.695C791.617 927.846 790.486 927.37 789.308 927.37C788.129 927.37 786.999 927.846 786.165 928.695C785.332 929.544 784.864 930.695 784.864 931.895C784.864 933.095 785.332 934.246 786.165 935.095C786.999 935.943 788.129 936.42 789.308 936.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask409_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask409_13_16078)">
+<mask id="mask410_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="783" y="946" width="10" height="11">
+<path d="M783.018 956.355H792.932V946.259H783.018V956.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask410_13_16078)">
+<path d="M787.975 955.832C789.154 955.832 790.284 955.355 791.117 954.507C791.951 953.658 792.419 952.507 792.419 951.307C792.419 950.107 791.951 948.955 791.117 948.107C790.284 947.258 789.154 946.781 787.975 946.781C786.796 946.781 785.666 947.258 784.833 948.107C783.999 948.955 783.531 950.107 783.531 951.307C783.531 952.507 783.999 953.658 784.833 954.507C785.666 955.355 786.796 955.832 787.975 955.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask411_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask411_13_16078)">
+<mask id="mask412_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="794" y="950" width="11" height="11">
+<path d="M794.811 960.543H804.726V950.448H794.811V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask412_13_16078)">
+<path d="M799.769 960.021C800.947 960.021 802.078 959.544 802.911 958.695C803.744 957.847 804.213 956.696 804.213 955.496C804.213 954.295 803.744 953.144 802.911 952.296C802.078 951.447 800.947 950.97 799.769 950.97C798.59 950.97 797.46 951.447 796.626 952.296C795.793 953.144 795.325 954.295 795.325 955.496C795.325 956.696 795.793 957.847 796.626 958.695C797.46 959.544 798.59 960.021 799.769 960.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask413_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask413_13_16078)">
+<path d="M782.86 894.113C782.453 894.113 782.16 894.228 781.888 894.481C781.481 894.895 781.21 895.724 781.21 896.575C781.21 897.381 781.436 898.232 781.775 898.646C782.047 898.969 782.408 899.13 782.815 899.13C783.177 899.13 783.493 899.015 783.742 898.762C784.171 898.37 784.442 897.519 784.442 896.621C784.442 895.125 783.787 894.113 782.86 894.113ZM782.838 894.297C783.425 894.297 783.742 895.125 783.742 896.644C783.742 898.163 783.448 898.946 782.815 898.946C782.205 898.946 781.888 898.163 781.888 896.644C781.888 895.102 782.205 894.297 782.838 894.297Z" fill="white"/>
+</g>
+<mask id="mask414_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask414_13_16078)">
+<path d="M800.833 879.137L799.545 879.804V879.896C799.635 879.85 799.703 879.827 799.748 879.827C799.861 879.758 799.997 879.735 800.065 879.735C800.223 879.735 800.291 879.85 800.291 880.08V883.394C800.291 883.624 800.223 883.785 800.11 883.854C799.997 883.923 799.906 883.946 799.59 883.946V884.061H801.579V883.946C801.014 883.946 800.901 883.877 800.901 883.532V879.137H800.833Z" fill="white"/>
+</g>
+<mask id="mask415_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask415_13_16078)">
+<path d="M775.905 880.356L775.792 880.31C775.543 880.724 775.453 880.794 775.114 880.794H773.419L774.617 879.505C775.249 878.837 775.521 878.285 775.521 877.71C775.521 876.973 774.956 876.421 774.21 876.421C773.803 876.421 773.441 876.582 773.17 876.858C772.944 877.111 772.831 877.341 772.718 877.871L772.854 877.894C773.148 877.18 773.419 876.95 773.893 876.95C774.504 876.95 774.91 877.364 774.91 877.986C774.91 878.561 774.594 879.229 773.984 879.873L772.718 881.254V881.346H775.498L775.905 880.356Z" fill="white"/>
+</g>
+<mask id="mask416_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask416_13_16078)">
+<path d="M782.843 870.811C783.25 870.811 783.408 870.834 783.589 870.903C784.041 871.065 784.312 871.479 784.312 871.985C784.312 872.583 783.905 873.067 783.386 873.067C783.182 873.067 783.047 873.021 782.775 872.837C782.549 872.698 782.436 872.652 782.323 872.652C782.143 872.652 782.052 872.768 782.052 872.906C782.052 873.159 782.346 873.32 782.843 873.32C783.408 873.32 783.973 873.136 784.312 872.837C784.651 872.537 784.832 872.123 784.832 871.64C784.832 871.249 784.719 870.926 784.516 870.696C784.357 870.535 784.222 870.443 783.905 870.305C784.403 869.96 784.583 869.684 784.583 869.292C784.583 868.694 784.131 868.303 783.476 868.303C783.114 868.303 782.798 868.418 782.549 868.648C782.323 868.855 782.21 869.039 782.052 869.477L782.165 869.5C782.459 868.97 782.775 868.74 783.227 868.74C783.702 868.74 784.018 869.062 784.018 869.523C784.018 869.776 783.905 870.029 783.725 870.213C783.521 870.443 783.318 870.558 782.843 870.719V870.811Z" fill="white"/>
+</g>
+<mask id="mask417_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask417_13_16078)">
+<path d="M835.965 893.756H835.219V890.511H834.903L832.665 893.756V894.216H834.677V895.436H835.219V894.216H835.965V893.756ZM834.677 893.756H832.937L834.677 891.248V893.756Z" fill="white"/>
+</g>
+<mask id="mask418_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask418_13_16078)">
+<path d="M838.112 913.525H839.536C839.649 913.525 839.671 913.525 839.694 913.456L839.965 912.811L839.897 912.765C839.784 912.926 839.717 912.949 839.558 912.949H838.067L837.298 914.676C837.276 914.699 837.276 914.699 837.276 914.722C837.276 914.745 837.321 914.768 837.366 914.768C837.592 914.768 837.886 914.837 838.18 914.929C838.993 915.182 839.378 915.642 839.378 916.379C839.378 917.069 838.948 917.621 838.383 917.621C838.248 917.621 838.112 917.552 837.909 917.414C837.683 917.23 837.502 917.161 837.366 917.161C837.163 917.161 837.05 917.253 837.05 917.437C837.05 917.713 837.389 917.874 837.931 917.874C838.519 917.874 839.039 917.69 839.4 917.322C839.739 916.977 839.875 916.563 839.875 916.01C839.875 915.481 839.739 915.159 839.378 914.791C839.084 914.468 838.654 914.307 837.818 914.146L838.112 913.525Z" fill="white"/>
+</g>
+<mask id="mask419_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask419_13_16078)">
+<path d="M856.011 892.134C855.198 892.203 854.791 892.341 854.271 892.732C853.48 893.284 853.073 894.113 853.073 895.102C853.073 895.724 853.254 896.368 853.571 896.736C853.842 897.058 854.226 897.22 854.678 897.22C855.559 897.22 856.17 896.529 856.17 895.54C856.17 894.596 855.65 893.998 854.836 893.998C854.52 893.998 854.362 894.067 853.91 894.343C854.113 893.238 854.904 892.433 856.034 892.249L856.011 892.134ZM854.565 894.343C855.175 894.343 855.537 894.872 855.537 895.77C855.537 896.575 855.243 897.035 854.746 897.035C854.113 897.035 853.729 896.345 853.729 895.217C853.729 894.826 853.797 894.642 853.932 894.527C854.09 894.412 854.316 894.343 854.565 894.343Z" fill="white"/>
+</g>
+<mask id="mask420_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask420_13_16078)">
+<path d="M858.141 904.003H855.497L855.068 905.085L855.203 905.131C855.497 904.647 855.633 904.555 856.04 904.555H857.576L856.175 908.905H856.627L858.141 904.118V904.003Z" fill="white"/>
+</g>
+<mask id="mask421_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask421_13_16078)">
+<path d="M811.647 938.27C812.348 937.902 812.596 937.58 812.596 937.097C812.596 936.498 812.099 936.061 811.376 936.061C810.585 936.061 810.02 936.544 810.02 937.212C810.02 937.672 810.156 937.902 810.901 938.57C810.133 939.168 809.975 939.398 809.975 939.881C809.975 940.595 810.54 941.078 811.353 941.078C812.212 941.078 812.755 940.618 812.755 939.858C812.755 939.283 812.506 938.938 811.647 938.27ZM811.512 939.03C812.031 939.421 812.212 939.674 812.212 940.088C812.212 940.549 811.896 940.894 811.421 940.894C810.879 940.894 810.517 940.457 810.517 939.835C810.517 939.352 810.675 939.053 811.082 938.708L811.512 939.03ZM811.444 938.155C810.811 937.718 810.54 937.396 810.54 936.982C810.54 936.567 810.856 936.268 811.308 936.268C811.805 936.268 812.122 936.59 812.122 937.074C812.122 937.488 811.918 937.833 811.512 938.109C811.466 938.132 811.466 938.132 811.444 938.155Z" fill="white"/>
+</g>
+<mask id="mask422_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask422_13_16078)">
+<path d="M787.945 933.737C788.736 933.645 789.143 933.507 789.618 933.138C790.363 932.586 790.815 931.688 790.815 930.699C790.815 929.502 790.137 928.651 789.211 928.651C788.375 928.651 787.742 929.387 787.742 930.377C787.742 931.251 788.239 931.85 789.03 931.85C789.414 931.85 789.708 931.734 790.092 931.435C789.798 932.609 789.007 933.391 787.923 933.599L787.945 933.737ZM790.115 930.975C790.115 931.136 790.07 931.205 790.002 931.274C789.798 931.435 789.527 931.527 789.279 931.527C788.736 931.527 788.397 930.975 788.397 930.124C788.397 929.709 788.51 929.272 788.646 929.065C788.781 928.927 788.962 928.858 789.166 928.858C789.776 928.858 790.115 929.479 790.115 930.699V930.975Z" fill="white"/>
+</g>
+<mask id="mask423_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask423_13_16078)">
+<path d="M786.476 948.063L785.188 948.73V948.822C785.278 948.776 785.346 948.753 785.391 948.753C785.504 948.684 785.64 948.661 785.708 948.661C785.866 948.661 785.934 948.776 785.934 949.006V952.32C785.934 952.55 785.866 952.711 785.753 952.78C785.64 952.85 785.55 952.873 785.233 952.873V952.988H787.222V952.873C786.657 952.873 786.544 952.804 786.544 952.458V948.063H786.476ZM789.804 948.063C789.397 948.063 789.103 948.178 788.832 948.431C788.425 948.845 788.154 949.674 788.154 950.525C788.154 951.331 788.38 952.182 788.719 952.596C788.99 952.919 789.352 953.08 789.759 953.08C790.12 953.08 790.437 952.965 790.685 952.711C791.115 952.32 791.386 951.469 791.386 950.571C791.386 949.075 790.731 948.063 789.804 948.063ZM789.781 948.247C790.369 948.247 790.685 949.075 790.685 950.594C790.685 952.113 790.392 952.896 789.759 952.896C789.149 952.896 788.832 952.113 788.832 950.594C788.832 949.052 789.149 948.247 789.781 948.247Z" fill="white"/>
+</g>
+<mask id="mask424_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask424_13_16078)">
+<path d="M798.268 952.251L796.98 952.919V953.011C797.07 952.965 797.138 952.942 797.183 952.942C797.296 952.873 797.432 952.85 797.499 952.85C797.658 952.85 797.725 952.965 797.725 953.195V956.509C797.725 956.739 797.658 956.9 797.545 956.969C797.432 957.038 797.341 957.061 797.025 957.061V957.176H799.014V957.061C798.449 957.061 798.336 956.992 798.336 956.647V952.251H798.268ZM801.85 952.251L800.562 952.919V953.011C800.652 952.965 800.72 952.942 800.765 952.942C800.878 952.873 801.014 952.85 801.082 952.85C801.24 952.85 801.308 952.965 801.308 953.195V956.509C801.308 956.739 801.24 956.9 801.127 956.969C801.014 957.038 800.923 957.061 800.607 957.061V957.176H802.596V957.061C802.031 957.061 801.918 956.992 801.918 956.647V952.251H801.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask425_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1212" y="775" width="112" height="114">
+<path d="M1212 888.037H1323V775H1212V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask425_13_16078)">
+<mask id="mask426_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask426_13_16078)">
+<path d="M1234.82 815.354L1252.54 800.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask427_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask427_13_16078)">
+<path d="M1234.82 815.354L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask428_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask428_13_16078)">
+<path d="M1234.82 815.354L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask429_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask429_13_16078)">
+<path d="M1234.82 815.354L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask430_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask430_13_16078)">
+<path d="M1252.54 800.382L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask431_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask431_13_16078)">
+<path d="M1252.54 800.382L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask432_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask432_13_16078)">
+<path d="M1252.54 800.382L1286.37 811.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask433_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask433_13_16078)">
+<path d="M1226.28 797.666L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask434_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask434_13_16078)">
+<path d="M1286.37 811.754L1290.61 834.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask435_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask435_13_16078)">
+<path d="M1286.37 811.754L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask436_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask436_13_16078)">
+<path d="M1286.37 811.754L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask437_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask437_13_16078)">
+<path d="M1290.61 834.102L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask438_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask438_13_16078)">
+<path d="M1290.61 834.102L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask439_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask439_13_16078)">
+<path d="M1290.61 834.102L1263.36 857.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask440_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask440_13_16078)">
+<path d="M1306.61 813.444L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask441_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask441_13_16078)">
+<path d="M1263.36 857.307L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask442_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask442_13_16078)">
+<path d="M1263.36 857.306L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask443_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask443_13_16078)">
+<path d="M1263.36 857.306L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask444_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask444_13_16078)">
+<path d="M1241.31 849.895L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask445_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask445_13_16078)">
+<path d="M1241.31 849.895L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask446_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask446_13_16078)">
+<path d="M1239.98 869.307L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask447_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask447_13_16078)">
+<mask id="mask448_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1229" y="810" width="11" height="11">
+<path d="M1229.86 820.402H1239.78V810.307H1229.86V820.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask448_13_16078)">
+<path d="M1234.82 819.88C1236 819.88 1237.13 819.403 1237.96 818.554C1238.8 817.706 1239.26 816.555 1239.26 815.354C1239.26 814.154 1238.8 813.003 1237.96 812.155C1237.13 811.306 1236 810.829 1234.82 810.829C1233.64 810.829 1232.51 811.306 1231.68 812.155C1230.85 813.003 1230.38 814.154 1230.38 815.354C1230.38 816.555 1230.85 817.706 1231.68 818.554C1232.51 819.403 1233.64 819.88 1234.82 819.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask449_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask449_13_16078)">
+<mask id="mask450_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1247" y="795" width="11" height="11">
+<path d="M1247.58 805.429H1257.5V795.334H1247.58V805.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask450_13_16078)">
+<path d="M1252.54 804.907C1253.72 804.907 1254.85 804.43 1255.68 803.581C1256.52 802.733 1256.98 801.582 1256.98 800.382C1256.98 799.181 1256.52 798.03 1255.68 797.182C1254.85 796.333 1253.72 795.856 1252.54 795.856C1251.36 795.856 1250.23 796.333 1249.4 797.182C1248.56 798.03 1248.1 799.181 1248.1 800.382C1248.1 801.582 1248.56 802.733 1249.4 803.581C1250.23 804.43 1251.36 804.907 1252.54 804.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask451_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask451_13_16078)">
+<mask id="mask452_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1221" y="792" width="11" height="11">
+<path d="M1221.32 802.714H1231.24V792.618H1221.32V802.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask452_13_16078)">
+<path d="M1226.28 802.191C1227.46 802.191 1228.59 801.714 1229.42 800.866C1230.26 800.017 1230.72 798.866 1230.72 797.666C1230.72 796.466 1230.26 795.315 1229.42 794.466C1228.59 793.617 1227.46 793.141 1226.28 793.141C1225.1 793.141 1223.97 793.617 1223.14 794.466C1222.3 795.315 1221.84 796.466 1221.84 797.666C1221.84 798.866 1222.3 800.017 1223.14 800.866C1223.97 801.714 1225.1 802.191 1226.28 802.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask453_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask453_13_16078)">
+<mask id="mask454_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1230" y="784" width="11" height="11">
+<path d="M1230.57 794.592H1240.48V784.496H1230.57V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask454_13_16078)">
+<path d="M1235.52 794.069C1236.7 794.069 1237.83 793.592 1238.67 792.744C1239.5 791.895 1239.97 790.744 1239.97 789.544C1239.97 788.344 1239.5 787.193 1238.67 786.344C1237.83 785.495 1236.7 785.019 1235.52 785.019C1234.34 785.019 1233.21 785.495 1232.38 786.344C1231.55 787.193 1231.08 788.344 1231.08 789.544C1231.08 790.744 1231.55 791.895 1232.38 792.744C1233.21 793.592 1234.34 794.069 1235.52 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask455_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask455_13_16078)">
+<mask id="mask456_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1281" y="806" width="11" height="11">
+<path d="M1281.41 816.802H1291.32V806.707H1281.41V816.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask456_13_16078)">
+<path d="M1286.37 816.28C1287.54 816.28 1288.67 815.803 1289.51 814.954C1290.34 814.106 1290.81 812.955 1290.81 811.754C1290.81 810.554 1290.34 809.403 1289.51 808.555C1288.67 807.706 1287.54 807.229 1286.37 807.229C1285.19 807.229 1284.06 807.706 1283.22 808.555C1282.39 809.403 1281.92 810.554 1281.92 811.754C1281.92 812.955 1282.39 814.106 1283.22 814.954C1284.06 815.803 1285.19 816.28 1286.37 816.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask457_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask457_13_16078)">
+<mask id="mask458_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1285" y="829" width="11" height="11">
+<path d="M1285.66 839.15H1295.57V829.054H1285.66V839.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask458_13_16078)">
+<path d="M1290.61 838.628C1291.79 838.628 1292.92 838.151 1293.75 837.302C1294.59 836.453 1295.06 835.302 1295.06 834.102C1295.06 832.902 1294.59 831.751 1293.75 830.902C1292.92 830.054 1291.79 829.577 1290.61 829.577C1289.43 829.577 1288.3 830.054 1287.47 830.902C1286.64 831.751 1286.17 832.902 1286.17 834.102C1286.17 835.302 1286.64 836.453 1287.47 837.302C1288.3 838.151 1289.43 838.628 1290.61 838.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask459_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask459_13_16078)">
+<mask id="mask460_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1301" y="808" width="11" height="11">
+<path d="M1301.66 818.492H1311.57V808.396H1301.66V818.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask460_13_16078)">
+<path d="M1306.61 817.969C1307.79 817.969 1308.92 817.492 1309.76 816.644C1310.59 815.795 1311.06 814.644 1311.06 813.444C1311.06 812.244 1310.59 811.093 1309.76 810.244C1308.92 809.395 1307.79 808.919 1306.61 808.919C1305.44 808.919 1304.3 809.395 1303.47 810.244C1302.64 811.093 1302.17 812.244 1302.17 813.444C1302.17 814.644 1302.64 815.795 1303.47 816.644C1304.3 817.492 1305.44 817.969 1306.61 817.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask461_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask461_13_16078)">
+<mask id="mask462_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1303" y="820" width="11" height="11">
+<path d="M1303.77 830.201H1313.68V820.105H1303.77V830.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask462_13_16078)">
+<path d="M1308.72 829.678C1309.9 829.678 1311.03 829.202 1311.87 828.353C1312.7 827.504 1313.17 826.353 1313.17 825.153C1313.17 823.953 1312.7 822.802 1311.87 821.953C1311.03 821.105 1309.9 820.628 1308.72 820.628C1307.54 820.628 1306.41 821.105 1305.58 821.953C1304.75 822.802 1304.28 823.953 1304.28 825.153C1304.28 826.353 1304.75 827.504 1305.58 828.353C1306.41 829.202 1307.54 829.678 1308.72 829.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask463_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask463_13_16078)">
+<mask id="mask464_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1258" y="852" width="11" height="11">
+<path d="M1258.4 862.354H1268.31V852.259H1258.4V862.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask464_13_16078)">
+<path d="M1263.36 861.832C1264.53 861.832 1265.67 861.355 1266.5 860.506C1267.33 859.658 1267.8 858.507 1267.8 857.307C1267.8 856.106 1267.33 854.955 1266.5 854.107C1265.67 853.258 1264.53 852.781 1263.36 852.781C1262.18 852.781 1261.05 853.258 1260.21 854.107C1259.38 854.955 1258.91 856.106 1258.91 857.307C1258.91 858.507 1259.38 859.658 1260.21 860.506C1261.05 861.355 1262.18 861.832 1263.36 861.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask465_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask465_13_16078)">
+<mask id="mask466_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1236" y="844" width="11" height="11">
+<path d="M1236.35 854.943H1246.26V844.847H1236.35V854.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask466_13_16078)">
+<path d="M1241.31 854.42C1242.49 854.42 1243.62 853.943 1244.45 853.095C1245.28 852.246 1245.75 851.095 1245.75 849.895C1245.75 848.695 1245.28 847.544 1244.45 846.695C1243.62 845.846 1242.49 845.37 1241.31 845.37C1240.13 845.37 1239 845.846 1238.17 846.695C1237.33 847.544 1236.86 848.695 1236.86 849.895C1236.86 851.095 1237.33 852.246 1238.17 853.095C1239 853.943 1240.13 854.42 1241.31 854.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask467_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask467_13_16078)">
+<mask id="mask468_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1235" y="864" width="10" height="11">
+<path d="M1235.02 874.355H1244.93V864.259H1235.02V874.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask468_13_16078)">
+<path d="M1239.98 873.832C1241.15 873.832 1242.28 873.355 1243.12 872.507C1243.95 871.658 1244.42 870.507 1244.42 869.307C1244.42 868.107 1243.95 866.955 1243.12 866.107C1242.28 865.258 1241.15 864.781 1239.98 864.781C1238.8 864.781 1237.67 865.258 1236.83 866.107C1236 866.955 1235.53 868.107 1235.53 869.307C1235.53 870.507 1236 871.658 1236.83 872.507C1237.67 873.355 1238.8 873.832 1239.98 873.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask469_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask469_13_16078)">
+<mask id="mask470_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1246" y="868" width="11" height="11">
+<path d="M1246.81 878.543H1256.73V868.448H1246.81V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask470_13_16078)">
+<path d="M1251.77 878.021C1252.95 878.021 1254.08 877.544 1254.91 876.695C1255.74 875.847 1256.21 874.696 1256.21 873.496C1256.21 872.295 1255.74 871.144 1254.91 870.296C1254.08 869.447 1252.95 868.97 1251.77 868.97C1250.59 868.97 1249.46 869.447 1248.63 870.296C1247.79 871.144 1247.32 872.295 1247.32 873.496C1247.32 874.696 1247.79 875.847 1248.63 876.695C1249.46 877.544 1250.59 878.021 1251.77 878.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask471_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask471_13_16078)">
+<path d="M1234.86 812.113C1234.45 812.113 1234.16 812.228 1233.89 812.481C1233.48 812.895 1233.21 813.724 1233.21 814.575C1233.21 815.381 1233.44 816.232 1233.78 816.646C1234.05 816.969 1234.41 817.13 1234.81 817.13C1235.18 817.13 1235.49 817.015 1235.74 816.762C1236.17 816.37 1236.44 815.519 1236.44 814.621C1236.44 813.125 1235.79 812.113 1234.86 812.113ZM1234.84 812.297C1235.43 812.297 1235.74 813.125 1235.74 814.644C1235.74 816.163 1235.45 816.946 1234.81 816.946C1234.2 816.946 1233.89 816.163 1233.89 814.644C1233.89 813.102 1234.2 812.297 1234.84 812.297Z" fill="white"/>
+</g>
+<mask id="mask472_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask472_13_16078)">
+<path d="M1252.83 797.137L1251.54 797.804V797.896C1251.64 797.85 1251.7 797.827 1251.75 797.827C1251.86 797.758 1252 797.735 1252.06 797.735C1252.22 797.735 1252.29 797.85 1252.29 798.08V801.394C1252.29 801.624 1252.22 801.785 1252.11 801.854C1252 801.923 1251.91 801.946 1251.59 801.946V802.061H1253.58V801.946C1253.01 801.946 1252.9 801.877 1252.9 801.532V797.137H1252.83Z" fill="white"/>
+</g>
+<mask id="mask473_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask473_13_16078)">
+<path d="M1227.9 798.356L1227.79 798.31C1227.54 798.724 1227.45 798.794 1227.11 798.794H1225.42L1226.62 797.505C1227.25 796.837 1227.52 796.285 1227.52 795.71C1227.52 794.973 1226.96 794.421 1226.21 794.421C1225.8 794.421 1225.44 794.582 1225.17 794.858C1224.94 795.111 1224.83 795.341 1224.72 795.871L1224.85 795.894C1225.15 795.18 1225.42 794.95 1225.89 794.95C1226.5 794.95 1226.91 795.364 1226.91 795.986C1226.91 796.561 1226.59 797.229 1225.98 797.873L1224.72 799.254V799.346H1227.5L1227.9 798.356Z" fill="white"/>
+</g>
+<mask id="mask474_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask474_13_16078)">
+<path d="M1234.84 788.811C1235.25 788.811 1235.41 788.834 1235.59 788.903C1236.04 789.065 1236.31 789.479 1236.31 789.985C1236.31 790.583 1235.91 791.067 1235.39 791.067C1235.18 791.067 1235.05 791.021 1234.78 790.837C1234.55 790.698 1234.44 790.652 1234.32 790.652C1234.14 790.652 1234.05 790.768 1234.05 790.906C1234.05 791.159 1234.35 791.32 1234.84 791.32C1235.41 791.32 1235.97 791.136 1236.31 790.837C1236.65 790.537 1236.83 790.123 1236.83 789.64C1236.83 789.249 1236.72 788.926 1236.52 788.696C1236.36 788.535 1236.22 788.443 1235.91 788.305C1236.4 787.96 1236.58 787.684 1236.58 787.292C1236.58 786.694 1236.13 786.303 1235.48 786.303C1235.11 786.303 1234.8 786.418 1234.55 786.648C1234.32 786.855 1234.21 787.039 1234.05 787.477L1234.17 787.5C1234.46 786.97 1234.78 786.74 1235.23 786.74C1235.7 786.74 1236.02 787.062 1236.02 787.523C1236.02 787.776 1235.91 788.029 1235.72 788.213C1235.52 788.443 1235.32 788.558 1234.84 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask475_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask475_13_16078)">
+<path d="M1287.96 811.756H1287.22V808.511H1286.9L1284.67 811.756V812.216H1286.68V813.436H1287.22V812.216H1287.96V811.756ZM1286.68 811.756H1284.94L1286.68 809.248V811.756Z" fill="white"/>
+</g>
+<mask id="mask476_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask476_13_16078)">
+<path d="M1290.11 831.525H1291.54C1291.65 831.525 1291.67 831.525 1291.69 831.456L1291.97 830.811L1291.9 830.765C1291.78 830.926 1291.72 830.949 1291.56 830.949H1290.07L1289.3 832.676C1289.28 832.699 1289.28 832.699 1289.28 832.722C1289.28 832.745 1289.32 832.768 1289.37 832.768C1289.59 832.768 1289.89 832.837 1290.18 832.929C1290.99 833.182 1291.38 833.642 1291.38 834.379C1291.38 835.069 1290.95 835.621 1290.38 835.621C1290.25 835.621 1290.11 835.552 1289.91 835.414C1289.68 835.23 1289.5 835.161 1289.37 835.161C1289.16 835.161 1289.05 835.253 1289.05 835.437C1289.05 835.713 1289.39 835.874 1289.93 835.874C1290.52 835.874 1291.04 835.69 1291.4 835.322C1291.74 834.977 1291.87 834.563 1291.87 834.01C1291.87 833.481 1291.74 833.159 1291.38 832.791C1291.08 832.468 1290.65 832.307 1289.82 832.146L1290.11 831.525Z" fill="white"/>
+</g>
+<mask id="mask477_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask477_13_16078)">
+<path d="M1308.01 810.134C1307.2 810.203 1306.79 810.341 1306.27 810.732C1305.48 811.284 1305.07 812.113 1305.07 813.102C1305.07 813.724 1305.25 814.368 1305.57 814.736C1305.84 815.058 1306.23 815.22 1306.68 815.22C1307.56 815.22 1308.17 814.529 1308.17 813.54C1308.17 812.596 1307.65 811.998 1306.84 811.998C1306.52 811.998 1306.36 812.067 1305.91 812.343C1306.11 811.238 1306.9 810.433 1308.03 810.249L1308.01 810.134ZM1306.56 812.343C1307.18 812.343 1307.54 812.872 1307.54 813.77C1307.54 814.575 1307.24 815.035 1306.75 815.035C1306.11 815.035 1305.73 814.345 1305.73 813.217C1305.73 812.826 1305.8 812.642 1305.93 812.527C1306.09 812.412 1306.32 812.343 1306.56 812.343Z" fill="white"/>
+</g>
+<mask id="mask478_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask478_13_16078)">
+<path d="M1310.14 822.003H1307.5L1307.07 823.085L1307.2 823.131C1307.5 822.647 1307.63 822.555 1308.04 822.555H1309.58L1308.18 826.905H1308.63L1310.14 822.118V822.003Z" fill="white"/>
+</g>
+<mask id="mask479_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask479_13_16078)">
+<path d="M1263.65 856.27C1264.35 855.902 1264.6 855.58 1264.6 855.097C1264.6 854.498 1264.1 854.061 1263.38 854.061C1262.58 854.061 1262.02 854.544 1262.02 855.212C1262.02 855.672 1262.16 855.902 1262.9 856.57C1262.13 857.168 1261.97 857.398 1261.97 857.881C1261.97 858.595 1262.54 859.078 1263.35 859.078C1264.21 859.078 1264.75 858.618 1264.75 857.858C1264.75 857.283 1264.51 856.938 1263.65 856.27ZM1263.51 857.03C1264.03 857.421 1264.21 857.674 1264.21 858.088C1264.21 858.549 1263.9 858.894 1263.42 858.894C1262.88 858.894 1262.52 858.457 1262.52 857.835C1262.52 857.352 1262.68 857.053 1263.08 856.708L1263.51 857.03ZM1263.44 856.155C1262.81 855.718 1262.54 855.396 1262.54 854.982C1262.54 854.567 1262.86 854.268 1263.31 854.268C1263.81 854.268 1264.12 854.59 1264.12 855.074C1264.12 855.488 1263.92 855.833 1263.51 856.109C1263.47 856.132 1263.47 856.132 1263.44 856.155Z" fill="white"/>
+</g>
+<mask id="mask480_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask480_13_16078)">
+<path d="M1239.95 851.737C1240.74 851.645 1241.14 851.507 1241.62 851.138C1242.36 850.586 1242.82 849.688 1242.82 848.699C1242.82 847.502 1242.14 846.651 1241.21 846.651C1240.37 846.651 1239.74 847.387 1239.74 848.377C1239.74 849.251 1240.24 849.85 1241.03 849.85C1241.41 849.85 1241.71 849.734 1242.09 849.435C1241.8 850.609 1241.01 851.391 1239.92 851.599L1239.95 851.737ZM1242.11 848.975C1242.11 849.136 1242.07 849.205 1242 849.274C1241.8 849.435 1241.53 849.527 1241.28 849.527C1240.74 849.527 1240.4 848.975 1240.4 848.124C1240.4 847.709 1240.51 847.272 1240.65 847.065C1240.78 846.927 1240.96 846.858 1241.17 846.858C1241.78 846.858 1242.11 847.479 1242.11 848.699V848.975Z" fill="white"/>
+</g>
+<mask id="mask481_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask481_13_16078)">
+<path d="M1238.48 866.063L1237.19 866.73V866.822C1237.28 866.776 1237.35 866.753 1237.39 866.753C1237.5 866.684 1237.64 866.661 1237.71 866.661C1237.87 866.661 1237.93 866.776 1237.93 867.006V870.32C1237.93 870.55 1237.87 870.711 1237.75 870.78C1237.64 870.85 1237.55 870.873 1237.23 870.873V870.988H1239.22V870.873C1238.66 870.873 1238.54 870.804 1238.54 870.458V866.063H1238.48ZM1241.8 866.063C1241.4 866.063 1241.1 866.178 1240.83 866.431C1240.43 866.845 1240.15 867.674 1240.15 868.525C1240.15 869.331 1240.38 870.182 1240.72 870.596C1240.99 870.919 1241.35 871.08 1241.76 871.08C1242.12 871.08 1242.44 870.965 1242.69 870.711C1243.11 870.32 1243.39 869.469 1243.39 868.571C1243.39 867.075 1242.73 866.063 1241.8 866.063ZM1241.78 866.247C1242.37 866.247 1242.69 867.075 1242.69 868.594C1242.69 870.113 1242.39 870.896 1241.76 870.896C1241.15 870.896 1240.83 870.113 1240.83 868.594C1240.83 867.052 1241.15 866.247 1241.78 866.247Z" fill="white"/>
+</g>
+<mask id="mask482_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask482_13_16078)">
+<path d="M1250.27 870.251L1248.98 870.919V871.011C1249.07 870.965 1249.14 870.942 1249.18 870.942C1249.3 870.873 1249.43 870.85 1249.5 870.85C1249.66 870.85 1249.73 870.965 1249.73 871.195V874.509C1249.73 874.739 1249.66 874.9 1249.54 874.969C1249.43 875.038 1249.34 875.061 1249.02 875.061V875.176H1251.01V875.061C1250.45 875.061 1250.34 874.992 1250.34 874.647V870.251H1250.27ZM1253.85 870.251L1252.56 870.919V871.011C1252.65 870.965 1252.72 870.942 1252.77 870.942C1252.88 870.873 1253.01 870.85 1253.08 870.85C1253.24 870.85 1253.31 870.965 1253.31 871.195V874.509C1253.31 874.739 1253.24 874.9 1253.13 874.969C1253.01 875.038 1252.92 875.061 1252.61 875.061V875.176H1254.6V875.061C1254.03 875.061 1253.92 874.992 1253.92 874.647V870.251H1253.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask483_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="599" width="112" height="114">
+<path d="M303 712.037H414.004V599H303V712.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask483_13_16078)">
+<mask id="mask484_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask484_13_16078)">
+<path d="M373.994 647.467L399.723 613.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask485_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask485_13_16078)">
+<path d="M373.994 647.467L346.753 682.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask486_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask486_13_16078)">
+<path d="M373.994 647.467L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask487_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask487_13_16078)">
+<path d="M373.994 647.467L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask488_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask488_13_16078)">
+<path d="M373.994 647.467L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask489_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask489_13_16078)">
+<path d="M346.753 682.876L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask490_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask490_13_16078)">
+<path d="M346.753 682.876L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask491_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask491_13_16078)">
+<path d="M346.753 682.876L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask492_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask492_13_16078)">
+<path d="M343.325 666.493L334.824 615.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask493_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask493_13_16078)">
+<path d="M343.325 666.493L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask494_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask494_13_16078)">
+<path d="M343.325 666.493L376.747 697.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask495_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask495_13_16078)">
+<path d="M343.325 666.493L324.53 693.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask496_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask496_13_16078)">
+<path d="M343.325 666.493L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask497_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask497_13_16078)">
+<path d="M343.325 666.493L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask498_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask498_13_16078)">
+<path d="M334.824 615.141L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask499_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask499_13_16078)">
+<path d="M353.445 633.168L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask500_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask500_13_16078)">
+<path d="M353.445 633.168L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask501_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask501_13_16078)">
+<path d="M376.747 697.496L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask502_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask502_13_16078)">
+<path d="M324.53 693.105L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask503_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask503_13_16078)">
+<mask id="mask504_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="369" y="642" width="10" height="11">
+<path d="M369.037 652.515H378.951V642.419H369.037V652.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask504_13_16078)">
+<path d="M373.994 651.992C375.172 651.992 376.303 651.515 377.136 650.667C377.97 649.818 378.438 648.667 378.438 647.467C378.438 646.267 377.97 645.116 377.136 644.267C376.303 643.418 375.172 642.942 373.994 642.942C372.815 642.942 371.685 643.418 370.851 644.267C370.018 645.116 369.55 646.267 369.55 647.467C369.55 648.667 370.018 649.818 370.851 650.667C371.685 651.515 372.815 651.992 373.994 651.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask505_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask505_13_16078)">
+<mask id="mask506_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="608" width="11" height="11">
+<path d="M394.766 618.592H404.68V608.496H394.766V618.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask506_13_16078)">
+<path d="M399.723 618.069C400.901 618.069 402.032 617.593 402.865 616.744C403.699 615.895 404.167 614.744 404.167 613.544C404.167 612.344 403.699 611.193 402.865 610.344C402.032 609.496 400.901 609.019 399.723 609.019C398.544 609.019 397.414 609.496 396.58 610.344C395.747 611.193 395.279 612.344 395.279 613.544C395.279 614.744 395.747 615.895 396.58 616.744C397.414 617.593 398.544 618.069 399.723 618.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask507_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask507_13_16078)">
+<mask id="mask508_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="341" y="677" width="11" height="11">
+<path d="M341.796 687.924H351.71V677.829H341.796V687.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask508_13_16078)">
+<path d="M346.753 687.402C347.931 687.402 349.062 686.925 349.895 686.076C350.728 685.228 351.197 684.077 351.197 682.876C351.197 681.676 350.728 680.525 349.895 679.677C349.062 678.828 347.931 678.351 346.753 678.351C345.574 678.351 344.444 678.828 343.61 679.677C342.777 680.525 342.309 681.676 342.309 682.876C342.309 684.077 342.777 685.228 343.61 686.076C344.444 686.925 345.574 687.402 346.753 687.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask509_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask509_13_16078)">
+<mask id="mask510_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="661" width="11" height="11">
+<path d="M338.368 671.541H348.282V661.445H338.368V671.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask510_13_16078)">
+<path d="M343.325 671.018C344.503 671.018 345.634 670.541 346.467 669.693C347.3 668.844 347.769 667.693 347.769 666.493C347.769 665.293 347.3 664.142 346.467 663.293C345.634 662.444 344.503 661.968 343.325 661.968C342.146 661.968 341.016 662.444 340.182 663.293C339.349 664.142 338.881 665.293 338.881 666.493C338.881 667.693 339.349 668.844 340.182 669.693C341.016 670.541 342.146 671.018 343.325 671.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask511_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask511_13_16078)">
+<mask id="mask512_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="610" width="11" height="11">
+<path d="M329.867 620.189H339.781V610.094H329.867V620.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask512_13_16078)">
+<path d="M334.824 619.667C336.003 619.667 337.133 619.19 337.967 618.341C338.8 617.493 339.268 616.342 339.268 615.141C339.268 613.941 338.8 612.79 337.967 611.941C337.133 611.093 336.003 610.616 334.824 610.616C333.646 610.616 332.515 611.093 331.682 611.941C330.848 612.79 330.38 613.941 330.38 615.141C330.38 616.342 330.848 617.493 331.682 618.341C332.515 619.19 333.646 619.667 334.824 619.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask513_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask513_13_16078)">
+<mask id="mask514_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="348" y="628" width="11" height="11">
+<path d="M348.488 638.216H358.402V628.12H348.488V638.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask514_13_16078)">
+<path d="M353.445 637.693C354.623 637.693 355.754 637.216 356.587 636.368C357.421 635.519 357.889 634.368 357.889 633.168C357.889 631.968 357.421 630.817 356.587 629.968C355.754 629.119 354.623 628.643 353.445 628.643C352.266 628.643 351.136 629.119 350.303 629.968C349.469 630.817 349.001 631.968 349.001 633.168C349.001 634.368 349.469 635.519 350.303 636.368C351.136 637.216 352.266 637.693 353.445 637.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask515_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask515_13_16078)">
+<mask id="mask516_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="371" y="692" width="11" height="11">
+<path d="M371.79 702.543H381.704V692.448H371.79V702.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask516_13_16078)">
+<path d="M376.747 702.021C377.925 702.021 379.056 701.544 379.889 700.696C380.723 699.847 381.191 698.696 381.191 697.496C381.191 696.295 380.723 695.144 379.889 694.296C379.056 693.447 377.925 692.97 376.747 692.97C375.568 692.97 374.438 693.447 373.604 694.296C372.771 695.144 372.303 696.295 372.303 697.496C372.303 698.696 372.771 699.847 373.604 700.696C374.438 701.544 375.568 702.021 376.747 702.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask517_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask517_13_16078)">
+<mask id="mask518_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="319" y="688" width="11" height="11">
+<path d="M319.573 698.153H329.487V688.057H319.573V698.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask518_13_16078)">
+<path d="M324.53 697.63C325.708 697.63 326.839 697.153 327.672 696.305C328.506 695.456 328.974 694.305 328.974 693.105C328.974 691.905 328.506 690.754 327.672 689.905C326.839 689.056 325.708 688.58 324.53 688.58C323.351 688.58 322.221 689.056 321.388 689.905C320.554 690.754 320.086 691.905 320.086 693.105C320.086 694.305 320.554 695.456 321.388 696.305C322.221 697.153 323.351 697.63 324.53 697.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask519_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask519_13_16078)">
+<mask id="mask520_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="335" y="646" width="11" height="11">
+<path d="M335.127 656.971H345.041V646.876H335.127V656.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask520_13_16078)">
+<path d="M340.084 656.449C341.263 656.449 342.393 655.972 343.226 655.123C344.06 654.275 344.528 653.124 344.528 651.924C344.528 650.723 344.06 649.572 343.226 648.724C342.393 647.875 341.263 647.398 340.084 647.398C338.905 647.398 337.775 647.875 336.942 648.724C336.108 649.572 335.64 650.723 335.64 651.924C335.64 653.124 336.108 654.275 336.942 655.123C337.775 655.972 338.905 656.449 340.084 656.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask521_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask521_13_16078)">
+<mask id="mask522_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="673" width="11" height="11">
+<path d="M392.783 683.164H402.697V673.068H392.783V683.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask522_13_16078)">
+<path d="M397.74 682.641C398.918 682.641 400.049 682.164 400.882 681.316C401.715 680.467 402.184 679.316 402.184 678.116C402.184 676.916 401.715 675.765 400.882 674.916C400.049 674.067 398.918 673.591 397.74 673.591C396.561 673.591 395.431 674.067 394.597 674.916C393.764 675.765 393.296 676.916 393.296 678.116C393.296 679.316 393.764 680.467 394.597 681.316C395.431 682.164 396.561 682.641 397.74 682.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask523_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask523_13_16078)">
+<mask id="mask524_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="356" y="664" width="10" height="11">
+<path d="M356.043 674.696H365.958V664.601H356.043V674.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask524_13_16078)">
+<path d="M361.001 674.174C362.179 674.174 363.31 673.697 364.143 672.848C364.976 672 365.445 670.849 365.445 669.649C365.445 668.448 364.976 667.297 364.143 666.449C363.31 665.6 362.179 665.123 361.001 665.123C359.822 665.123 358.692 665.6 357.858 666.449C357.025 667.297 356.557 668.448 356.557 669.649C356.557 670.849 357.025 672 357.858 672.848C358.692 673.697 359.822 674.174 361.001 674.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask525_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask525_13_16078)">
+<mask id="mask526_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="669" width="11" height="11">
+<path d="M312.323 679.902H322.237V669.806H312.323V679.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask526_13_16078)">
+<path d="M317.28 679.38C318.458 679.38 319.589 678.903 320.422 678.054C321.256 677.206 321.724 676.054 321.724 674.854C321.724 673.654 321.256 672.503 320.422 671.654C319.589 670.806 318.458 670.329 317.28 670.329C316.101 670.329 314.971 670.806 314.137 671.654C313.304 672.503 312.836 673.654 312.836 674.854C312.836 676.054 313.304 677.206 314.137 678.054C314.971 678.903 316.101 679.38 317.28 679.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask527_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask527_13_16078)">
+<path d="M374.032 644.225C373.626 644.225 373.332 644.34 373.061 644.593C372.654 645.008 372.383 645.836 372.383 646.688C372.383 647.493 372.609 648.345 372.948 648.759C373.219 649.081 373.58 649.242 373.987 649.242C374.349 649.242 374.665 649.127 374.914 648.874C375.343 648.483 375.614 647.631 375.614 646.734C375.614 645.238 374.959 644.225 374.032 644.225ZM374.01 644.409C374.597 644.409 374.914 645.238 374.914 646.757C374.914 648.276 374.62 649.058 373.987 649.058C373.377 649.058 373.061 648.276 373.061 646.757C373.061 645.215 373.377 644.409 374.01 644.409Z" fill="white"/>
+</g>
+<mask id="mask528_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask528_13_16078)">
+<path d="M400.011 610.303L398.723 610.97V611.062C398.814 611.016 398.881 610.993 398.927 610.993C399.04 610.924 399.175 610.901 399.243 610.901C399.401 610.901 399.469 611.016 399.469 611.246V614.56C399.469 614.791 399.401 614.952 399.288 615.021C399.175 615.09 399.085 615.113 398.768 615.113V615.228H400.757V615.113C400.192 615.113 400.079 615.044 400.079 614.698V610.303H400.011Z" fill="white"/>
+</g>
+<mask id="mask529_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask529_13_16078)">
+<path d="M348.376 683.567L348.263 683.521C348.014 683.935 347.924 684.004 347.585 684.004H345.89L347.087 682.716C347.72 682.048 347.991 681.496 347.991 680.921C347.991 680.184 347.426 679.632 346.681 679.632C346.274 679.632 345.912 679.793 345.641 680.069C345.415 680.322 345.302 680.552 345.189 681.082L345.325 681.105C345.618 680.391 345.89 680.161 346.364 680.161C346.974 680.161 347.381 680.575 347.381 681.197C347.381 681.772 347.065 682.439 346.455 683.084L345.189 684.465V684.557H347.969L348.376 683.567Z" fill="white"/>
+</g>
+<mask id="mask530_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask530_13_16078)">
+<path d="M342.641 665.76C343.048 665.76 343.206 665.783 343.387 665.852C343.839 666.013 344.11 666.428 344.11 666.934C344.11 667.532 343.703 668.016 343.183 668.016C342.98 668.016 342.844 667.97 342.573 667.785C342.347 667.647 342.234 667.601 342.121 667.601C341.94 667.601 341.85 667.716 341.85 667.855C341.85 668.108 342.144 668.269 342.641 668.269C343.206 668.269 343.771 668.085 344.11 667.785C344.449 667.486 344.63 667.072 344.63 666.589C344.63 666.198 344.517 665.875 344.313 665.645C344.155 665.484 344.019 665.392 343.703 665.254C344.2 664.909 344.381 664.633 344.381 664.241C344.381 663.643 343.929 663.252 343.274 663.252C342.912 663.252 342.596 663.367 342.347 663.597C342.121 663.804 342.008 663.988 341.85 664.425L341.963 664.448C342.257 663.919 342.573 663.689 343.025 663.689C343.5 663.689 343.816 664.011 343.816 664.471C343.816 664.725 343.703 664.978 343.522 665.162C343.319 665.392 343.115 665.507 342.641 665.668V665.76Z" fill="white"/>
+</g>
+<mask id="mask531_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask531_13_16078)">
+<path d="M336.426 615.142H335.68V611.897H335.364L333.126 615.142V615.602H335.138V616.822H335.68V615.602H336.426V615.142ZM335.138 615.142H333.397L335.138 612.633V615.142Z" fill="white"/>
+</g>
+<mask id="mask532_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask532_13_16078)">
+<path d="M352.946 630.59H354.37C354.483 630.59 354.506 630.59 354.528 630.52L354.8 629.876L354.732 629.83C354.619 629.991 354.551 630.014 354.393 630.014H352.901L352.133 631.74C352.11 631.763 352.11 631.763 352.11 631.786C352.11 631.809 352.155 631.832 352.201 631.832C352.427 631.832 352.72 631.901 353.014 631.993C353.828 632.247 354.212 632.707 354.212 633.443C354.212 634.134 353.783 634.686 353.218 634.686C353.082 634.686 352.946 634.617 352.743 634.479C352.517 634.295 352.336 634.226 352.201 634.226C351.997 634.226 351.884 634.318 351.884 634.502C351.884 634.778 352.223 634.939 352.766 634.939C353.353 634.939 353.873 634.755 354.235 634.387C354.574 634.042 354.709 633.627 354.709 633.075C354.709 632.546 354.574 632.224 354.212 631.855C353.918 631.533 353.489 631.372 352.653 631.211L352.946 630.59Z" fill="white"/>
+</g>
+<mask id="mask533_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask533_13_16078)">
+<path d="M378.146 694.182C377.332 694.251 376.925 694.389 376.405 694.781C375.614 695.333 375.208 696.161 375.208 697.151C375.208 697.772 375.388 698.417 375.705 698.785C375.976 699.107 376.36 699.268 376.812 699.268C377.694 699.268 378.304 698.578 378.304 697.588C378.304 696.645 377.784 696.046 376.97 696.046C376.654 696.046 376.496 696.115 376.044 696.392C376.247 695.287 377.038 694.481 378.168 694.297L378.146 694.182ZM376.699 696.392C377.309 696.392 377.671 696.921 377.671 697.818C377.671 698.624 377.377 699.084 376.88 699.084C376.247 699.084 375.863 698.394 375.863 697.266C375.863 696.875 375.931 696.691 376.066 696.576C376.225 696.461 376.451 696.392 376.699 696.392Z" fill="white"/>
+</g>
+<mask id="mask534_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask534_13_16078)">
+<path d="M325.951 689.953H323.306L322.877 691.035L323.012 691.081C323.306 690.598 323.442 690.506 323.849 690.506H325.386L323.984 694.855H324.436L325.951 690.068V689.953Z" fill="white"/>
+</g>
+<mask id="mask535_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask535_13_16078)">
+<path d="M340.375 650.888C341.076 650.519 341.324 650.197 341.324 649.714C341.324 649.116 340.827 648.678 340.104 648.678C339.313 648.678 338.748 649.162 338.748 649.829C338.748 650.289 338.883 650.519 339.629 651.187C338.861 651.785 338.703 652.015 338.703 652.499C338.703 653.212 339.268 653.695 340.081 653.695C340.94 653.695 341.482 653.235 341.482 652.476C341.482 651.9 341.234 651.555 340.375 650.888ZM340.239 651.647C340.759 652.038 340.94 652.291 340.94 652.706C340.94 653.166 340.624 653.511 340.149 653.511C339.607 653.511 339.245 653.074 339.245 652.453C339.245 651.969 339.403 651.67 339.81 651.325L340.239 651.647ZM340.172 650.773C339.539 650.335 339.268 650.013 339.268 649.599C339.268 649.185 339.584 648.885 340.036 648.885C340.533 648.885 340.85 649.208 340.85 649.691C340.85 650.105 340.646 650.45 340.239 650.727C340.194 650.75 340.194 650.75 340.172 650.773Z" fill="white"/>
+</g>
+<mask id="mask536_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask536_13_16078)">
+<path d="M396.378 679.96C397.169 679.868 397.576 679.73 398.051 679.361C398.797 678.809 399.249 677.911 399.249 676.922C399.249 675.725 398.571 674.874 397.644 674.874C396.808 674.874 396.175 675.61 396.175 676.6C396.175 677.474 396.672 678.073 397.463 678.073C397.847 678.073 398.141 677.957 398.525 677.658C398.232 678.832 397.441 679.614 396.356 679.822L396.378 679.96ZM398.548 677.198C398.548 677.359 398.503 677.428 398.435 677.497C398.232 677.658 397.96 677.75 397.712 677.75C397.169 677.75 396.83 677.198 396.83 676.347C396.83 675.932 396.943 675.495 397.079 675.288C397.215 675.15 397.395 675.081 397.599 675.081C398.209 675.081 398.548 675.702 398.548 676.922V677.198Z" fill="white"/>
+</g>
+<mask id="mask537_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask537_13_16078)">
+<path d="M359.501 666.405L358.212 667.072V667.164C358.303 667.118 358.371 667.095 358.416 667.095C358.529 667.026 358.664 667.003 358.732 667.003C358.89 667.003 358.958 667.118 358.958 667.348V670.662C358.958 670.892 358.89 671.053 358.777 671.122C358.664 671.191 358.574 671.214 358.258 671.214V671.33H360.246V671.214C359.681 671.214 359.568 671.145 359.568 670.8V666.405H359.501ZM362.828 666.405C362.422 666.405 362.128 666.52 361.857 666.773C361.45 667.187 361.179 668.016 361.179 668.867C361.179 669.673 361.405 670.524 361.744 670.938C362.015 671.261 362.376 671.422 362.783 671.422C363.145 671.422 363.461 671.307 363.71 671.053C364.139 670.662 364.41 669.811 364.41 668.913C364.41 667.417 363.755 666.405 362.828 666.405ZM362.806 666.589C363.393 666.589 363.71 667.417 363.71 668.936C363.71 670.455 363.416 671.237 362.783 671.237C362.173 671.237 361.857 670.455 361.857 668.936C361.857 667.394 362.173 666.589 362.806 666.589Z" fill="white"/>
+</g>
+<mask id="mask538_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask538_13_16078)">
+<path d="M315.78 671.612L314.492 672.279V672.371C314.583 672.325 314.65 672.302 314.696 672.302C314.809 672.233 314.944 672.21 315.012 672.21C315.17 672.21 315.238 672.325 315.238 672.555V675.869C315.238 676.099 315.17 676.26 315.057 676.329C314.944 676.398 314.854 676.421 314.537 676.421V676.536H316.526V676.421C315.961 676.421 315.848 676.352 315.848 676.007V671.612H315.78ZM319.357 671.612L318.069 672.279V672.371C318.159 672.325 318.227 672.302 318.272 672.302C318.385 672.233 318.521 672.21 318.589 672.21C318.747 672.21 318.815 672.325 318.815 672.555V675.869C318.815 676.099 318.747 676.26 318.634 676.329C318.521 676.398 318.43 676.421 318.114 676.421V676.536H320.103V676.421C319.538 676.421 319.425 676.352 319.425 676.007V671.612H319.357Z" fill="white"/>
+</g>
+</g>
+<mask id="mask539_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="857" width="112" height="114">
+<path d="M320 970.037H431.004V857H320V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask539_13_16078)">
+<mask id="mask540_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask540_13_16078)">
+<path d="M390.994 905.467L416.723 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask541_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask541_13_16078)">
+<path d="M390.994 905.467L363.753 940.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask542_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask542_13_16078)">
+<path d="M390.994 905.467L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask543_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask543_13_16078)">
+<path d="M390.994 905.467L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask544_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask544_13_16078)">
+<path d="M390.994 905.467L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask545_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask545_13_16078)">
+<path d="M363.753 940.876L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask546_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask546_13_16078)">
+<path d="M363.753 940.876L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask547_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask547_13_16078)">
+<path d="M363.753 940.876L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask548_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask548_13_16078)">
+<path d="M360.325 924.493L351.824 873.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask549_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask549_13_16078)">
+<path d="M360.325 924.493L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask550_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask550_13_16078)">
+<path d="M360.325 924.493L393.747 955.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask551_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask551_13_16078)">
+<path d="M360.325 924.493L341.53 951.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask552_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask552_13_16078)">
+<path d="M360.325 924.493L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask553_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask553_13_16078)">
+<path d="M360.325 924.493L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask554_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask554_13_16078)">
+<path d="M351.824 873.141L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask555_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask555_13_16078)">
+<path d="M370.445 891.168L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask556_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask556_13_16078)">
+<path d="M370.445 891.168L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask557_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask557_13_16078)">
+<path d="M393.747 955.496L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask558_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask558_13_16078)">
+<path d="M341.53 951.105L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask559_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask559_13_16078)">
+<mask id="mask560_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="386" y="900" width="10" height="11">
+<path d="M386.037 910.515H395.951V900.419H386.037V910.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask560_13_16078)">
+<path d="M390.994 909.992C392.172 909.992 393.303 909.515 394.136 908.667C394.97 907.818 395.438 906.667 395.438 905.467C395.438 904.267 394.97 903.116 394.136 902.267C393.303 901.418 392.172 900.942 390.994 900.942C389.815 900.942 388.685 901.418 387.851 902.267C387.018 903.116 386.55 904.267 386.55 905.467C386.55 906.667 387.018 907.818 387.851 908.667C388.685 909.515 389.815 909.992 390.994 909.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask561_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask561_13_16078)">
+<mask id="mask562_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="411" y="866" width="11" height="11">
+<path d="M411.766 876.592H421.68V866.496H411.766V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask562_13_16078)">
+<path d="M416.723 876.069C417.901 876.069 419.032 875.593 419.865 874.744C420.699 873.895 421.167 872.744 421.167 871.544C421.167 870.344 420.699 869.193 419.865 868.344C419.032 867.496 417.901 867.019 416.723 867.019C415.544 867.019 414.414 867.496 413.58 868.344C412.747 869.193 412.279 870.344 412.279 871.544C412.279 872.744 412.747 873.895 413.58 874.744C414.414 875.593 415.544 876.069 416.723 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask563_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask563_13_16078)">
+<mask id="mask564_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="358" y="935" width="11" height="11">
+<path d="M358.796 945.924H368.71V935.829H358.796V945.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask564_13_16078)">
+<path d="M363.753 945.402C364.931 945.402 366.062 944.925 366.895 944.076C367.728 943.228 368.197 942.077 368.197 940.876C368.197 939.676 367.728 938.525 366.895 937.677C366.062 936.828 364.931 936.351 363.753 936.351C362.574 936.351 361.444 936.828 360.61 937.677C359.777 938.525 359.309 939.676 359.309 940.876C359.309 942.077 359.777 943.228 360.61 944.076C361.444 944.925 362.574 945.402 363.753 945.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask565_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask565_13_16078)">
+<mask id="mask566_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="355" y="919" width="11" height="11">
+<path d="M355.368 929.541H365.282V919.445H355.368V929.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask566_13_16078)">
+<path d="M360.325 929.018C361.503 929.018 362.634 928.541 363.467 927.693C364.3 926.844 364.769 925.693 364.769 924.493C364.769 923.293 364.3 922.142 363.467 921.293C362.634 920.444 361.503 919.968 360.325 919.968C359.146 919.968 358.016 920.444 357.182 921.293C356.349 922.142 355.881 923.293 355.881 924.493C355.881 925.693 356.349 926.844 357.182 927.693C358.016 928.541 359.146 929.018 360.325 929.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask567_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask567_13_16078)">
+<mask id="mask568_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="346" y="868" width="11" height="11">
+<path d="M346.867 878.189H356.781V868.094H346.867V878.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask568_13_16078)">
+<path d="M351.824 877.667C353.003 877.667 354.133 877.19 354.967 876.341C355.8 875.493 356.268 874.342 356.268 873.141C356.268 871.941 355.8 870.79 354.967 869.941C354.133 869.093 353.003 868.616 351.824 868.616C350.646 868.616 349.515 869.093 348.682 869.941C347.848 870.79 347.38 871.941 347.38 873.141C347.38 874.342 347.848 875.493 348.682 876.341C349.515 877.19 350.646 877.667 351.824 877.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask569_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask569_13_16078)">
+<mask id="mask570_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="365" y="886" width="11" height="11">
+<path d="M365.488 896.216H375.402V886.12H365.488V896.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask570_13_16078)">
+<path d="M370.445 895.693C371.623 895.693 372.754 895.216 373.587 894.368C374.421 893.519 374.889 892.368 374.889 891.168C374.889 889.968 374.421 888.817 373.587 887.968C372.754 887.119 371.623 886.643 370.445 886.643C369.266 886.643 368.136 887.119 367.303 887.968C366.469 888.817 366.001 889.968 366.001 891.168C366.001 892.368 366.469 893.519 367.303 894.368C368.136 895.216 369.266 895.693 370.445 895.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask571_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask571_13_16078)">
+<mask id="mask572_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="388" y="950" width="11" height="11">
+<path d="M388.79 960.543H398.704V950.448H388.79V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask572_13_16078)">
+<path d="M393.747 960.021C394.925 960.021 396.056 959.544 396.889 958.696C397.723 957.847 398.191 956.696 398.191 955.496C398.191 954.295 397.723 953.144 396.889 952.296C396.056 951.447 394.925 950.97 393.747 950.97C392.568 950.97 391.438 951.447 390.604 952.296C389.771 953.144 389.303 954.295 389.303 955.496C389.303 956.696 389.771 957.847 390.604 958.696C391.438 959.544 392.568 960.021 393.747 960.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask573_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask573_13_16078)">
+<mask id="mask574_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="336" y="946" width="11" height="11">
+<path d="M336.573 956.153H346.487V946.057H336.573V956.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask574_13_16078)">
+<path d="M341.53 955.63C342.708 955.63 343.839 955.153 344.672 954.305C345.506 953.456 345.974 952.305 345.974 951.105C345.974 949.905 345.506 948.754 344.672 947.905C343.839 947.056 342.708 946.58 341.53 946.58C340.351 946.58 339.221 947.056 338.388 947.905C337.554 948.754 337.086 949.905 337.086 951.105C337.086 952.305 337.554 953.456 338.388 954.305C339.221 955.153 340.351 955.63 341.53 955.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask575_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask575_13_16078)">
+<mask id="mask576_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="352" y="904" width="11" height="11">
+<path d="M352.127 914.971H362.041V904.876H352.127V914.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask576_13_16078)">
+<path d="M357.084 914.449C358.263 914.449 359.393 913.972 360.226 913.123C361.06 912.275 361.528 911.124 361.528 909.924C361.528 908.723 361.06 907.572 360.226 906.724C359.393 905.875 358.263 905.398 357.084 905.398C355.905 905.398 354.775 905.875 353.942 906.724C353.108 907.572 352.64 908.723 352.64 909.924C352.64 911.124 353.108 912.275 353.942 913.123C354.775 913.972 355.905 914.449 357.084 914.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask577_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask577_13_16078)">
+<mask id="mask578_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="409" y="931" width="11" height="11">
+<path d="M409.783 941.164H419.697V931.068H409.783V941.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask578_13_16078)">
+<path d="M414.74 940.641C415.918 940.641 417.049 940.164 417.882 939.316C418.715 938.467 419.184 937.316 419.184 936.116C419.184 934.916 418.715 933.765 417.882 932.916C417.049 932.067 415.918 931.591 414.74 931.591C413.561 931.591 412.431 932.067 411.597 932.916C410.764 933.765 410.296 934.916 410.296 936.116C410.296 937.316 410.764 938.467 411.597 939.316C412.431 940.164 413.561 940.641 414.74 940.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask579_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask579_13_16078)">
+<mask id="mask580_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="373" y="922" width="10" height="11">
+<path d="M373.043 932.696H382.958V922.601H373.043V932.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask580_13_16078)">
+<path d="M378.001 932.174C379.179 932.174 380.31 931.697 381.143 930.848C381.976 930 382.445 928.849 382.445 927.649C382.445 926.448 381.976 925.297 381.143 924.449C380.31 923.6 379.179 923.123 378.001 923.123C376.822 923.123 375.692 923.6 374.858 924.449C374.025 925.297 373.557 926.448 373.557 927.649C373.557 928.849 374.025 930 374.858 930.848C375.692 931.697 376.822 932.174 378.001 932.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask581_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask581_13_16078)">
+<mask id="mask582_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="927" width="11" height="11">
+<path d="M329.323 937.902H339.237V927.806H329.323V937.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask582_13_16078)">
+<path d="M334.28 937.38C335.458 937.38 336.589 936.903 337.422 936.054C338.256 935.206 338.724 934.054 338.724 932.854C338.724 931.654 338.256 930.503 337.422 929.654C336.589 928.806 335.458 928.329 334.28 928.329C333.101 928.329 331.971 928.806 331.137 929.654C330.304 930.503 329.836 931.654 329.836 932.854C329.836 934.054 330.304 935.206 331.137 936.054C331.971 936.903 333.101 937.38 334.28 937.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask583_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask583_13_16078)">
+<path d="M391.032 902.225C390.626 902.225 390.332 902.34 390.061 902.593C389.654 903.008 389.383 903.836 389.383 904.688C389.383 905.493 389.609 906.345 389.948 906.759C390.219 907.081 390.58 907.242 390.987 907.242C391.349 907.242 391.665 907.127 391.914 906.874C392.343 906.483 392.614 905.631 392.614 904.734C392.614 903.238 391.959 902.225 391.032 902.225ZM391.01 902.409C391.597 902.409 391.914 903.238 391.914 904.757C391.914 906.276 391.62 907.058 390.987 907.058C390.377 907.058 390.061 906.276 390.061 904.757C390.061 903.215 390.377 902.409 391.01 902.409Z" fill="white"/>
+</g>
+<mask id="mask584_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask584_13_16078)">
+<path d="M417.011 868.303L415.723 868.97V869.062C415.814 869.016 415.881 868.993 415.927 868.993C416.04 868.924 416.175 868.901 416.243 868.901C416.401 868.901 416.469 869.016 416.469 869.246V872.56C416.469 872.791 416.401 872.952 416.288 873.021C416.175 873.09 416.085 873.113 415.768 873.113V873.228H417.757V873.113C417.192 873.113 417.079 873.044 417.079 872.698V868.303H417.011Z" fill="white"/>
+</g>
+<mask id="mask585_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask585_13_16078)">
+<path d="M365.376 941.567L365.263 941.521C365.014 941.935 364.924 942.004 364.585 942.004H362.89L364.087 940.716C364.72 940.048 364.991 939.496 364.991 938.921C364.991 938.184 364.426 937.632 363.681 937.632C363.274 937.632 362.912 937.793 362.641 938.069C362.415 938.322 362.302 938.552 362.189 939.082L362.325 939.105C362.618 938.391 362.89 938.161 363.364 938.161C363.974 938.161 364.381 938.575 364.381 939.197C364.381 939.772 364.065 940.439 363.455 941.084L362.189 942.465V942.557H364.969L365.376 941.567Z" fill="white"/>
+</g>
+<mask id="mask586_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask586_13_16078)">
+<path d="M359.641 923.76C360.048 923.76 360.206 923.783 360.387 923.852C360.839 924.013 361.11 924.428 361.11 924.934C361.11 925.532 360.703 926.016 360.183 926.016C359.98 926.016 359.844 925.97 359.573 925.785C359.347 925.647 359.234 925.601 359.121 925.601C358.94 925.601 358.85 925.716 358.85 925.855C358.85 926.108 359.144 926.269 359.641 926.269C360.206 926.269 360.771 926.085 361.11 925.785C361.449 925.486 361.63 925.072 361.63 924.589C361.63 924.198 361.517 923.875 361.313 923.645C361.155 923.484 361.019 923.392 360.703 923.254C361.2 922.909 361.381 922.633 361.381 922.241C361.381 921.643 360.929 921.252 360.274 921.252C359.912 921.252 359.596 921.367 359.347 921.597C359.121 921.804 359.008 921.988 358.85 922.425L358.963 922.448C359.257 921.919 359.573 921.689 360.025 921.689C360.5 921.689 360.816 922.011 360.816 922.471C360.816 922.725 360.703 922.978 360.522 923.162C360.319 923.392 360.115 923.507 359.641 923.668V923.76Z" fill="white"/>
+</g>
+<mask id="mask587_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask587_13_16078)">
+<path d="M353.426 873.142H352.68V869.897H352.364L350.126 873.142V873.602H352.138V874.822H352.68V873.602H353.426V873.142ZM352.138 873.142H350.397L352.138 870.633V873.142Z" fill="white"/>
+</g>
+<mask id="mask588_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask588_13_16078)">
+<path d="M369.946 888.59H371.37C371.483 888.59 371.506 888.59 371.528 888.52L371.8 887.876L371.732 887.83C371.619 887.991 371.551 888.014 371.393 888.014H369.901L369.133 889.74C369.11 889.763 369.11 889.763 369.11 889.786C369.11 889.809 369.155 889.832 369.201 889.832C369.427 889.832 369.72 889.901 370.014 889.993C370.828 890.247 371.212 890.707 371.212 891.443C371.212 892.134 370.783 892.686 370.218 892.686C370.082 892.686 369.946 892.617 369.743 892.479C369.517 892.295 369.336 892.226 369.201 892.226C368.997 892.226 368.884 892.318 368.884 892.502C368.884 892.778 369.223 892.939 369.766 892.939C370.353 892.939 370.873 892.755 371.235 892.387C371.574 892.042 371.709 891.627 371.709 891.075C371.709 890.546 371.574 890.224 371.212 889.855C370.918 889.533 370.489 889.372 369.653 889.211L369.946 888.59Z" fill="white"/>
+</g>
+<mask id="mask589_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask589_13_16078)">
+<path d="M395.146 952.182C394.332 952.251 393.925 952.389 393.405 952.781C392.614 953.333 392.208 954.161 392.208 955.151C392.208 955.772 392.388 956.417 392.705 956.785C392.976 957.107 393.36 957.268 393.812 957.268C394.694 957.268 395.304 956.578 395.304 955.588C395.304 954.645 394.784 954.046 393.97 954.046C393.654 954.046 393.496 954.115 393.044 954.392C393.247 953.287 394.038 952.481 395.168 952.297L395.146 952.182ZM393.699 954.392C394.309 954.392 394.671 954.921 394.671 955.818C394.671 956.624 394.377 957.084 393.88 957.084C393.247 957.084 392.863 956.394 392.863 955.266C392.863 954.875 392.931 954.691 393.066 954.576C393.225 954.461 393.451 954.392 393.699 954.392Z" fill="white"/>
+</g>
+<mask id="mask590_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask590_13_16078)">
+<path d="M342.951 947.953H340.306L339.877 949.035L340.012 949.081C340.306 948.598 340.442 948.506 340.849 948.506H342.386L340.984 952.855H341.436L342.951 948.068V947.953Z" fill="white"/>
+</g>
+<mask id="mask591_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask591_13_16078)">
+<path d="M357.375 908.888C358.076 908.519 358.324 908.197 358.324 907.714C358.324 907.116 357.827 906.678 357.104 906.678C356.313 906.678 355.748 907.162 355.748 907.829C355.748 908.289 355.883 908.519 356.629 909.187C355.861 909.785 355.703 910.015 355.703 910.499C355.703 911.212 356.268 911.695 357.081 911.695C357.94 911.695 358.482 911.235 358.482 910.476C358.482 909.9 358.234 909.555 357.375 908.888ZM357.239 909.647C357.759 910.038 357.94 910.291 357.94 910.706C357.94 911.166 357.624 911.511 357.149 911.511C356.607 911.511 356.245 911.074 356.245 910.453C356.245 909.969 356.403 909.67 356.81 909.325L357.239 909.647ZM357.172 908.773C356.539 908.335 356.268 908.013 356.268 907.599C356.268 907.185 356.584 906.885 357.036 906.885C357.533 906.885 357.85 907.208 357.85 907.691C357.85 908.105 357.646 908.45 357.239 908.727C357.194 908.75 357.194 908.75 357.172 908.773Z" fill="white"/>
+</g>
+<mask id="mask592_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask592_13_16078)">
+<path d="M413.378 937.96C414.169 937.868 414.576 937.73 415.051 937.361C415.797 936.809 416.249 935.911 416.249 934.922C416.249 933.725 415.571 932.874 414.644 932.874C413.808 932.874 413.175 933.61 413.175 934.6C413.175 935.474 413.672 936.073 414.463 936.073C414.847 936.073 415.141 935.957 415.525 935.658C415.232 936.832 414.441 937.614 413.356 937.822L413.378 937.96ZM415.548 935.198C415.548 935.359 415.503 935.428 415.435 935.497C415.232 935.658 414.96 935.75 414.712 935.75C414.169 935.75 413.83 935.198 413.83 934.347C413.83 933.932 413.943 933.495 414.079 933.288C414.215 933.15 414.395 933.081 414.599 933.081C415.209 933.081 415.548 933.702 415.548 934.922V935.198Z" fill="white"/>
+</g>
+<mask id="mask593_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask593_13_16078)">
+<path d="M376.501 924.405L375.212 925.072V925.164C375.303 925.118 375.371 925.095 375.416 925.095C375.529 925.026 375.664 925.003 375.732 925.003C375.89 925.003 375.958 925.118 375.958 925.348V928.662C375.958 928.892 375.89 929.053 375.777 929.122C375.664 929.191 375.574 929.214 375.258 929.214V929.33H377.246V929.214C376.681 929.214 376.568 929.145 376.568 928.8V924.405H376.501ZM379.828 924.405C379.422 924.405 379.128 924.52 378.857 924.773C378.45 925.187 378.179 926.016 378.179 926.867C378.179 927.673 378.405 928.524 378.744 928.938C379.015 929.261 379.376 929.422 379.783 929.422C380.145 929.422 380.461 929.307 380.71 929.053C381.139 928.662 381.41 927.811 381.41 926.913C381.41 925.417 380.755 924.405 379.828 924.405ZM379.806 924.589C380.393 924.589 380.71 925.417 380.71 926.936C380.71 928.455 380.416 929.237 379.783 929.237C379.173 929.237 378.857 928.455 378.857 926.936C378.857 925.394 379.173 924.589 379.806 924.589Z" fill="white"/>
+</g>
+<mask id="mask594_13_16078" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask594_13_16078)">
+<path d="M332.78 929.612L331.492 930.279V930.371C331.583 930.325 331.65 930.302 331.696 930.302C331.809 930.233 331.944 930.21 332.012 930.21C332.17 930.21 332.238 930.325 332.238 930.555V933.869C332.238 934.099 332.17 934.26 332.057 934.329C331.944 934.398 331.854 934.421 331.537 934.421V934.536H333.526V934.421C332.961 934.421 332.848 934.352 332.848 934.007V929.612H332.78ZM336.357 929.612L335.069 930.279V930.371C335.159 930.325 335.227 930.302 335.272 930.302C335.385 930.233 335.521 930.21 335.589 930.21C335.747 930.21 335.815 930.325 335.815 930.555V933.869C335.815 934.099 335.747 934.26 335.634 934.329C335.521 934.398 335.43 934.421 335.114 934.421V934.536H337.103V934.421C336.538 934.421 336.425 934.352 336.425 934.007V929.612H336.357Z" fill="white"/>
+</g>
+</g>
+<path d="M216.565 235H207.284V208.818H216.642C219.275 208.818 221.542 209.342 223.443 210.391C225.343 211.43 226.805 212.926 227.828 214.878C228.859 216.83 229.375 219.165 229.375 221.884C229.375 224.611 228.859 226.955 227.828 228.915C226.805 230.875 225.335 232.379 223.417 233.428C221.508 234.476 219.224 235 216.565 235ZM212.819 230.257H216.335C217.971 230.257 219.348 229.967 220.464 229.388C221.589 228.8 222.433 227.892 222.995 226.665C223.567 225.429 223.852 223.835 223.852 221.884C223.852 219.949 223.567 218.368 222.995 217.141C222.433 215.913 221.593 215.01 220.477 214.43C219.361 213.851 217.984 213.561 216.348 213.561H212.819V230.257ZM232.653 235V215.364H238.099V235H232.653ZM235.389 212.832C234.579 212.832 233.885 212.564 233.305 212.027C232.734 211.482 232.448 210.83 232.448 210.071C232.448 209.321 232.734 208.678 233.305 208.141C233.885 207.595 234.579 207.322 235.389 207.322C236.198 207.322 236.889 207.595 237.46 208.141C238.039 208.678 238.329 209.321 238.329 210.071C238.329 210.83 238.039 211.482 237.46 212.027C236.889 212.564 236.198 212.832 235.389 212.832ZM250.614 235.384C248.602 235.384 246.872 234.957 245.423 234.105C243.983 233.244 242.875 232.051 242.1 230.526C241.332 229 240.949 227.244 240.949 225.259C240.949 223.247 241.337 221.483 242.112 219.966C242.896 218.44 244.009 217.251 245.449 216.399C246.889 215.538 248.602 215.108 250.588 215.108C252.301 215.108 253.801 215.419 255.088 216.041C256.375 216.663 257.394 217.537 258.144 218.662C258.894 219.787 259.307 221.108 259.384 222.625H254.244C254.1 221.645 253.716 220.857 253.094 220.26C252.48 219.655 251.675 219.352 250.678 219.352C249.834 219.352 249.097 219.582 248.466 220.043C247.844 220.494 247.358 221.155 247.009 222.024C246.659 222.893 246.484 223.946 246.484 225.182C246.484 226.435 246.655 227.5 246.996 228.378C247.345 229.256 247.835 229.925 248.466 230.385C249.097 230.845 249.834 231.075 250.678 231.075C251.3 231.075 251.858 230.947 252.352 230.692C252.855 230.436 253.269 230.065 253.592 229.58C253.925 229.085 254.142 228.493 254.244 227.803H259.384C259.298 229.303 258.889 230.624 258.156 231.766C257.432 232.899 256.43 233.786 255.152 234.425C253.874 235.064 252.361 235.384 250.614 235.384ZM272.595 215.364V219.455H260.77V215.364H272.595ZM263.454 210.659H268.9V228.966C268.9 229.469 268.977 229.861 269.131 230.142C269.284 230.415 269.497 230.607 269.77 230.717C270.051 230.828 270.375 230.884 270.741 230.884C270.997 230.884 271.253 230.862 271.508 230.82C271.764 230.768 271.96 230.73 272.096 230.705L272.953 234.757C272.68 234.842 272.297 234.94 271.802 235.051C271.308 235.17 270.707 235.243 270 235.268C268.687 235.32 267.537 235.145 266.548 234.744C265.568 234.344 264.805 233.722 264.26 232.878C263.714 232.034 263.446 230.969 263.454 229.682V210.659ZM275.423 235V215.364H280.869V235H275.423ZM278.158 212.832C277.349 212.832 276.654 212.564 276.075 212.027C275.504 211.482 275.218 210.83 275.218 210.071C275.218 209.321 275.504 208.678 276.075 208.141C276.654 207.595 277.349 207.322 278.158 207.322C278.968 207.322 279.658 207.595 280.229 208.141C280.809 208.678 281.099 209.321 281.099 210.071C281.099 210.83 280.809 211.482 280.229 212.027C279.658 212.564 278.968 212.832 278.158 212.832ZM293.383 235.384C291.398 235.384 289.68 234.962 288.231 234.118C286.791 233.266 285.679 232.081 284.895 230.564C284.111 229.038 283.719 227.27 283.719 225.259C283.719 223.23 284.111 221.457 284.895 219.94C285.679 218.415 286.791 217.23 288.231 216.386C289.68 215.534 291.398 215.108 293.383 215.108C295.369 215.108 297.082 215.534 298.523 216.386C299.971 217.23 301.088 218.415 301.872 219.94C302.656 221.457 303.048 223.23 303.048 225.259C303.048 227.27 302.656 229.038 301.872 230.564C301.088 232.081 299.971 233.266 298.523 234.118C297.082 234.962 295.369 235.384 293.383 235.384ZM293.409 231.165C294.312 231.165 295.067 230.909 295.672 230.398C296.277 229.878 296.733 229.17 297.04 228.276C297.355 227.381 297.513 226.362 297.513 225.22C297.513 224.078 297.355 223.06 297.04 222.165C296.733 221.27 296.277 220.562 295.672 220.043C295.067 219.523 294.312 219.263 293.409 219.263C292.497 219.263 291.73 219.523 291.108 220.043C290.494 220.562 290.03 221.27 289.714 222.165C289.408 223.06 289.254 224.078 289.254 225.22C289.254 226.362 289.408 227.381 289.714 228.276C290.03 229.17 290.494 229.878 291.108 230.398C291.73 230.909 292.497 231.165 293.409 231.165ZM311.315 223.648V235H305.869V215.364H311.06V218.828H311.29C311.724 217.686 312.453 216.783 313.476 216.118C314.499 215.445 315.739 215.108 317.196 215.108C318.56 215.108 319.749 215.406 320.763 216.003C321.777 216.599 322.565 217.452 323.128 218.56C323.69 219.659 323.972 220.972 323.972 222.497V235H318.526V223.469C318.534 222.267 318.227 221.33 317.605 220.656C316.983 219.974 316.126 219.634 315.036 219.634C314.303 219.634 313.655 219.791 313.092 220.107C312.538 220.422 312.104 220.882 311.788 221.487C311.482 222.084 311.324 222.804 311.315 223.648ZM333.143 235.371C331.89 235.371 330.774 235.153 329.794 234.719C328.814 234.276 328.038 233.624 327.467 232.763C326.905 231.893 326.623 230.811 326.623 229.516C326.623 228.425 326.824 227.509 327.224 226.767C327.625 226.026 328.17 225.429 328.861 224.977C329.551 224.526 330.335 224.185 331.213 223.955C332.099 223.724 333.028 223.562 334 223.469C335.142 223.349 336.062 223.239 336.761 223.136C337.46 223.026 337.967 222.864 338.283 222.651C338.598 222.437 338.756 222.122 338.756 221.705V221.628C338.756 220.818 338.5 220.192 337.989 219.749C337.486 219.305 336.77 219.084 335.841 219.084C334.861 219.084 334.081 219.301 333.501 219.736C332.922 220.162 332.538 220.699 332.351 221.347L327.314 220.938C327.569 219.744 328.072 218.713 328.822 217.844C329.572 216.966 330.54 216.293 331.724 215.824C332.917 215.347 334.298 215.108 335.866 215.108C336.957 215.108 338.001 215.236 338.998 215.491C340.004 215.747 340.895 216.143 341.67 216.68C342.454 217.217 343.072 217.908 343.524 218.751C343.976 219.587 344.202 220.588 344.202 221.756V235H339.037V232.277H338.883C338.568 232.891 338.146 233.432 337.618 233.901C337.089 234.361 336.454 234.723 335.713 234.987C334.971 235.243 334.115 235.371 333.143 235.371ZM334.703 231.612C335.504 231.612 336.212 231.455 336.825 231.139C337.439 230.815 337.92 230.381 338.27 229.835C338.619 229.29 338.794 228.672 338.794 227.982V225.898C338.623 226.009 338.389 226.111 338.091 226.205C337.801 226.29 337.473 226.371 337.106 226.447C336.74 226.516 336.373 226.58 336.007 226.639C335.64 226.69 335.308 226.737 335.01 226.78C334.371 226.874 333.812 227.023 333.335 227.227C332.858 227.432 332.487 227.709 332.223 228.058C331.959 228.399 331.827 228.825 331.827 229.337C331.827 230.078 332.095 230.645 332.632 231.037C333.177 231.42 333.868 231.612 334.703 231.612ZM347.707 235V215.364H352.987V218.79H353.191C353.549 217.571 354.15 216.651 354.994 216.028C355.837 215.398 356.809 215.082 357.908 215.082C358.181 215.082 358.475 215.099 358.791 215.134C359.106 215.168 359.383 215.214 359.622 215.274V220.107C359.366 220.03 359.012 219.962 358.56 219.902C358.109 219.842 357.695 219.812 357.32 219.812C356.519 219.812 355.803 219.987 355.173 220.337C354.55 220.678 354.056 221.155 353.69 221.768C353.332 222.382 353.153 223.089 353.153 223.891V235H347.707ZM365.677 242.364C364.987 242.364 364.339 242.308 363.734 242.197C363.137 242.095 362.643 241.963 362.251 241.801L363.478 237.736C364.117 237.932 364.693 238.038 365.204 238.055C365.724 238.072 366.171 237.953 366.546 237.697C366.93 237.442 367.241 237.007 367.48 236.393L367.799 235.562L360.755 215.364H366.482L370.548 229.784H370.752L374.856 215.364H380.622L372.99 237.122C372.623 238.179 372.125 239.099 371.494 239.884C370.872 240.676 370.083 241.286 369.129 241.712C368.174 242.146 367.024 242.364 365.677 242.364ZM390.301 235V215.364H395.491V218.828H395.721C396.13 217.678 396.812 216.77 397.767 216.105C398.721 215.44 399.863 215.108 401.193 215.108C402.539 215.108 403.686 215.445 404.632 216.118C405.578 216.783 406.208 217.686 406.524 218.828H406.728C407.129 217.703 407.853 216.804 408.901 216.131C409.958 215.449 411.207 215.108 412.647 215.108C414.48 215.108 415.967 215.692 417.109 216.859C418.259 218.018 418.835 219.663 418.835 221.794V235H413.401V222.868C413.401 221.777 413.112 220.959 412.532 220.413C411.953 219.868 411.228 219.595 410.359 219.595C409.37 219.595 408.599 219.911 408.045 220.541C407.491 221.163 407.214 221.986 407.214 223.009V235H401.934V222.753C401.934 221.79 401.657 221.023 401.103 220.452C400.558 219.881 399.838 219.595 398.943 219.595C398.338 219.595 397.792 219.749 397.306 220.055C396.829 220.354 396.45 220.776 396.169 221.321C395.887 221.858 395.747 222.489 395.747 223.213V235H390.301ZM428.016 235.371C426.763 235.371 425.647 235.153 424.667 234.719C423.686 234.276 422.911 233.624 422.34 232.763C421.777 231.893 421.496 230.811 421.496 229.516C421.496 228.425 421.696 227.509 422.097 226.767C422.498 226.026 423.043 225.429 423.733 224.977C424.424 224.526 425.208 224.185 426.086 223.955C426.972 223.724 427.901 223.562 428.873 223.469C430.015 223.349 430.935 223.239 431.634 223.136C432.333 223.026 432.84 222.864 433.155 222.651C433.471 222.437 433.628 222.122 433.628 221.705V221.628C433.628 220.818 433.373 220.192 432.861 219.749C432.358 219.305 431.642 219.084 430.713 219.084C429.733 219.084 428.953 219.301 428.374 219.736C427.794 220.162 427.411 220.699 427.223 221.347L422.186 220.938C422.442 219.744 422.945 218.713 423.695 217.844C424.445 216.966 425.412 216.293 426.597 215.824C427.79 215.347 429.171 215.108 430.739 215.108C431.83 215.108 432.874 215.236 433.871 215.491C434.877 215.747 435.767 216.143 436.543 216.68C437.327 217.217 437.945 217.908 438.397 218.751C438.848 219.587 439.074 220.588 439.074 221.756V235H433.909V232.277H433.756C433.441 232.891 433.019 233.432 432.49 233.901C431.962 234.361 431.327 234.723 430.586 234.987C429.844 235.243 428.988 235.371 428.016 235.371ZM429.576 231.612C430.377 231.612 431.084 231.455 431.698 231.139C432.311 230.815 432.793 230.381 433.142 229.835C433.492 229.29 433.667 228.672 433.667 227.982V225.898C433.496 226.009 433.262 226.111 432.963 226.205C432.674 226.29 432.346 226.371 431.979 226.447C431.613 226.516 431.246 226.58 430.88 226.639C430.513 226.69 430.181 226.737 429.882 226.78C429.243 226.874 428.685 227.023 428.208 227.227C427.73 227.432 427.36 227.709 427.096 228.058C426.831 228.399 426.699 228.825 426.699 229.337C426.699 230.078 426.968 230.645 427.505 231.037C428.05 231.42 428.74 231.612 429.576 231.612ZM442.579 242.364V215.364H447.949V218.662H448.192C448.43 218.134 448.775 217.597 449.227 217.051C449.687 216.497 450.284 216.037 451.017 215.67C451.758 215.295 452.679 215.108 453.778 215.108C455.21 215.108 456.531 215.483 457.741 216.233C458.952 216.974 459.919 218.095 460.643 219.595C461.368 221.087 461.73 222.957 461.73 225.207C461.73 227.398 461.376 229.247 460.669 230.756C459.97 232.256 459.015 233.393 457.805 234.169C456.604 234.936 455.257 235.32 453.765 235.32C452.709 235.32 451.809 235.145 451.068 234.795C450.335 234.446 449.734 234.007 449.265 233.479C448.797 232.942 448.439 232.401 448.192 231.855H448.025V242.364H442.579ZM447.91 225.182C447.91 226.349 448.072 227.368 448.396 228.237C448.72 229.107 449.189 229.784 449.802 230.27C450.416 230.747 451.162 230.986 452.04 230.986C452.926 230.986 453.676 230.743 454.29 230.257C454.903 229.763 455.368 229.081 455.683 228.212C456.007 227.334 456.169 226.324 456.169 225.182C456.169 224.048 456.011 223.051 455.696 222.19C455.381 221.33 454.916 220.656 454.302 220.17C453.689 219.685 452.934 219.442 452.04 219.442C451.153 219.442 450.403 219.676 449.79 220.145C449.184 220.614 448.72 221.278 448.396 222.139C448.072 223 447.91 224.014 447.91 225.182ZM464.641 242.364V215.364H470.01V218.662H470.253C470.491 218.134 470.837 217.597 471.288 217.051C471.749 216.497 472.345 216.037 473.078 215.67C473.82 215.295 474.74 215.108 475.84 215.108C477.271 215.108 478.592 215.483 479.803 216.233C481.013 216.974 481.98 218.095 482.705 219.595C483.429 221.087 483.791 222.957 483.791 225.207C483.791 227.398 483.438 229.247 482.73 230.756C482.031 232.256 481.077 233.393 479.866 234.169C478.665 234.936 477.318 235.32 475.827 235.32C474.77 235.32 473.871 235.145 473.129 234.795C472.396 234.446 471.795 234.007 471.327 233.479C470.858 232.942 470.5 232.401 470.253 231.855H470.087V242.364H464.641ZM469.972 225.182C469.972 226.349 470.134 227.368 470.457 228.237C470.781 229.107 471.25 229.784 471.864 230.27C472.477 230.747 473.223 230.986 474.101 230.986C474.987 230.986 475.737 230.743 476.351 230.257C476.965 229.763 477.429 229.081 477.744 228.212C478.068 227.334 478.23 226.324 478.23 225.182C478.23 224.048 478.072 223.051 477.757 222.19C477.442 221.33 476.977 220.656 476.364 220.17C475.75 219.685 474.996 219.442 474.101 219.442C473.215 219.442 472.465 219.676 471.851 220.145C471.246 220.614 470.781 221.278 470.457 222.139C470.134 223 469.972 224.014 469.972 225.182ZM486.702 235V215.364H492.148V235H486.702ZM489.438 212.832C488.628 212.832 487.933 212.564 487.354 212.027C486.783 211.482 486.497 210.83 486.497 210.071C486.497 209.321 486.783 208.678 487.354 208.141C487.933 207.595 488.628 207.322 489.438 207.322C490.247 207.322 490.938 207.595 491.509 208.141C492.088 208.678 492.378 209.321 492.378 210.071C492.378 210.83 492.088 211.482 491.509 212.027C490.938 212.564 490.247 212.832 489.438 212.832ZM501.237 223.648V235H495.79V215.364H500.981V218.828H501.211C501.646 217.686 502.374 216.783 503.397 216.118C504.42 215.445 505.66 215.108 507.117 215.108C508.481 215.108 509.67 215.406 510.684 216.003C511.698 216.599 512.487 217.452 513.049 218.56C513.612 219.659 513.893 220.972 513.893 222.497V235H508.447V223.469C508.455 222.267 508.148 221.33 507.526 220.656C506.904 219.974 506.048 219.634 504.957 219.634C504.224 219.634 503.576 219.791 503.013 220.107C502.46 220.422 502.025 220.882 501.71 221.487C501.403 222.084 501.245 222.804 501.237 223.648ZM526.312 242.773C524.547 242.773 523.035 242.53 521.773 242.044C520.52 241.567 519.523 240.915 518.782 240.088C518.04 239.261 517.559 238.332 517.337 237.301L522.374 236.624C522.528 237.016 522.77 237.382 523.103 237.723C523.435 238.064 523.874 238.337 524.42 238.541C524.974 238.754 525.647 238.861 526.439 238.861C527.624 238.861 528.6 238.571 529.367 237.991C530.143 237.42 530.53 236.462 530.53 235.115V231.523H530.3C530.062 232.068 529.704 232.584 529.226 233.07C528.749 233.555 528.135 233.952 527.385 234.259C526.635 234.565 525.741 234.719 524.701 234.719C523.226 234.719 521.884 234.378 520.674 233.696C519.472 233.006 518.513 231.953 517.797 230.538C517.09 229.115 516.736 227.317 516.736 225.143C516.736 222.919 517.099 221.061 517.823 219.57C518.547 218.078 519.51 216.962 520.712 216.22C521.922 215.479 523.248 215.108 524.688 215.108C525.787 215.108 526.708 215.295 527.449 215.67C528.191 216.037 528.787 216.497 529.239 217.051C529.699 217.597 530.053 218.134 530.3 218.662H530.505V215.364H535.912V235.192C535.912 236.862 535.503 238.26 534.685 239.385C533.867 240.51 532.733 241.354 531.285 241.916C529.844 242.487 528.187 242.773 526.312 242.773ZM526.427 230.628C527.305 230.628 528.046 230.411 528.651 229.976C529.265 229.533 529.733 228.902 530.057 228.084C530.39 227.257 530.556 226.268 530.556 225.118C530.556 223.967 530.394 222.97 530.07 222.126C529.746 221.274 529.278 220.614 528.664 220.145C528.05 219.676 527.305 219.442 526.427 219.442C525.532 219.442 524.778 219.685 524.164 220.17C523.55 220.648 523.086 221.312 522.77 222.165C522.455 223.017 522.297 224.001 522.297 225.118C522.297 226.251 522.455 227.232 522.77 228.058C523.094 228.876 523.559 229.511 524.164 229.963C524.778 230.406 525.532 230.628 526.427 230.628ZM547.138 242.364V215.364H552.508V218.662H552.751C552.989 218.134 553.334 217.597 553.786 217.051C554.246 216.497 554.843 216.037 555.576 215.67C556.317 215.295 557.238 215.108 558.337 215.108C559.769 215.108 561.09 215.483 562.3 216.233C563.51 216.974 564.478 218.095 565.202 219.595C565.927 221.087 566.289 222.957 566.289 225.207C566.289 227.398 565.935 229.247 565.228 230.756C564.529 232.256 563.574 233.393 562.364 234.169C561.162 234.936 559.816 235.32 558.324 235.32C557.268 235.32 556.368 235.145 555.627 234.795C554.894 234.446 554.293 234.007 553.824 233.479C553.356 232.942 552.998 232.401 552.751 231.855H552.584V242.364H547.138ZM552.469 225.182C552.469 226.349 552.631 227.368 552.955 228.237C553.279 229.107 553.748 229.784 554.361 230.27C554.975 230.747 555.721 230.986 556.599 230.986C557.485 230.986 558.235 230.743 558.849 230.257C559.462 229.763 559.927 229.081 560.242 228.212C560.566 227.334 560.728 226.324 560.728 225.182C560.728 224.048 560.57 223.051 560.255 222.19C559.939 221.33 559.475 220.656 558.861 220.17C558.248 219.685 557.493 219.442 556.599 219.442C555.712 219.442 554.962 219.676 554.349 220.145C553.743 220.614 553.279 221.278 552.955 222.139C552.631 223 552.469 224.014 552.469 225.182ZM578.148 235.384C576.129 235.384 574.39 234.974 572.932 234.156C571.484 233.33 570.367 232.162 569.583 230.653C568.799 229.136 568.407 227.342 568.407 225.271C568.407 223.251 568.799 221.479 569.583 219.953C570.367 218.428 571.471 217.239 572.894 216.386C574.326 215.534 576.005 215.108 577.931 215.108C579.227 215.108 580.432 215.317 581.549 215.734C582.674 216.143 583.654 216.761 584.489 217.588C585.333 218.415 585.989 219.455 586.458 220.707C586.927 221.952 587.161 223.409 587.161 225.08V226.575H570.58V223.2H582.035C582.035 222.416 581.864 221.722 581.523 221.116C581.182 220.511 580.709 220.038 580.104 219.697C579.508 219.348 578.813 219.173 578.021 219.173C577.194 219.173 576.461 219.365 575.822 219.749C575.191 220.124 574.697 220.631 574.339 221.27C573.981 221.901 573.798 222.604 573.789 223.379V226.588C573.789 227.56 573.968 228.399 574.326 229.107C574.692 229.814 575.208 230.359 575.873 230.743C576.538 231.126 577.326 231.318 578.238 231.318C578.843 231.318 579.397 231.233 579.9 231.062C580.403 230.892 580.833 230.636 581.191 230.295C581.549 229.955 581.822 229.537 582.009 229.043L587.046 229.375C586.79 230.585 586.266 231.642 585.474 232.545C584.69 233.44 583.675 234.139 582.431 234.642C581.195 235.136 579.768 235.384 578.148 235.384ZM589.995 235V215.364H595.275V218.79H595.48C595.837 217.571 596.438 216.651 597.282 216.028C598.126 215.398 599.097 215.082 600.197 215.082C600.47 215.082 600.764 215.099 601.079 215.134C601.394 215.168 601.671 215.214 601.91 215.274V220.107C601.654 220.03 601.301 219.962 600.849 219.902C600.397 219.842 599.984 219.812 599.609 219.812C598.808 219.812 598.092 219.987 597.461 220.337C596.839 220.678 596.345 221.155 595.978 221.768C595.62 222.382 595.441 223.089 595.441 223.891V235H589.995ZM615.435 215.364V219.455H603.609V215.364H615.435ZM606.294 210.659H611.74V228.966C611.74 229.469 611.817 229.861 611.97 230.142C612.124 230.415 612.337 230.607 612.609 230.717C612.891 230.828 613.214 230.884 613.581 230.884C613.837 230.884 614.092 230.862 614.348 230.82C614.604 230.768 614.8 230.73 614.936 230.705L615.793 234.757C615.52 234.842 615.136 234.94 614.642 235.051C614.148 235.17 613.547 235.243 612.839 235.268C611.527 235.32 610.376 235.145 609.388 234.744C608.408 234.344 607.645 233.722 607.099 232.878C606.554 232.034 606.285 230.969 606.294 229.682V210.659ZM630.855 226.639V215.364H636.301V235H631.072V231.433H630.867C630.424 232.584 629.687 233.509 628.656 234.207C627.633 234.906 626.384 235.256 624.91 235.256C623.597 235.256 622.443 234.957 621.445 234.361C620.448 233.764 619.668 232.916 619.106 231.817C618.552 230.717 618.271 229.401 618.262 227.866V215.364H623.708V226.895C623.717 228.054 624.028 228.97 624.641 229.643C625.255 230.317 626.078 230.653 627.109 230.653C627.765 230.653 628.379 230.504 628.95 230.206C629.521 229.899 629.981 229.447 630.33 228.851C630.688 228.254 630.863 227.517 630.855 226.639ZM639.937 235V215.364H645.217V218.79H645.421C645.779 217.571 646.38 216.651 647.224 216.028C648.067 215.398 649.039 215.082 650.138 215.082C650.411 215.082 650.705 215.099 651.021 215.134C651.336 215.168 651.613 215.214 651.851 215.274V220.107C651.596 220.03 651.242 219.962 650.79 219.902C650.339 219.842 649.925 219.812 649.55 219.812C648.749 219.812 648.033 219.987 647.403 220.337C646.78 220.678 646.286 221.155 645.92 221.768C645.562 222.382 645.383 223.089 645.383 223.891V235H639.937ZM654.049 235V208.818H659.495V218.662H659.662C659.9 218.134 660.245 217.597 660.697 217.051C661.157 216.497 661.754 216.037 662.487 215.67C663.228 215.295 664.149 215.108 665.248 215.108C666.68 215.108 668.001 215.483 669.211 216.233C670.422 216.974 671.389 218.095 672.113 219.595C672.838 221.087 673.2 222.957 673.2 225.207C673.2 227.398 672.846 229.247 672.139 230.756C671.44 232.256 670.486 233.393 669.275 234.169C668.074 234.936 666.727 235.32 665.236 235.32C664.179 235.32 663.28 235.145 662.538 234.795C661.805 234.446 661.204 234.007 660.736 233.479C660.267 232.942 659.909 232.401 659.662 231.855H659.419V235H654.049ZM659.38 225.182C659.38 226.349 659.542 227.368 659.866 228.237C660.19 229.107 660.659 229.784 661.272 230.27C661.886 230.747 662.632 230.986 663.51 230.986C664.396 230.986 665.146 230.743 665.76 230.257C666.373 229.763 666.838 229.081 667.153 228.212C667.477 227.334 667.639 226.324 667.639 225.182C667.639 224.048 667.481 223.051 667.166 222.19C666.851 221.33 666.386 220.656 665.772 220.17C665.159 219.685 664.405 219.442 663.51 219.442C662.623 219.442 661.873 219.676 661.26 220.145C660.655 220.614 660.19 221.278 659.866 222.139C659.542 223 659.38 224.014 659.38 225.182ZM681.713 235.371C680.46 235.371 679.344 235.153 678.364 234.719C677.384 234.276 676.608 233.624 676.037 232.763C675.475 231.893 675.193 230.811 675.193 229.516C675.193 228.425 675.394 227.509 675.794 226.767C676.195 226.026 676.74 225.429 677.431 224.977C678.121 224.526 678.905 224.185 679.783 223.955C680.669 223.724 681.598 223.562 682.57 223.469C683.712 223.349 684.632 223.239 685.331 223.136C686.03 223.026 686.537 222.864 686.853 222.651C687.168 222.437 687.326 222.122 687.326 221.705V221.628C687.326 220.818 687.07 220.192 686.559 219.749C686.056 219.305 685.34 219.084 684.411 219.084C683.431 219.084 682.651 219.301 682.071 219.736C681.492 220.162 681.108 220.699 680.921 221.347L675.884 220.938C676.139 219.744 676.642 218.713 677.392 217.844C678.142 216.966 679.11 216.293 680.294 215.824C681.487 215.347 682.868 215.108 684.436 215.108C685.527 215.108 686.571 215.236 687.568 215.491C688.574 215.747 689.465 216.143 690.24 216.68C691.024 217.217 691.642 217.908 692.094 218.751C692.546 219.587 692.772 220.588 692.772 221.756V235H687.607V232.277H687.453C687.138 232.891 686.716 233.432 686.188 233.901C685.659 234.361 685.024 234.723 684.283 234.987C683.541 235.243 682.685 235.371 681.713 235.371ZM683.273 231.612C684.074 231.612 684.782 231.455 685.395 231.139C686.009 230.815 686.49 230.381 686.84 229.835C687.189 229.29 687.364 228.672 687.364 227.982V225.898C687.193 226.009 686.959 226.111 686.661 226.205C686.371 226.29 686.043 226.371 685.676 226.447C685.31 226.516 684.943 226.58 684.577 226.639C684.21 226.69 683.878 226.737 683.58 226.78C682.941 226.874 682.382 227.023 681.905 227.227C681.428 227.432 681.057 227.709 680.793 228.058C680.529 228.399 680.397 228.825 680.397 229.337C680.397 230.078 680.665 230.645 681.202 231.037C681.747 231.42 682.438 231.612 683.273 231.612ZM706.721 215.364V219.455H694.896V215.364H706.721ZM697.581 210.659H703.027V228.966C703.027 229.469 703.103 229.861 703.257 230.142C703.41 230.415 703.623 230.607 703.896 230.717C704.177 230.828 704.501 230.884 704.868 230.884C705.123 230.884 705.379 230.862 705.635 230.82C705.89 230.768 706.086 230.73 706.223 230.705L707.079 234.757C706.807 234.842 706.423 234.94 705.929 235.051C705.434 235.17 704.834 235.243 704.126 235.268C702.814 235.32 701.663 235.145 700.674 234.744C699.694 234.344 698.932 233.722 698.386 232.878C697.841 232.034 697.572 230.969 697.581 229.682V210.659ZM709.549 235V215.364H714.995V235H709.549ZM712.285 212.832C711.475 212.832 710.78 212.564 710.201 212.027C709.63 211.482 709.344 210.83 709.344 210.071C709.344 209.321 709.63 208.678 710.201 208.141C710.78 207.595 711.475 207.322 712.285 207.322C713.094 207.322 713.785 207.595 714.356 208.141C714.935 208.678 715.225 209.321 715.225 210.071C715.225 210.83 714.935 211.482 714.356 212.027C713.785 212.564 713.094 212.832 712.285 212.832ZM727.51 235.384C725.524 235.384 723.807 234.962 722.358 234.118C720.917 233.266 719.805 232.081 719.021 230.564C718.237 229.038 717.845 227.27 717.845 225.259C717.845 223.23 718.237 221.457 719.021 219.94C719.805 218.415 720.917 217.23 722.358 216.386C723.807 215.534 725.524 215.108 727.51 215.108C729.495 215.108 731.209 215.534 732.649 216.386C734.098 217.23 735.214 218.415 735.998 219.94C736.782 221.457 737.174 223.23 737.174 225.259C737.174 227.27 736.782 229.038 735.998 230.564C735.214 232.081 734.098 233.266 732.649 234.118C731.209 234.962 729.495 235.384 727.51 235.384ZM727.535 231.165C728.439 231.165 729.193 230.909 729.798 230.398C730.403 229.878 730.859 229.17 731.166 228.276C731.481 227.381 731.639 226.362 731.639 225.22C731.639 224.078 731.481 223.06 731.166 222.165C730.859 221.27 730.403 220.562 729.798 220.043C729.193 219.523 728.439 219.263 727.535 219.263C726.623 219.263 725.856 219.523 725.234 220.043C724.62 220.562 724.156 221.27 723.841 222.165C723.534 223.06 723.38 224.078 723.38 225.22C723.38 226.362 723.534 227.381 723.841 228.276C724.156 229.17 724.62 229.878 725.234 230.398C725.856 230.909 726.623 231.165 727.535 231.165ZM745.442 223.648V235H739.996V215.364H745.186V218.828H745.416C745.851 217.686 746.579 216.783 747.602 216.118C748.625 215.445 749.865 215.108 751.322 215.108C752.686 215.108 753.875 215.406 754.889 216.003C755.903 216.599 756.692 217.452 757.254 218.56C757.817 219.659 758.098 220.972 758.098 222.497V235H752.652V223.469C752.66 222.267 752.354 221.33 751.731 220.656C751.109 219.974 750.253 219.634 749.162 219.634C748.429 219.634 747.781 219.791 747.219 220.107C746.665 220.422 746.23 220.882 745.915 221.487C745.608 222.084 745.45 222.804 745.442 223.648ZM778.008 220.963L773.022 221.27C772.937 220.844 772.754 220.46 772.473 220.119C772.191 219.77 771.821 219.493 771.36 219.288C770.909 219.075 770.368 218.969 769.737 218.969C768.893 218.969 768.181 219.148 767.602 219.506C767.022 219.855 766.733 220.324 766.733 220.912C766.733 221.381 766.92 221.777 767.295 222.101C767.67 222.425 768.314 222.685 769.226 222.881L772.779 223.597C774.689 223.989 776.112 224.619 777.049 225.489C777.987 226.358 778.456 227.5 778.456 228.915C778.456 230.202 778.076 231.331 777.318 232.303C776.568 233.274 775.537 234.033 774.224 234.578C772.92 235.115 771.416 235.384 769.711 235.384C767.112 235.384 765.041 234.842 763.498 233.76C761.964 232.669 761.065 231.186 760.801 229.311L766.157 229.03C766.319 229.822 766.711 230.428 767.333 230.845C767.956 231.254 768.753 231.459 769.724 231.459C770.679 231.459 771.446 231.276 772.025 230.909C772.613 230.534 772.912 230.053 772.92 229.464C772.912 228.97 772.703 228.565 772.294 228.25C771.885 227.926 771.254 227.679 770.402 227.509L767.001 226.831C765.083 226.447 763.656 225.783 762.718 224.837C761.789 223.891 761.325 222.685 761.325 221.219C761.325 219.957 761.666 218.871 762.348 217.959C763.038 217.047 764.005 216.344 765.25 215.849C766.503 215.355 767.968 215.108 769.647 215.108C772.128 215.108 774.079 215.632 775.503 216.68C776.934 217.729 777.77 219.156 778.008 220.963ZM261.09 263.364V267.455H249.265V263.364H261.09ZM251.949 258.659H257.395V276.966C257.395 277.469 257.472 277.861 257.625 278.142C257.779 278.415 257.992 278.607 258.265 278.717C258.546 278.828 258.87 278.884 259.236 278.884C259.492 278.884 259.748 278.862 260.003 278.82C260.259 278.768 260.455 278.73 260.591 278.705L261.448 282.757C261.175 282.842 260.792 282.94 260.297 283.051C259.803 283.17 259.202 283.243 258.495 283.268C257.182 283.32 256.032 283.145 255.043 282.744C254.063 282.344 253.3 281.722 252.755 280.878C252.209 280.034 251.941 278.969 251.949 277.682V258.659ZM272.579 283.384C270.593 283.384 268.876 282.962 267.427 282.118C265.986 281.266 264.874 280.081 264.09 278.564C263.306 277.038 262.914 275.27 262.914 273.259C262.914 271.23 263.306 269.457 264.09 267.94C264.874 266.415 265.986 265.23 267.427 264.386C268.876 263.534 270.593 263.108 272.579 263.108C274.564 263.108 276.278 263.534 277.718 264.386C279.167 265.23 280.283 266.415 281.067 267.94C281.851 269.457 282.243 271.23 282.243 273.259C282.243 275.27 281.851 277.038 281.067 278.564C280.283 280.081 279.167 281.266 277.718 282.118C276.278 282.962 274.564 283.384 272.579 283.384ZM272.604 279.165C273.508 279.165 274.262 278.909 274.867 278.398C275.472 277.878 275.928 277.17 276.235 276.276C276.55 275.381 276.708 274.362 276.708 273.22C276.708 272.078 276.55 271.06 276.235 270.165C275.928 269.27 275.472 268.562 274.867 268.043C274.262 267.523 273.508 267.263 272.604 267.263C271.692 267.263 270.925 267.523 270.303 268.043C269.689 268.562 269.225 269.27 268.91 270.165C268.603 271.06 268.449 272.078 268.449 273.22C268.449 274.362 268.603 275.381 268.91 276.276C269.225 277.17 269.689 277.878 270.303 278.398C270.925 278.909 271.692 279.165 272.604 279.165ZM292.677 290.364V263.364H298.046V266.662H298.289C298.528 266.134 298.873 265.597 299.324 265.051C299.785 264.497 300.381 264.037 301.114 263.67C301.856 263.295 302.776 263.108 303.876 263.108C305.307 263.108 306.628 263.483 307.839 264.233C309.049 264.974 310.016 266.095 310.741 267.595C311.465 269.087 311.827 270.957 311.827 273.207C311.827 275.398 311.474 277.247 310.766 278.756C310.067 280.256 309.113 281.393 307.903 282.169C306.701 282.936 305.354 283.32 303.863 283.32C302.806 283.32 301.907 283.145 301.165 282.795C300.432 282.446 299.831 282.007 299.363 281.479C298.894 280.942 298.536 280.401 298.289 279.855H298.123V290.364H292.677ZM298.008 273.182C298.008 274.349 298.17 275.368 298.493 276.237C298.817 277.107 299.286 277.784 299.9 278.27C300.513 278.747 301.259 278.986 302.137 278.986C303.023 278.986 303.773 278.743 304.387 278.257C305.001 277.763 305.465 277.081 305.78 276.212C306.104 275.334 306.266 274.324 306.266 273.182C306.266 272.048 306.108 271.051 305.793 270.19C305.478 269.33 305.013 268.656 304.4 268.17C303.786 267.685 303.032 267.442 302.137 267.442C301.251 267.442 300.501 267.676 299.887 268.145C299.282 268.614 298.817 269.278 298.493 270.139C298.17 271 298.008 272.014 298.008 273.182ZM323.687 283.384C321.667 283.384 319.928 282.974 318.471 282.156C317.022 281.33 315.906 280.162 315.121 278.653C314.337 277.136 313.945 275.342 313.945 273.271C313.945 271.251 314.337 269.479 315.121 267.953C315.906 266.428 317.009 265.239 318.433 264.386C319.864 263.534 321.543 263.108 323.469 263.108C324.765 263.108 325.971 263.317 327.087 263.734C328.212 264.143 329.192 264.761 330.028 265.588C330.871 266.415 331.528 267.455 331.996 268.707C332.465 269.952 332.7 271.409 332.7 273.08V274.575H316.119V271.2H327.573C327.573 270.416 327.403 269.722 327.062 269.116C326.721 268.511 326.248 268.038 325.643 267.697C325.046 267.348 324.352 267.173 323.559 267.173C322.732 267.173 321.999 267.365 321.36 267.749C320.729 268.124 320.235 268.631 319.877 269.27C319.519 269.901 319.336 270.604 319.327 271.379V274.588C319.327 275.56 319.506 276.399 319.864 277.107C320.231 277.814 320.746 278.359 321.411 278.743C322.076 279.126 322.864 279.318 323.776 279.318C324.381 279.318 324.935 279.233 325.438 279.062C325.941 278.892 326.371 278.636 326.729 278.295C327.087 277.955 327.36 277.537 327.548 277.043L332.585 277.375C332.329 278.585 331.805 279.642 331.012 280.545C330.228 281.44 329.214 282.139 327.969 282.642C326.734 283.136 325.306 283.384 323.687 283.384ZM335.534 283V263.364H340.813V266.79H341.018C341.376 265.571 341.977 264.651 342.82 264.028C343.664 263.398 344.636 263.082 345.735 263.082C346.008 263.082 346.302 263.099 346.617 263.134C346.933 263.168 347.21 263.214 347.448 263.274V268.107C347.193 268.03 346.839 267.962 346.387 267.902C345.936 267.842 345.522 267.812 345.147 267.812C344.346 267.812 343.63 267.987 342.999 268.337C342.377 268.678 341.883 269.155 341.516 269.768C341.159 270.382 340.98 271.089 340.98 271.891V283H335.534ZM361.088 263.364V267.455H348.969V263.364H361.088ZM351.743 283V261.945C351.743 260.521 352.02 259.341 352.574 258.403C353.136 257.466 353.903 256.763 354.875 256.294C355.847 255.825 356.95 255.591 358.186 255.591C359.021 255.591 359.784 255.655 360.474 255.783C361.173 255.911 361.693 256.026 362.034 256.128L361.062 260.219C360.849 260.151 360.585 260.087 360.27 260.027C359.963 259.967 359.648 259.938 359.324 259.938C358.523 259.938 357.964 260.125 357.649 260.5C357.334 260.866 357.176 261.382 357.176 262.047V283H351.743ZM371.864 283.384C369.878 283.384 368.161 282.962 366.712 282.118C365.272 281.266 364.16 280.081 363.375 278.564C362.591 277.038 362.199 275.27 362.199 273.259C362.199 271.23 362.591 269.457 363.375 267.94C364.16 266.415 365.272 265.23 366.712 264.386C368.161 263.534 369.878 263.108 371.864 263.108C373.85 263.108 375.563 263.534 377.003 264.386C378.452 265.23 379.569 266.415 380.353 267.94C381.137 269.457 381.529 271.23 381.529 273.259C381.529 275.27 381.137 277.038 380.353 278.564C379.569 280.081 378.452 281.266 377.003 282.118C375.563 282.962 373.85 283.384 371.864 283.384ZM371.89 279.165C372.793 279.165 373.547 278.909 374.152 278.398C374.758 277.878 375.214 277.17 375.52 276.276C375.836 275.381 375.993 274.362 375.993 273.22C375.993 272.078 375.836 271.06 375.52 270.165C375.214 269.27 374.758 268.562 374.152 268.043C373.547 267.523 372.793 267.263 371.89 267.263C370.978 267.263 370.211 267.523 369.589 268.043C368.975 268.562 368.51 269.27 368.195 270.165C367.888 271.06 367.735 272.078 367.735 273.22C367.735 274.362 367.888 275.381 368.195 276.276C368.51 277.17 368.975 277.878 369.589 278.398C370.211 278.909 370.978 279.165 371.89 279.165ZM384.35 283V263.364H389.63V266.79H389.834C390.192 265.571 390.793 264.651 391.637 264.028C392.481 263.398 393.452 263.082 394.552 263.082C394.825 263.082 395.119 263.099 395.434 263.134C395.749 263.168 396.026 263.214 396.265 263.274V268.107C396.009 268.03 395.655 267.962 395.204 267.902C394.752 267.842 394.339 267.812 393.964 267.812C393.163 267.812 392.447 267.987 391.816 268.337C391.194 268.678 390.7 269.155 390.333 269.768C389.975 270.382 389.796 271.089 389.796 271.891V283H384.35ZM398.361 283V263.364H403.551V266.828H403.781C404.19 265.678 404.872 264.77 405.826 264.105C406.781 263.44 407.923 263.108 409.253 263.108C410.599 263.108 411.746 263.445 412.692 264.118C413.638 264.783 414.268 265.686 414.584 266.828H414.788C415.189 265.703 415.913 264.804 416.961 264.131C418.018 263.449 419.267 263.108 420.707 263.108C422.54 263.108 424.027 263.692 425.169 264.859C426.319 266.018 426.895 267.663 426.895 269.794V283H421.461V270.868C421.461 269.777 421.172 268.959 420.592 268.413C420.013 267.868 419.288 267.595 418.419 267.595C417.43 267.595 416.659 267.911 416.105 268.541C415.551 269.163 415.274 269.986 415.274 271.009V283H409.994V270.753C409.994 269.79 409.717 269.023 409.163 268.452C408.618 267.881 407.897 267.595 407.003 267.595C406.397 267.595 405.852 267.749 405.366 268.055C404.889 268.354 404.51 268.776 404.228 269.321C403.947 269.858 403.807 270.489 403.807 271.213V283H398.361ZM436.076 283.371C434.823 283.371 433.707 283.153 432.727 282.719C431.746 282.276 430.971 281.624 430.4 280.763C429.837 279.893 429.556 278.811 429.556 277.516C429.556 276.425 429.756 275.509 430.157 274.767C430.557 274.026 431.103 273.429 431.793 272.977C432.484 272.526 433.268 272.185 434.146 271.955C435.032 271.724 435.961 271.562 436.932 271.469C438.075 271.349 438.995 271.239 439.694 271.136C440.393 271.026 440.9 270.864 441.215 270.651C441.53 270.437 441.688 270.122 441.688 269.705V269.628C441.688 268.818 441.432 268.192 440.921 267.749C440.418 267.305 439.702 267.084 438.773 267.084C437.793 267.084 437.013 267.301 436.434 267.736C435.854 268.162 435.471 268.699 435.283 269.347L430.246 268.938C430.502 267.744 431.005 266.713 431.755 265.844C432.505 264.966 433.472 264.293 434.657 263.824C435.85 263.347 437.231 263.108 438.799 263.108C439.89 263.108 440.934 263.236 441.931 263.491C442.937 263.747 443.827 264.143 444.603 264.68C445.387 265.217 446.005 265.908 446.457 266.751C446.908 267.587 447.134 268.588 447.134 269.756V283H441.969V280.277H441.816C441.501 280.891 441.079 281.432 440.55 281.901C440.022 282.361 439.387 282.723 438.646 282.987C437.904 283.243 437.048 283.371 436.076 283.371ZM437.636 279.612C438.437 279.612 439.144 279.455 439.758 279.139C440.371 278.815 440.853 278.381 441.202 277.835C441.552 277.29 441.727 276.672 441.727 275.982V273.898C441.556 274.009 441.322 274.111 441.023 274.205C440.734 274.29 440.405 274.371 440.039 274.447C439.673 274.516 439.306 274.58 438.94 274.639C438.573 274.69 438.241 274.737 437.942 274.78C437.303 274.874 436.745 275.023 436.268 275.227C435.79 275.432 435.42 275.709 435.155 276.058C434.891 276.399 434.759 276.825 434.759 277.337C434.759 278.078 435.028 278.645 435.565 279.037C436.11 279.42 436.8 279.612 437.636 279.612ZM456.085 271.648V283H450.639V263.364H455.83V266.828H456.06C456.494 265.686 457.223 264.783 458.246 264.118C459.269 263.445 460.509 263.108 461.966 263.108C463.33 263.108 464.519 263.406 465.533 264.003C466.547 264.599 467.335 265.452 467.898 266.56C468.46 267.659 468.742 268.972 468.742 270.497V283H463.296V271.469C463.304 270.267 462.997 269.33 462.375 268.656C461.753 267.974 460.896 267.634 459.806 267.634C459.073 267.634 458.425 267.791 457.862 268.107C457.308 268.422 456.874 268.882 456.558 269.487C456.252 270.084 456.094 270.804 456.085 271.648ZM481.186 283.384C479.175 283.384 477.445 282.957 475.996 282.105C474.555 281.244 473.447 280.051 472.672 278.526C471.905 277 471.521 275.244 471.521 273.259C471.521 271.247 471.909 269.483 472.685 267.966C473.469 266.44 474.581 265.251 476.021 264.399C477.462 263.538 479.175 263.108 481.16 263.108C482.874 263.108 484.374 263.419 485.66 264.041C486.947 264.663 487.966 265.537 488.716 266.662C489.466 267.787 489.879 269.108 489.956 270.625H484.817C484.672 269.645 484.288 268.857 483.666 268.26C483.052 267.655 482.247 267.352 481.25 267.352C480.406 267.352 479.669 267.582 479.038 268.043C478.416 268.494 477.93 269.155 477.581 270.024C477.231 270.893 477.057 271.946 477.057 273.182C477.057 274.435 477.227 275.5 477.568 276.378C477.918 277.256 478.408 277.925 479.038 278.385C479.669 278.845 480.406 279.075 481.25 279.075C481.872 279.075 482.43 278.947 482.925 278.692C483.427 278.436 483.841 278.065 484.165 277.58C484.497 277.085 484.714 276.493 484.817 275.803H489.956C489.871 277.303 489.462 278.624 488.729 279.766C488.004 280.899 487.003 281.786 485.724 282.425C484.446 283.064 482.933 283.384 481.186 283.384ZM501.672 283.384C499.652 283.384 497.913 282.974 496.456 282.156C495.007 281.33 493.89 280.162 493.106 278.653C492.322 277.136 491.93 275.342 491.93 273.271C491.93 271.251 492.322 269.479 493.106 267.953C493.89 266.428 494.994 265.239 496.417 264.386C497.849 263.534 499.528 263.108 501.454 263.108C502.75 263.108 503.956 263.317 505.072 263.734C506.197 264.143 507.177 264.761 508.013 265.588C508.856 266.415 509.513 267.455 509.981 268.707C510.45 269.952 510.684 271.409 510.684 273.08V274.575H494.103V271.2H505.558C505.558 270.416 505.388 269.722 505.047 269.116C504.706 268.511 504.233 268.038 503.628 267.697C503.031 267.348 502.336 267.173 501.544 267.173C500.717 267.173 499.984 267.365 499.345 267.749C498.714 268.124 498.22 268.631 497.862 269.27C497.504 269.901 497.321 270.604 497.312 271.379V274.588C497.312 275.56 497.491 276.399 497.849 277.107C498.216 277.814 498.731 278.359 499.396 278.743C500.061 279.126 500.849 279.318 501.761 279.318C502.366 279.318 502.92 279.233 503.423 279.062C503.926 278.892 504.356 278.636 504.714 278.295C505.072 277.955 505.345 277.537 505.532 277.043L510.569 277.375C510.314 278.585 509.789 279.642 508.997 280.545C508.213 281.44 507.199 282.139 505.954 282.642C504.718 283.136 503.291 283.384 501.672 283.384ZM528.366 283.32C526.875 283.32 525.524 282.936 524.314 282.169C523.112 281.393 522.157 280.256 521.45 278.756C520.751 277.247 520.402 275.398 520.402 273.207C520.402 270.957 520.764 269.087 521.488 267.595C522.213 266.095 523.176 264.974 524.378 264.233C525.588 263.483 526.913 263.108 528.353 263.108C529.453 263.108 530.369 263.295 531.102 263.67C531.843 264.037 532.44 264.497 532.892 265.051C533.352 265.597 533.701 266.134 533.94 266.662H534.106V256.818H539.54V283H534.17V279.855H533.94C533.684 280.401 533.322 280.942 532.853 281.479C532.393 282.007 531.792 282.446 531.051 282.795C530.318 283.145 529.423 283.32 528.366 283.32ZM530.092 278.986C530.97 278.986 531.711 278.747 532.316 278.27C532.93 277.784 533.399 277.107 533.723 276.237C534.055 275.368 534.221 274.349 534.221 273.182C534.221 272.014 534.059 271 533.736 270.139C533.412 269.278 532.943 268.614 532.329 268.145C531.716 267.676 530.97 267.442 530.092 267.442C529.197 267.442 528.443 267.685 527.829 268.17C527.216 268.656 526.751 269.33 526.436 270.19C526.12 271.051 525.963 272.048 525.963 273.182C525.963 274.324 526.12 275.334 526.436 276.212C526.76 277.081 527.224 277.763 527.829 278.257C528.443 278.743 529.197 278.986 530.092 278.986ZM543.297 283V263.364H548.743V283H543.297ZM546.033 260.832C545.223 260.832 544.529 260.564 543.949 260.027C543.378 259.482 543.093 258.83 543.093 258.071C543.093 257.321 543.378 256.678 543.949 256.141C544.529 255.595 545.223 255.322 546.033 255.322C546.843 255.322 547.533 255.595 548.104 256.141C548.683 256.678 548.973 257.321 548.973 258.071C548.973 258.83 548.683 259.482 548.104 260.027C547.533 260.564 546.843 260.832 546.033 260.832ZM568.724 268.963L563.738 269.27C563.653 268.844 563.47 268.46 563.188 268.119C562.907 267.77 562.536 267.493 562.076 267.288C561.624 267.075 561.083 266.969 560.452 266.969C559.609 266.969 558.897 267.148 558.318 267.506C557.738 267.855 557.448 268.324 557.448 268.912C557.448 269.381 557.636 269.777 558.011 270.101C558.386 270.425 559.029 270.685 559.941 270.881L563.495 271.597C565.404 271.989 566.827 272.619 567.765 273.489C568.702 274.358 569.171 275.5 569.171 276.915C569.171 278.202 568.792 279.331 568.033 280.303C567.283 281.274 566.252 282.033 564.94 282.578C563.636 283.115 562.131 283.384 560.427 283.384C557.827 283.384 555.756 282.842 554.214 281.76C552.68 280.669 551.781 279.186 551.516 277.311L556.873 277.03C557.035 277.822 557.427 278.428 558.049 278.845C558.671 279.254 559.468 279.459 560.44 279.459C561.394 279.459 562.161 279.276 562.741 278.909C563.329 278.534 563.627 278.053 563.636 277.464C563.627 276.97 563.418 276.565 563.009 276.25C562.6 275.926 561.97 275.679 561.117 275.509L557.717 274.831C555.799 274.447 554.372 273.783 553.434 272.837C552.505 271.891 552.041 270.685 552.041 269.219C552.041 267.957 552.381 266.871 553.063 265.959C553.754 265.047 554.721 264.344 555.965 263.849C557.218 263.355 558.684 263.108 560.363 263.108C562.843 263.108 564.795 263.632 566.218 264.68C567.65 265.729 568.485 267.156 568.724 268.963ZM582.325 263.364V267.455H570.5V263.364H582.325ZM573.185 258.659H578.631V276.966C578.631 277.469 578.707 277.861 578.861 278.142C579.014 278.415 579.227 278.607 579.5 278.717C579.781 278.828 580.105 278.884 580.471 278.884C580.727 278.884 580.983 278.862 581.239 278.82C581.494 278.768 581.69 278.73 581.827 278.705L582.683 282.757C582.41 282.842 582.027 282.94 581.533 283.051C581.038 283.17 580.437 283.243 579.73 283.268C578.418 283.32 577.267 283.145 576.278 282.744C575.298 282.344 574.535 281.722 573.99 280.878C573.444 280.034 573.176 278.969 573.185 277.682V258.659ZM585.153 283V263.364H590.433V266.79H590.637C590.995 265.571 591.596 264.651 592.44 264.028C593.283 263.398 594.255 263.082 595.354 263.082C595.627 263.082 595.921 263.099 596.237 263.134C596.552 263.168 596.829 263.214 597.068 263.274V268.107C596.812 268.03 596.458 267.962 596.006 267.902C595.555 267.842 595.141 267.812 594.766 267.812C593.965 267.812 593.249 267.987 592.619 268.337C591.997 268.678 591.502 269.155 591.136 269.768C590.778 270.382 590.599 271.089 590.599 271.891V283H585.153ZM599.163 283V263.364H604.609V283H599.163ZM601.899 260.832C601.089 260.832 600.395 260.564 599.815 260.027C599.244 259.482 598.959 258.83 598.959 258.071C598.959 257.321 599.244 256.678 599.815 256.141C600.395 255.595 601.089 255.322 601.899 255.322C602.709 255.322 603.399 255.595 603.97 256.141C604.55 256.678 604.839 257.321 604.839 258.071C604.839 258.83 604.55 259.482 603.97 260.027C603.399 260.564 602.709 260.832 601.899 260.832ZM608.354 283V256.818H613.8V266.662H613.966C614.205 266.134 614.55 265.597 615.002 265.051C615.462 264.497 616.059 264.037 616.792 263.67C617.533 263.295 618.454 263.108 619.553 263.108C620.985 263.108 622.306 263.483 623.516 264.233C624.726 264.974 625.694 266.095 626.418 267.595C627.142 269.087 627.505 270.957 627.505 273.207C627.505 275.398 627.151 277.247 626.444 278.756C625.745 280.256 624.79 281.393 623.58 282.169C622.378 282.936 621.032 283.32 619.54 283.32C618.483 283.32 617.584 283.145 616.843 282.795C616.11 282.446 615.509 282.007 615.04 281.479C614.571 280.942 614.213 280.401 613.966 279.855H613.723V283H608.354ZM613.685 273.182C613.685 274.349 613.847 275.368 614.171 276.237C614.495 277.107 614.963 277.784 615.577 278.27C616.191 278.747 616.936 278.986 617.814 278.986C618.701 278.986 619.451 278.743 620.064 278.257C620.678 277.763 621.142 277.081 621.458 276.212C621.782 275.334 621.944 274.324 621.944 273.182C621.944 272.048 621.786 271.051 621.471 270.19C621.155 269.33 620.691 268.656 620.077 268.17C619.463 267.685 618.709 267.442 617.814 267.442C616.928 267.442 616.178 267.676 615.564 268.145C614.959 268.614 614.495 269.278 614.171 270.139C613.847 271 613.685 272.014 613.685 273.182ZM643.011 274.639V263.364H648.457V283H643.228V279.433H643.024C642.58 280.584 641.843 281.509 640.812 282.207C639.789 282.906 638.541 283.256 637.066 283.256C635.754 283.256 634.599 282.957 633.602 282.361C632.605 281.764 631.825 280.916 631.262 279.817C630.708 278.717 630.427 277.401 630.419 275.866V263.364H635.865V274.895C635.873 276.054 636.184 276.97 636.798 277.643C637.411 278.317 638.234 278.653 639.265 278.653C639.921 278.653 640.535 278.504 641.106 278.206C641.677 277.899 642.137 277.447 642.487 276.851C642.845 276.254 643.019 275.517 643.011 274.639ZM662.538 263.364V267.455H650.712V263.364H662.538ZM653.397 258.659H658.843V276.966C658.843 277.469 658.92 277.861 659.073 278.142C659.227 278.415 659.44 278.607 659.712 278.717C659.994 278.828 660.317 278.884 660.684 278.884C660.94 278.884 661.195 278.862 661.451 278.82C661.707 278.768 661.903 278.73 662.039 278.705L662.896 282.757C662.623 282.842 662.239 282.94 661.745 283.051C661.251 283.17 660.65 283.243 659.942 283.268C658.63 283.32 657.479 283.145 656.491 282.744C655.511 282.344 654.748 281.722 654.202 280.878C653.657 280.034 653.389 278.969 653.397 277.682V258.659ZM665.365 283V263.364H670.811V283H665.365ZM668.101 260.832C667.291 260.832 666.597 260.564 666.017 260.027C665.446 259.482 665.161 258.83 665.161 258.071C665.161 257.321 665.446 256.678 666.017 256.141C666.597 255.595 667.291 255.322 668.101 255.322C668.911 255.322 669.601 255.595 670.172 256.141C670.752 256.678 671.041 257.321 671.041 258.071C671.041 258.83 670.752 259.482 670.172 260.027C669.601 260.564 668.911 260.832 668.101 260.832ZM683.326 283.384C681.34 283.384 679.623 282.962 678.174 282.118C676.734 281.266 675.621 280.081 674.837 278.564C674.053 277.038 673.661 275.27 673.661 273.259C673.661 271.23 674.053 269.457 674.837 267.94C675.621 266.415 676.734 265.23 678.174 264.386C679.623 263.534 681.34 263.108 683.326 263.108C685.312 263.108 687.025 263.534 688.465 264.386C689.914 265.23 691.031 266.415 691.815 267.94C692.599 269.457 692.991 271.23 692.991 273.259C692.991 275.27 692.599 277.038 691.815 278.564C691.031 280.081 689.914 281.266 688.465 282.118C687.025 282.962 685.312 283.384 683.326 283.384ZM683.352 279.165C684.255 279.165 685.009 278.909 685.614 278.398C686.219 277.878 686.675 277.17 686.982 276.276C687.298 275.381 687.455 274.362 687.455 273.22C687.455 272.078 687.298 271.06 686.982 270.165C686.675 269.27 686.219 268.562 685.614 268.043C685.009 267.523 684.255 267.263 683.352 267.263C682.44 267.263 681.673 267.523 681.05 268.043C680.437 268.562 679.972 269.27 679.657 270.165C679.35 271.06 679.197 272.078 679.197 273.22C679.197 274.362 679.35 275.381 679.657 276.276C679.972 277.17 680.437 277.878 681.05 278.398C681.673 278.909 682.44 279.165 683.352 279.165ZM701.258 271.648V283H695.812V263.364H701.002V266.828H701.232C701.667 265.686 702.396 264.783 703.419 264.118C704.441 263.445 705.681 263.108 707.139 263.108C708.502 263.108 709.691 263.406 710.705 264.003C711.72 264.599 712.508 265.452 713.07 266.56C713.633 267.659 713.914 268.972 713.914 270.497V283H708.468V271.469C708.477 270.267 708.17 269.33 707.548 268.656C706.926 267.974 706.069 267.634 704.978 267.634C704.245 267.634 703.597 267.791 703.035 268.107C702.481 268.422 702.046 268.882 701.731 269.487C701.424 270.084 701.267 270.804 701.258 271.648ZM733.825 268.963L728.839 269.27C728.754 268.844 728.57 268.46 728.289 268.119C728.008 267.77 727.637 267.493 727.177 267.288C726.725 267.075 726.184 266.969 725.553 266.969C724.71 266.969 723.998 267.148 723.418 267.506C722.839 267.855 722.549 268.324 722.549 268.912C722.549 269.381 722.737 269.777 723.112 270.101C723.487 270.425 724.13 270.685 725.042 270.881L728.596 271.597C730.505 271.989 731.928 272.619 732.866 273.489C733.803 274.358 734.272 275.5 734.272 276.915C734.272 278.202 733.893 279.331 733.134 280.303C732.384 281.274 731.353 282.033 730.041 282.578C728.737 283.115 727.232 283.384 725.528 283.384C722.928 283.384 720.857 282.842 719.315 281.76C717.781 280.669 716.881 279.186 716.617 277.311L721.974 277.03C722.136 277.822 722.528 278.428 723.15 278.845C723.772 279.254 724.569 279.459 725.541 279.459C726.495 279.459 727.262 279.276 727.842 278.909C728.43 278.534 728.728 278.053 728.737 277.464C728.728 276.97 728.519 276.565 728.11 276.25C727.701 275.926 727.07 275.679 726.218 275.509L722.817 274.831C720.9 274.447 719.472 273.783 718.535 272.837C717.606 271.891 717.141 270.685 717.141 269.219C717.141 267.957 717.482 266.871 718.164 265.959C718.854 265.047 719.822 264.344 721.066 263.849C722.319 263.355 723.785 263.108 725.464 263.108C727.944 263.108 729.896 263.632 731.319 264.68C732.751 265.729 733.586 267.156 733.825 268.963Z" fill="black"/>
+<path d="M282.981 821V794.818H293.311C295.297 794.818 296.988 795.197 298.386 795.956C299.784 796.706 300.849 797.75 301.582 799.088C302.324 800.418 302.694 801.952 302.694 803.69C302.694 805.429 302.319 806.963 301.569 808.293C300.819 809.622 299.733 810.658 298.309 811.399C296.895 812.141 295.182 812.511 293.17 812.511H286.586V808.075H292.275C293.341 808.075 294.219 807.892 294.909 807.526C295.608 807.151 296.128 806.635 296.469 805.979C296.818 805.314 296.993 804.551 296.993 803.69C296.993 802.821 296.818 802.062 296.469 801.415C296.128 800.759 295.608 800.251 294.909 799.893C294.21 799.527 293.324 799.344 292.25 799.344H288.517V821H282.981ZM314.1 821.384C312.08 821.384 310.342 820.974 308.884 820.156C307.435 819.33 306.319 818.162 305.535 816.653C304.751 815.136 304.359 813.342 304.359 811.271C304.359 809.251 304.751 807.479 305.535 805.953C306.319 804.428 307.423 803.239 308.846 802.386C310.278 801.534 311.957 801.108 313.883 801.108C315.178 801.108 316.384 801.317 317.501 801.734C318.626 802.143 319.606 802.761 320.441 803.588C321.285 804.415 321.941 805.455 322.41 806.707C322.879 807.952 323.113 809.409 323.113 811.08V812.575H306.532V809.2H317.986C317.986 808.416 317.816 807.722 317.475 807.116C317.134 806.511 316.661 806.038 316.056 805.697C315.46 805.348 314.765 805.173 313.972 805.173C313.146 805.173 312.413 805.365 311.773 805.749C311.143 806.124 310.648 806.631 310.29 807.27C309.933 807.901 309.749 808.604 309.741 809.379V812.588C309.741 813.56 309.92 814.399 310.278 815.107C310.644 815.814 311.16 816.359 311.825 816.743C312.489 817.126 313.278 817.318 314.19 817.318C314.795 817.318 315.349 817.233 315.852 817.062C316.354 816.892 316.785 816.636 317.143 816.295C317.501 815.955 317.773 815.537 317.961 815.043L322.998 815.375C322.742 816.585 322.218 817.642 321.425 818.545C320.641 819.44 319.627 820.139 318.383 820.642C317.147 821.136 315.719 821.384 314.1 821.384ZM325.947 821V801.364H331.227V804.79H331.431C331.789 803.571 332.39 802.651 333.234 802.028C334.078 801.398 335.049 801.082 336.149 801.082C336.421 801.082 336.715 801.099 337.031 801.134C337.346 801.168 337.623 801.214 337.862 801.274V806.107C337.606 806.03 337.252 805.962 336.801 805.902C336.349 805.842 335.936 805.812 335.561 805.812C334.759 805.812 334.043 805.987 333.413 806.337C332.791 806.678 332.296 807.155 331.93 807.768C331.572 808.382 331.393 809.089 331.393 809.891V821H325.947ZM351.501 801.364V805.455H339.382V801.364H351.501ZM342.156 821V799.945C342.156 798.521 342.433 797.341 342.987 796.403C343.55 795.466 344.317 794.763 345.288 794.294C346.26 793.825 347.364 793.591 348.599 793.591C349.435 793.591 350.197 793.655 350.888 793.783C351.587 793.911 352.107 794.026 352.447 794.128L351.476 798.219C351.263 798.151 350.999 798.087 350.683 798.027C350.376 797.967 350.061 797.938 349.737 797.938C348.936 797.938 348.378 798.125 348.062 798.5C347.747 798.866 347.589 799.382 347.589 800.047V821H342.156ZM362.277 821.384C360.292 821.384 358.574 820.962 357.125 820.118C355.685 819.266 354.573 818.081 353.789 816.564C353.005 815.038 352.613 813.27 352.613 811.259C352.613 809.23 353.005 807.457 353.789 805.94C354.573 804.415 355.685 803.23 357.125 802.386C358.574 801.534 360.292 801.108 362.277 801.108C364.263 801.108 365.976 801.534 367.417 802.386C368.866 803.23 369.982 804.415 370.766 805.94C371.55 807.457 371.942 809.23 371.942 811.259C371.942 813.27 371.55 815.038 370.766 816.564C369.982 818.081 368.866 819.266 367.417 820.118C365.976 820.962 364.263 821.384 362.277 821.384ZM362.303 817.165C363.206 817.165 363.961 816.909 364.566 816.398C365.171 815.878 365.627 815.17 365.934 814.276C366.249 813.381 366.407 812.362 366.407 811.22C366.407 810.078 366.249 809.06 365.934 808.165C365.627 807.27 365.171 806.562 364.566 806.043C363.961 805.523 363.206 805.263 362.303 805.263C361.391 805.263 360.624 805.523 360.002 806.043C359.388 806.562 358.924 807.27 358.608 808.165C358.302 809.06 358.148 810.078 358.148 811.22C358.148 812.362 358.302 813.381 358.608 814.276C358.924 815.17 359.388 815.878 360.002 816.398C360.624 816.909 361.391 817.165 362.303 817.165ZM374.763 821V801.364H380.043V804.79H380.248C380.606 803.571 381.207 802.651 382.05 802.028C382.894 801.398 383.866 801.082 384.965 801.082C385.238 801.082 385.532 801.099 385.847 801.134C386.163 801.168 386.44 801.214 386.678 801.274V806.107C386.423 806.03 386.069 805.962 385.617 805.902C385.165 805.842 384.752 805.812 384.377 805.812C383.576 805.812 382.86 805.987 382.229 806.337C381.607 806.678 381.113 807.155 380.746 807.768C380.388 808.382 380.209 809.089 380.209 809.891V821H374.763ZM388.774 821V801.364H393.964V804.828H394.194C394.603 803.678 395.285 802.77 396.24 802.105C397.194 801.44 398.336 801.108 399.666 801.108C401.013 801.108 402.159 801.445 403.105 802.118C404.051 802.783 404.682 803.686 404.997 804.828H405.201C405.602 803.703 406.326 802.804 407.375 802.131C408.432 801.449 409.68 801.108 411.121 801.108C412.953 801.108 414.44 801.692 415.582 802.859C416.733 804.018 417.308 805.663 417.308 807.794V821H411.875V808.868C411.875 807.777 411.585 806.959 411.005 806.413C410.426 805.868 409.701 805.595 408.832 805.595C407.844 805.595 407.072 805.911 406.518 806.541C405.964 807.163 405.687 807.986 405.687 809.009V821H400.407V808.753C400.407 807.79 400.13 807.023 399.576 806.452C399.031 805.881 398.311 805.595 397.416 805.595C396.811 805.595 396.265 805.749 395.78 806.055C395.302 806.354 394.923 806.776 394.642 807.321C394.361 807.858 394.22 808.489 394.22 809.213V821H388.774ZM426.489 821.371C425.236 821.371 424.12 821.153 423.14 820.719C422.16 820.276 421.384 819.624 420.813 818.763C420.251 817.893 419.969 816.811 419.969 815.516C419.969 814.425 420.17 813.509 420.57 812.767C420.971 812.026 421.516 811.429 422.207 810.977C422.897 810.526 423.681 810.185 424.559 809.955C425.445 809.724 426.374 809.562 427.346 809.469C428.488 809.349 429.408 809.239 430.107 809.136C430.806 809.026 431.313 808.864 431.629 808.651C431.944 808.437 432.102 808.122 432.102 807.705V807.628C432.102 806.818 431.846 806.192 431.334 805.749C430.832 805.305 430.116 805.084 429.187 805.084C428.207 805.084 427.427 805.301 426.847 805.736C426.268 806.162 425.884 806.699 425.697 807.347L420.66 806.938C420.915 805.744 421.418 804.713 422.168 803.844C422.918 802.966 423.886 802.293 425.07 801.824C426.263 801.347 427.644 801.108 429.212 801.108C430.303 801.108 431.347 801.236 432.344 801.491C433.35 801.747 434.241 802.143 435.016 802.68C435.8 803.217 436.418 803.908 436.87 804.751C437.322 805.587 437.548 806.588 437.548 807.756V821H432.383V818.277H432.229C431.914 818.891 431.492 819.432 430.964 819.901C430.435 820.361 429.8 820.723 429.059 820.987C428.317 821.243 427.461 821.371 426.489 821.371ZM428.049 817.612C428.85 817.612 429.557 817.455 430.171 817.139C430.785 816.815 431.266 816.381 431.616 815.835C431.965 815.29 432.14 814.672 432.14 813.982V811.898C431.969 812.009 431.735 812.111 431.437 812.205C431.147 812.29 430.819 812.371 430.452 812.447C430.086 812.516 429.719 812.58 429.353 812.639C428.986 812.69 428.654 812.737 428.356 812.78C427.717 812.874 427.158 813.023 426.681 813.227C426.204 813.432 425.833 813.709 425.569 814.058C425.305 814.399 425.173 814.825 425.173 815.337C425.173 816.078 425.441 816.645 425.978 817.037C426.523 817.42 427.214 817.612 428.049 817.612ZM446.499 809.648V821H441.053V801.364H446.243V804.828H446.473C446.908 803.686 447.636 802.783 448.659 802.118C449.682 801.445 450.922 801.108 452.379 801.108C453.743 801.108 454.932 801.406 455.946 802.003C456.96 802.599 457.749 803.452 458.311 804.56C458.874 805.659 459.155 806.972 459.155 808.497V821H453.709V809.469C453.717 808.267 453.411 807.33 452.788 806.656C452.166 805.974 451.31 805.634 450.219 805.634C449.486 805.634 448.838 805.791 448.276 806.107C447.722 806.422 447.287 806.882 446.972 807.487C446.665 808.084 446.507 808.804 446.499 809.648ZM471.599 821.384C469.588 821.384 467.858 820.957 466.409 820.105C464.969 819.244 463.861 818.051 463.085 816.526C462.318 815 461.935 813.244 461.935 811.259C461.935 809.247 462.322 807.483 463.098 805.966C463.882 804.44 464.994 803.251 466.435 802.399C467.875 801.538 469.588 801.108 471.574 801.108C473.287 801.108 474.787 801.419 476.074 802.041C477.361 802.663 478.379 803.537 479.129 804.662C479.879 805.787 480.293 807.108 480.369 808.625H475.23C475.085 807.645 474.702 806.857 474.079 806.26C473.466 805.655 472.66 805.352 471.663 805.352C470.82 805.352 470.082 805.582 469.452 806.043C468.829 806.494 468.344 807.155 467.994 808.024C467.645 808.893 467.47 809.946 467.47 811.182C467.47 812.435 467.641 813.5 467.981 814.378C468.331 815.256 468.821 815.925 469.452 816.385C470.082 816.845 470.82 817.075 471.663 817.075C472.285 817.075 472.844 816.947 473.338 816.692C473.841 816.436 474.254 816.065 474.578 815.58C474.91 815.085 475.128 814.493 475.23 813.803H480.369C480.284 815.303 479.875 816.624 479.142 817.766C478.418 818.899 477.416 819.786 476.138 820.425C474.859 821.064 473.347 821.384 471.599 821.384ZM492.085 821.384C490.065 821.384 488.326 820.974 486.869 820.156C485.42 819.33 484.304 818.162 483.52 816.653C482.736 815.136 482.344 813.342 482.344 811.271C482.344 809.251 482.736 807.479 483.52 805.953C484.304 804.428 485.407 803.239 486.831 802.386C488.263 801.534 489.942 801.108 491.868 801.108C493.163 801.108 494.369 801.317 495.486 801.734C496.611 802.143 497.591 802.761 498.426 803.588C499.27 804.415 499.926 805.455 500.395 806.707C500.863 807.952 501.098 809.409 501.098 811.08V812.575H484.517V809.2H495.971C495.971 808.416 495.801 807.722 495.46 807.116C495.119 806.511 494.646 806.038 494.041 805.697C493.444 805.348 492.75 805.173 491.957 805.173C491.13 805.173 490.397 805.365 489.758 805.749C489.128 806.124 488.633 806.631 488.275 807.27C487.917 807.901 487.734 808.604 487.726 809.379V812.588C487.726 813.56 487.905 814.399 488.263 815.107C488.629 815.814 489.145 816.359 489.809 816.743C490.474 817.126 491.263 817.318 492.174 817.318C492.78 817.318 493.334 817.233 493.836 817.062C494.339 816.892 494.77 816.636 495.128 816.295C495.486 815.955 495.758 815.537 495.946 815.043L500.983 815.375C500.727 816.585 500.203 817.642 499.41 818.545C498.626 819.44 497.612 820.139 496.368 820.642C495.132 821.136 493.704 821.384 492.085 821.384ZM527.882 806.963L522.896 807.27C522.811 806.844 522.628 806.46 522.346 806.119C522.065 805.77 521.694 805.493 521.234 805.288C520.782 805.075 520.241 804.969 519.611 804.969C518.767 804.969 518.055 805.148 517.476 805.506C516.896 805.855 516.606 806.324 516.606 806.912C516.606 807.381 516.794 807.777 517.169 808.101C517.544 808.425 518.187 808.685 519.099 808.881L522.653 809.597C524.562 809.989 525.986 810.619 526.923 811.489C527.861 812.358 528.329 813.5 528.329 814.915C528.329 816.202 527.95 817.331 527.192 818.303C526.442 819.274 525.41 820.033 524.098 820.578C522.794 821.115 521.29 821.384 519.585 821.384C516.986 821.384 514.915 820.842 513.372 819.76C511.838 818.669 510.939 817.186 510.674 815.311L516.031 815.03C516.193 815.822 516.585 816.428 517.207 816.845C517.829 817.254 518.626 817.459 519.598 817.459C520.552 817.459 521.319 817.276 521.899 816.909C522.487 816.534 522.785 816.053 522.794 815.464C522.785 814.97 522.576 814.565 522.167 814.25C521.758 813.926 521.128 813.679 520.275 813.509L516.875 812.831C514.957 812.447 513.53 811.783 512.592 810.837C511.663 809.891 511.199 808.685 511.199 807.219C511.199 805.957 511.54 804.871 512.221 803.959C512.912 803.047 513.879 802.344 515.123 801.849C516.376 801.355 517.842 801.108 519.521 801.108C522.001 801.108 523.953 801.632 525.376 802.68C526.808 803.729 527.643 805.156 527.882 806.963ZM539.987 821.384C537.968 821.384 536.229 820.974 534.772 820.156C533.323 819.33 532.206 818.162 531.422 816.653C530.638 815.136 530.246 813.342 530.246 811.271C530.246 809.251 530.638 807.479 531.422 805.953C532.206 804.428 533.31 803.239 534.733 802.386C536.165 801.534 537.844 801.108 539.77 801.108C541.066 801.108 542.272 801.317 543.388 801.734C544.513 802.143 545.493 802.761 546.328 803.588C547.172 804.415 547.828 805.455 548.297 806.707C548.766 807.952 549 809.409 549 811.08V812.575H532.419V809.2H543.874C543.874 808.416 543.703 807.722 543.362 807.116C543.022 806.511 542.549 806.038 541.943 805.697C541.347 805.348 540.652 805.173 539.86 805.173C539.033 805.173 538.3 805.365 537.661 805.749C537.03 806.124 536.536 806.631 536.178 807.27C535.82 807.901 535.637 808.604 535.628 809.379V812.588C535.628 813.56 535.807 814.399 536.165 815.107C536.531 815.814 537.047 816.359 537.712 816.743C538.377 817.126 539.165 817.318 540.077 817.318C540.682 817.318 541.236 817.233 541.739 817.062C542.242 816.892 542.672 816.636 543.03 816.295C543.388 815.955 543.661 815.537 543.848 815.043L548.885 815.375C548.63 816.585 548.105 817.642 547.313 818.545C546.529 819.44 545.514 820.139 544.27 820.642C543.034 821.136 541.607 821.384 539.987 821.384ZM551.834 828.364V801.364H557.204V804.662H557.446C557.685 804.134 558.03 803.597 558.482 803.051C558.942 802.497 559.539 802.037 560.272 801.67C561.013 801.295 561.934 801.108 563.033 801.108C564.465 801.108 565.786 801.483 566.996 802.233C568.206 802.974 569.174 804.095 569.898 805.595C570.623 807.087 570.985 808.957 570.985 811.207C570.985 813.398 570.631 815.247 569.924 816.756C569.225 818.256 568.27 819.393 567.06 820.169C565.858 820.936 564.512 821.32 563.02 821.32C561.964 821.32 561.064 821.145 560.323 820.795C559.59 820.446 558.989 820.007 558.52 819.479C558.052 818.942 557.694 818.401 557.446 817.855H557.28V828.364H551.834ZM557.165 811.182C557.165 812.349 557.327 813.368 557.651 814.237C557.975 815.107 558.444 815.784 559.057 816.27C559.671 816.747 560.417 816.986 561.294 816.986C562.181 816.986 562.931 816.743 563.544 816.257C564.158 815.763 564.623 815.081 564.938 814.212C565.262 813.334 565.424 812.324 565.424 811.182C565.424 810.048 565.266 809.051 564.951 808.19C564.635 807.33 564.171 806.656 563.557 806.17C562.944 805.685 562.189 805.442 561.294 805.442C560.408 805.442 559.658 805.676 559.044 806.145C558.439 806.614 557.975 807.278 557.651 808.139C557.327 809 557.165 810.014 557.165 811.182ZM579.495 821.371C578.242 821.371 577.126 821.153 576.145 820.719C575.165 820.276 574.39 819.624 573.819 818.763C573.256 817.893 572.975 816.811 572.975 815.516C572.975 814.425 573.175 813.509 573.576 812.767C573.976 812.026 574.522 811.429 575.212 810.977C575.903 810.526 576.687 810.185 577.565 809.955C578.451 809.724 579.38 809.562 580.351 809.469C581.494 809.349 582.414 809.239 583.113 809.136C583.812 809.026 584.319 808.864 584.634 808.651C584.949 808.437 585.107 808.122 585.107 807.705V807.628C585.107 806.818 584.851 806.192 584.34 805.749C583.837 805.305 583.121 805.084 582.192 805.084C581.212 805.084 580.432 805.301 579.853 805.736C579.273 806.162 578.89 806.699 578.702 807.347L573.665 806.938C573.921 805.744 574.424 804.713 575.174 803.844C575.924 802.966 576.891 802.293 578.076 801.824C579.269 801.347 580.65 801.108 582.218 801.108C583.309 801.108 584.353 801.236 585.35 801.491C586.356 801.747 587.246 802.143 588.022 802.68C588.806 803.217 589.424 803.908 589.876 804.751C590.327 805.587 590.553 806.588 590.553 807.756V821H585.388V818.277H585.235C584.92 818.891 584.498 819.432 583.969 819.901C583.441 820.361 582.806 820.723 582.065 820.987C581.323 821.243 580.467 821.371 579.495 821.371ZM581.055 817.612C581.856 817.612 582.563 817.455 583.177 817.139C583.79 816.815 584.272 816.381 584.621 815.835C584.971 815.29 585.145 814.672 585.145 813.982V811.898C584.975 812.009 584.741 812.111 584.442 812.205C584.153 812.29 583.824 812.371 583.458 812.447C583.092 812.516 582.725 812.58 582.359 812.639C581.992 812.69 581.66 812.737 581.361 812.78C580.722 812.874 580.164 813.023 579.687 813.227C579.209 813.432 578.839 813.709 578.574 814.058C578.31 814.399 578.178 814.825 578.178 815.337C578.178 816.078 578.447 816.645 578.984 817.037C579.529 817.42 580.219 817.612 581.055 817.612ZM594.058 821V801.364H599.338V804.79H599.543C599.901 803.571 600.501 802.651 601.345 802.028C602.189 801.398 603.161 801.082 604.26 801.082C604.533 801.082 604.827 801.099 605.142 801.134C605.457 801.168 605.734 801.214 605.973 801.274V806.107C605.717 806.03 605.364 805.962 604.912 805.902C604.46 805.842 604.047 805.812 603.672 805.812C602.871 805.812 602.155 805.987 601.524 806.337C600.902 806.678 600.408 807.155 600.041 807.768C599.683 808.382 599.504 809.089 599.504 809.891V821H594.058ZM613.106 821.371C611.853 821.371 610.736 821.153 609.756 820.719C608.776 820.276 608.001 819.624 607.43 818.763C606.867 817.893 606.586 816.811 606.586 815.516C606.586 814.425 606.786 813.509 607.187 812.767C607.587 812.026 608.133 811.429 608.823 810.977C609.513 810.526 610.297 810.185 611.175 809.955C612.062 809.724 612.991 809.562 613.962 809.469C615.104 809.349 616.025 809.239 616.724 809.136C617.422 809.026 617.93 808.864 618.245 808.651C618.56 808.437 618.718 808.122 618.718 807.705V807.628C618.718 806.818 618.462 806.192 617.951 805.749C617.448 805.305 616.732 805.084 615.803 805.084C614.823 805.084 614.043 805.301 613.464 805.736C612.884 806.162 612.501 806.699 612.313 807.347L607.276 806.938C607.532 805.744 608.035 804.713 608.785 803.844C609.535 802.966 610.502 802.293 611.687 801.824C612.88 801.347 614.261 801.108 615.829 801.108C616.92 801.108 617.964 801.236 618.961 801.491C619.967 801.747 620.857 802.143 621.633 802.68C622.417 803.217 623.035 803.908 623.486 804.751C623.938 805.587 624.164 806.588 624.164 807.756V821H618.999V818.277H618.846C618.53 818.891 618.109 819.432 617.58 819.901C617.052 820.361 616.417 820.723 615.675 820.987C614.934 821.243 614.077 821.371 613.106 821.371ZM614.665 817.612C615.467 817.612 616.174 817.455 616.788 817.139C617.401 816.815 617.883 816.381 618.232 815.835C618.582 815.29 618.756 814.672 618.756 813.982V811.898C618.586 812.009 618.351 812.111 618.053 812.205C617.763 812.29 617.435 812.371 617.069 812.447C616.702 812.516 616.336 812.58 615.969 812.639C615.603 812.69 615.27 812.737 614.972 812.78C614.333 812.874 613.775 813.023 613.297 813.227C612.82 813.432 612.449 813.709 612.185 814.058C611.921 814.399 611.789 814.825 611.789 815.337C611.789 816.078 612.057 816.645 612.594 817.037C613.14 817.42 613.83 817.612 614.665 817.612ZM627.771 821V794.818H633.217V804.662H633.384C633.622 804.134 633.967 803.597 634.419 803.051C634.879 802.497 635.476 802.037 636.209 801.67C636.95 801.295 637.871 801.108 638.97 801.108C640.402 801.108 641.723 801.483 642.933 802.233C644.144 802.974 645.111 804.095 645.835 805.595C646.56 807.087 646.922 808.957 646.922 811.207C646.922 813.398 646.568 815.247 645.861 816.756C645.162 818.256 644.207 819.393 642.997 820.169C641.796 820.936 640.449 821.32 638.957 821.32C637.901 821.32 637.001 821.145 636.26 820.795C635.527 820.446 634.926 820.007 634.457 819.479C633.989 818.942 633.631 818.401 633.384 817.855H633.141V821H627.771ZM633.102 811.182C633.102 812.349 633.264 813.368 633.588 814.237C633.912 815.107 634.381 815.784 634.994 816.27C635.608 816.747 636.354 816.986 637.232 816.986C638.118 816.986 638.868 816.743 639.482 816.257C640.095 815.763 640.56 815.081 640.875 814.212C641.199 813.334 641.361 812.324 641.361 811.182C641.361 810.048 641.203 809.051 640.888 808.19C640.572 807.33 640.108 806.656 639.494 806.17C638.881 805.685 638.126 805.442 637.232 805.442C636.345 805.442 635.595 805.676 634.982 806.145C634.376 806.614 633.912 807.278 633.588 808.139C633.264 809 633.102 810.014 633.102 811.182ZM649.836 821V801.364H655.282V821H649.836ZM652.572 798.832C651.762 798.832 651.067 798.564 650.488 798.027C649.917 797.482 649.631 796.83 649.631 796.071C649.631 795.321 649.917 794.678 650.488 794.141C651.067 793.595 651.762 793.322 652.572 793.322C653.381 793.322 654.072 793.595 654.643 794.141C655.222 794.678 655.512 795.321 655.512 796.071C655.512 796.83 655.222 797.482 654.643 798.027C654.072 798.564 653.381 798.832 652.572 798.832ZM664.37 794.818V821H658.924V794.818H664.37ZM668.013 821V801.364H673.459V821H668.013ZM670.749 798.832C669.939 798.832 669.245 798.564 668.665 798.027C668.094 797.482 667.808 796.83 667.808 796.071C667.808 795.321 668.094 794.678 668.665 794.141C669.245 793.595 669.939 793.322 670.749 793.322C671.558 793.322 672.249 793.595 672.82 794.141C673.399 794.678 673.689 795.321 673.689 796.071C673.689 796.83 673.399 797.482 672.82 798.027C672.249 798.564 671.558 798.832 670.749 798.832ZM687.546 801.364V805.455H675.721V801.364H687.546ZM678.406 796.659H683.852V814.966C683.852 815.469 683.928 815.861 684.082 816.142C684.235 816.415 684.448 816.607 684.721 816.717C685.002 816.828 685.326 816.884 685.692 816.884C685.948 816.884 686.204 816.862 686.46 816.82C686.715 816.768 686.911 816.73 687.048 816.705L687.904 820.757C687.631 820.842 687.248 820.94 686.754 821.051C686.259 821.17 685.658 821.243 684.951 821.268C683.639 821.32 682.488 821.145 681.499 820.744C680.519 820.344 679.756 819.722 679.211 818.878C678.665 818.034 678.397 816.969 678.406 815.682V796.659ZM693.736 828.364C693.046 828.364 692.398 828.308 691.793 828.197C691.196 828.095 690.702 827.963 690.31 827.801L691.537 823.736C692.176 823.932 692.752 824.038 693.263 824.055C693.783 824.072 694.23 823.953 694.605 823.697C694.989 823.442 695.3 823.007 695.539 822.393L695.858 821.562L688.814 801.364H694.541L698.607 815.784H698.811L702.915 801.364H708.681L701.048 823.122C700.682 824.179 700.183 825.099 699.553 825.884C698.931 826.676 698.142 827.286 697.188 827.712C696.233 828.146 695.083 828.364 693.736 828.364Z" fill="black"/>
+<path d="M1099.12 468.121C1100.29 466.95 1100.29 465.05 1099.12 463.879L1080.03 444.787C1078.86 443.615 1076.96 443.615 1075.79 444.787C1074.62 445.958 1074.62 447.858 1075.79 449.029L1092.76 466L1075.79 482.971C1074.62 484.142 1074.62 486.042 1075.79 487.213C1076.96 488.385 1078.86 488.385 1080.03 487.213L1099.12 468.121ZM725 466V469H1097V466V463H725V466Z" fill="black"/>
+<path d="M908.867 865.379C907.695 866.55 907.695 868.45 908.867 869.621L927.958 888.713C929.13 889.885 931.03 889.885 932.201 888.713C933.373 887.542 933.373 885.642 932.201 884.471L915.231 867.5L932.201 850.529C933.373 849.358 933.373 847.458 932.201 846.287C931.03 845.115 929.13 845.115 927.958 846.287L908.867 865.379ZM1097.01 867.5V864.5L910.988 864.5V867.5V870.5L1097.01 870.5V867.5Z" fill="black"/>
+<path d="M501.707 398.707C502.098 398.317 502.098 397.683 501.707 397.293L495.343 390.929C494.953 390.538 494.319 390.538 493.929 390.929C493.538 391.319 493.538 391.953 493.929 392.343L499.586 398L493.929 403.657C493.538 404.047 493.538 404.681 493.929 405.071C494.319 405.462 494.953 405.462 495.343 405.071L501.707 398.707ZM451 398V399H501V398V397H451V398Z" fill="black"/>
+<path d="M501.707 530.707C502.098 530.317 502.098 529.683 501.707 529.293L495.343 522.929C494.953 522.538 494.319 522.538 493.929 522.929C493.538 523.319 493.538 523.953 493.929 524.343L499.586 530L493.929 535.657C493.538 536.047 493.538 536.681 493.929 537.071C494.319 537.462 494.953 537.462 495.343 537.071L501.707 530.707ZM451 530V531H501V530V529H451V530Z" fill="black"/>
+<path d="M501.707 659.707C502.098 659.317 502.098 658.683 501.707 658.293L495.343 651.929C494.953 651.538 494.319 651.538 493.929 651.929C493.538 652.319 493.538 652.953 493.929 653.343L499.586 659L493.929 664.657C493.538 665.047 493.538 665.681 493.929 666.071C494.319 666.462 494.953 666.462 495.343 666.071L501.707 659.707ZM451 659V660H501V659V658H451V659Z" fill="black"/>
+<path d="M465 892.5H502C503.933 892.5 505.5 894.067 505.5 896V932C505.5 933.933 503.933 935.5 502 935.5H465C463.067 935.5 461.5 933.933 461.5 932V896C461.5 894.067 463.067 892.5 465 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M490.563 897.591L482.126 928.938H477.434L485.871 897.591H490.563Z" fill="black"/>
+<path d="M261 894.5H298C299.933 894.5 301.5 896.067 301.5 898V934C301.5 935.933 299.933 937.5 298 937.5H261C259.067 937.5 257.5 935.933 257.5 934V898C257.5 896.067 259.067 894.5 261 894.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M269.993 927.332C269.149 927.332 268.424 927.034 267.819 926.438C267.223 925.832 266.924 925.108 266.924 924.264C266.924 923.429 267.223 922.713 267.819 922.116C268.424 921.52 269.149 921.222 269.993 921.222C270.811 921.222 271.527 921.52 272.14 922.116C272.754 922.713 273.061 923.429 273.061 924.264C273.061 924.827 272.916 925.342 272.626 925.811C272.345 926.271 271.974 926.642 271.514 926.923C271.054 927.196 270.547 927.332 269.993 927.332ZM279.995 927.332C279.151 927.332 278.427 927.034 277.822 926.438C277.225 925.832 276.927 925.108 276.927 924.264C276.927 923.429 277.225 922.713 277.822 922.116C278.427 921.52 279.151 921.222 279.995 921.222C280.813 921.222 281.529 921.52 282.143 922.116C282.757 922.713 283.063 923.429 283.063 924.264C283.063 924.827 282.919 925.342 282.629 925.811C282.347 926.271 281.977 926.642 281.517 926.923C281.056 927.196 280.549 927.332 279.995 927.332ZM289.998 927.332C289.154 927.332 288.43 927.034 287.825 926.438C287.228 925.832 286.93 925.108 286.93 924.264C286.93 923.429 287.228 922.713 287.825 922.116C288.43 921.52 289.154 921.222 289.998 921.222C290.816 921.222 291.532 921.52 292.146 922.116C292.759 922.713 293.066 923.429 293.066 924.264C293.066 924.827 292.921 925.342 292.631 925.811C292.35 926.271 291.979 926.642 291.519 926.923C291.059 927.196 290.552 927.332 289.998 927.332Z" fill="black"/>
+<path d="M689 892.5H726C727.933 892.5 729.5 894.067 729.5 896V932C729.5 933.933 727.933 935.5 726 935.5H689C687.067 935.5 685.5 933.933 685.5 932V896C685.5 894.067 687.067 892.5 689 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M699 916.78V912.28L717 904.354V909.531L704.676 914.479L704.842 914.21V914.849L704.676 914.581L717 919.528V924.706L699 916.78Z" fill="black"/>
+<rect x="538" y="334" width="152" height="261" rx="2" stroke="black" stroke-width="4"/>
+<rect x="526" y="843" width="346" height="141" rx="6" stroke="black" stroke-width="4"/>
+<defs>
+<clipPath id="clip0_13_16078">
+<rect width="212" height="217" fill="white" transform="translate(1152 383)"/>
+</clipPath>
+<clipPath id="clip1_13_16078">
+<rect width="95" height="95" fill="white" transform="translate(566 609)"/>
+</clipPath>
+<clipPath id="clip2_13_16078">
+<rect width="212" height="217" fill="white" transform="translate(1656 383)"/>
+</clipPath>
+</defs>
+</svg>

--- a/docs/source/_static/separability-overview.svg
+++ b/docs/source/_static/separability-overview.svg
@@ -1,0 +1,3541 @@
+<svg width="2040" height="1040" viewBox="0 0 2040 1040" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="91" width="2036" height="947" rx="32" fill="white" stroke="black" stroke-width="4"/>
+<path d="M469.493 751.332C468.649 751.332 467.924 751.034 467.319 750.438C466.723 749.832 466.424 749.108 466.424 748.264C466.424 747.429 466.723 746.713 467.319 746.116C467.924 745.52 468.649 745.222 469.493 745.222C470.311 745.222 471.027 745.52 471.64 746.116C472.254 746.713 472.561 747.429 472.561 748.264C472.561 748.827 472.416 749.342 472.126 749.811C471.845 750.271 471.474 750.642 471.014 750.923C470.554 751.196 470.047 751.332 469.493 751.332ZM479.495 751.332C478.651 751.332 477.927 751.034 477.322 750.438C476.725 749.832 476.427 749.108 476.427 748.264C476.427 747.429 476.725 746.713 477.322 746.116C477.927 745.52 478.651 745.222 479.495 745.222C480.313 745.222 481.029 745.52 481.643 746.116C482.257 746.713 482.563 747.429 482.563 748.264C482.563 748.827 482.419 749.342 482.129 749.811C481.847 750.271 481.477 750.642 481.017 750.923C480.556 751.196 480.049 751.332 479.495 751.332ZM489.498 751.332C488.654 751.332 487.93 751.034 487.325 750.438C486.728 749.832 486.43 749.108 486.43 748.264C486.43 747.429 486.728 746.713 487.325 746.116C487.93 745.52 488.654 745.222 489.498 745.222C490.316 745.222 491.032 745.52 491.646 746.116C492.259 746.713 492.566 747.429 492.566 748.264C492.566 748.827 492.421 749.342 492.131 749.811C491.85 750.271 491.479 750.642 491.019 750.923C490.559 751.196 490.052 751.332 489.498 751.332Z" fill="black"/>
+<rect x="1044" y="235" width="945" height="675" rx="32" fill="white" stroke="black" stroke-width="4"/>
+<mask id="mask0_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1726" y="775" width="112" height="114">
+<path d="M1726 888.037H1837V775H1726V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_13_16077)">
+<mask id="mask1_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_13_16077)">
+<path d="M1822.72 831.52L1817.2 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask2_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_13_16077)">
+<path d="M1822.72 831.52L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask3_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_13_16077)">
+<path d="M1822.72 831.52L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask4_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_13_16077)">
+<path d="M1822.72 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask5_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_13_16077)">
+<path d="M1817.2 810.532L1802.11 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask6_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_13_16077)">
+<path d="M1817.2 810.532L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask7_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_13_16077)">
+<path d="M1817.2 810.532L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask8_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_13_16077)">
+<path d="M1802.11 795.168L1781.5 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask9_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_13_16077)">
+<path d="M1760.89 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask10_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_13_16077)">
+<path d="M1760.89 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask11_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_13_16077)">
+<path d="M1760.89 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask12_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_13_16077)">
+<path d="M1745.8 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask13_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_13_16077)">
+<path d="M1745.8 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask14_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_13_16077)">
+<path d="M1745.8 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask15_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_13_16077)">
+<path d="M1740.28 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask16_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_13_16077)">
+<path d="M1760.89 867.872L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask17_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_13_16077)">
+<path d="M1760.89 867.872H1802.11" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask18_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_13_16077)">
+<path d="M1760.89 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask19_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_13_16077)">
+<path d="M1781.5 873.495L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask20_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_13_16077)">
+<path d="M1781.5 873.495L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask21_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_13_16077)">
+<path d="M1802.11 867.872L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask22_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_13_16077)">
+<path d="M1822.72 831.52L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask23_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_13_16077)">
+<path d="M1822.72 831.52L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask24_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_13_16077)">
+<path d="M1822.72 831.52L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask25_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_13_16077)">
+<path d="M1822.72 831.52L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask26_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask26_13_16077)">
+<path d="M1822.72 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask27_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask27_13_16077)">
+<path d="M1822.72 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask28_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask28_13_16077)">
+<path d="M1822.72 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask29_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask29_13_16077)">
+<path d="M1817.2 810.532H1745.8" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask30_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask30_13_16077)">
+<path d="M1817.2 810.532L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask31_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask31_13_16077)">
+<path d="M1817.2 810.532L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask32_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask32_13_16077)">
+<path d="M1817.2 810.532L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask33_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask33_13_16077)">
+<path d="M1817.2 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask34_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask34_13_16077)">
+<path d="M1817.2 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask35_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask35_13_16077)">
+<path d="M1817.2 810.532V852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask36_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask36_13_16077)">
+<path d="M1802.11 795.168H1760.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask37_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask37_13_16077)">
+<path d="M1802.11 795.168L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask38_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask38_13_16077)">
+<path d="M1802.11 795.168L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask39_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask39_13_16077)">
+<path d="M1802.11 795.168L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask40_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask40_13_16077)">
+<path d="M1802.11 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask41_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask41_13_16077)">
+<path d="M1802.11 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask42_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask42_13_16077)">
+<path d="M1802.11 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask43_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask43_13_16077)">
+<path d="M1802.11 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask44_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask44_13_16077)">
+<path d="M1781.5 789.544L1760.89 795.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask45_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask45_13_16077)">
+<path d="M1781.5 789.544L1745.8 810.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask46_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask46_13_16077)">
+<path d="M1781.5 789.544L1740.28 831.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask47_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask47_13_16077)">
+<path d="M1781.5 789.544L1745.8 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask48_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask48_13_16077)">
+<path d="M1781.5 789.544L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask49_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask49_13_16077)">
+<path d="M1781.5 789.544V873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask50_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask50_13_16077)">
+<path d="M1781.5 789.544L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask51_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask51_13_16077)">
+<path d="M1781.5 789.544L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask52_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask52_13_16077)">
+<path d="M1760.89 795.168L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask53_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask53_13_16077)">
+<path d="M1760.89 795.168L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask54_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask54_13_16077)">
+<path d="M1760.89 795.168L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask55_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask55_13_16077)">
+<path d="M1760.89 795.168L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask56_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask56_13_16077)">
+<path d="M1745.8 810.532L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask57_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask57_13_16077)">
+<path d="M1745.8 810.532L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask58_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask58_13_16077)">
+<path d="M1745.8 810.532L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask59_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask59_13_16077)">
+<path d="M1740.28 831.52L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask60_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask60_13_16077)">
+<path d="M1740.28 831.52L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask61_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask61_13_16077)">
+<path d="M1740.28 831.52L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask62_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask62_13_16077)">
+<path d="M1740.28 831.52L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask63_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask63_13_16077)">
+<path d="M1745.8 852.508L1760.89 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask64_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask64_13_16077)">
+<path d="M1745.8 852.508L1781.5 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask65_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask65_13_16077)">
+<path d="M1745.8 852.508L1802.11 867.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask66_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask66_13_16077)">
+<path d="M1745.8 852.508L1817.2 852.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask67_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask67_13_16077)">
+<mask id="mask68_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1817" y="826" width="11" height="11">
+<path d="M1817.77 836.568H1827.68V826.472H1817.77V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask68_13_16077)">
+<path d="M1822.72 836.045C1823.9 836.045 1825.03 835.568 1825.87 834.72C1826.7 833.871 1827.17 832.72 1827.17 831.52C1827.17 830.32 1826.7 829.168 1825.87 828.32C1825.03 827.471 1823.9 826.994 1822.72 826.994C1821.54 826.994 1820.41 827.471 1819.58 828.32C1818.75 829.168 1818.28 830.32 1818.28 831.52C1818.28 832.72 1818.75 833.871 1819.58 834.72C1820.41 835.568 1821.54 836.045 1822.72 836.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask69_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask69_13_16077)">
+<mask id="mask70_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="805" width="11" height="11">
+<path d="M1812.24 815.58H1822.16V805.484H1812.24V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask70_13_16077)">
+<path d="M1817.2 815.057C1818.38 815.057 1819.51 814.58 1820.34 813.732C1821.18 812.883 1821.64 811.732 1821.64 810.532C1821.64 809.332 1821.18 808.181 1820.34 807.332C1819.51 806.483 1818.38 806.007 1817.2 806.007C1816.02 806.007 1814.89 806.483 1814.06 807.332C1813.22 808.181 1812.76 809.332 1812.76 810.532C1812.76 811.732 1813.22 812.883 1814.06 813.732C1814.89 814.58 1816.02 815.057 1817.2 815.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask71_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask71_13_16077)">
+<mask id="mask72_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="790" width="11" height="11">
+<path d="M1797.15 800.215H1807.07V790.12H1797.15V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask72_13_16077)">
+<path d="M1802.11 799.693C1803.29 799.693 1804.42 799.216 1805.25 798.367C1806.09 797.519 1806.56 796.368 1806.56 795.168C1806.56 793.967 1806.09 792.816 1805.25 791.968C1804.42 791.119 1803.29 790.642 1802.11 790.642C1800.93 790.642 1799.8 791.119 1798.97 791.968C1798.14 792.816 1797.67 793.967 1797.67 795.168C1797.67 796.368 1798.14 797.519 1798.97 798.367C1799.8 799.216 1800.93 799.693 1802.11 799.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask73_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask73_13_16077)">
+<mask id="mask74_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="784" width="11" height="11">
+<path d="M1776.54 794.592H1786.46V784.496H1776.54V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask74_13_16077)">
+<path d="M1781.5 794.069C1782.68 794.069 1783.81 793.592 1784.64 792.744C1785.48 791.895 1785.95 790.744 1785.95 789.544C1785.95 788.344 1785.48 787.193 1784.64 786.344C1783.81 785.495 1782.68 785.019 1781.5 785.019C1780.32 785.019 1779.19 785.495 1778.36 786.344C1777.53 787.193 1777.06 788.344 1777.06 789.544C1777.06 790.744 1777.53 791.895 1778.36 792.744C1779.19 793.592 1780.32 794.069 1781.5 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask75_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask75_13_16077)">
+<mask id="mask76_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="790" width="11" height="11">
+<path d="M1755.93 800.215H1765.85V790.12H1755.93V800.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask76_13_16077)">
+<path d="M1760.89 799.693C1762.07 799.693 1763.2 799.216 1764.03 798.367C1764.87 797.519 1765.33 796.368 1765.33 795.168C1765.33 793.967 1764.87 792.816 1764.03 791.968C1763.2 791.119 1762.07 790.642 1760.89 790.642C1759.71 790.642 1758.58 791.119 1757.75 791.968C1756.91 792.816 1756.45 793.967 1756.45 795.168C1756.45 796.368 1756.91 797.519 1757.75 798.367C1758.58 799.216 1759.71 799.693 1760.89 799.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask77_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask77_13_16077)">
+<mask id="mask78_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="805" width="11" height="11">
+<path d="M1740.85 815.58H1750.76V805.484H1740.85V815.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask78_13_16077)">
+<path d="M1745.8 815.057C1746.98 815.057 1748.11 814.58 1748.94 813.732C1749.78 812.883 1750.25 811.732 1750.25 810.532C1750.25 809.332 1749.78 808.181 1748.94 807.332C1748.11 806.483 1746.98 806.007 1745.8 806.007C1744.62 806.007 1743.49 806.483 1742.66 807.332C1741.83 808.181 1741.36 809.332 1741.36 810.532C1741.36 811.732 1741.83 812.883 1742.66 813.732C1743.49 814.58 1744.62 815.057 1745.8 815.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask79_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask79_13_16077)">
+<mask id="mask80_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1735" y="826" width="11" height="11">
+<path d="M1735.32 836.568H1745.24V826.472H1735.32V836.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask80_13_16077)">
+<path d="M1740.28 836.045C1741.46 836.045 1742.59 835.568 1743.42 834.72C1744.26 833.871 1744.72 832.72 1744.72 831.52C1744.72 830.32 1744.26 829.168 1743.42 828.32C1742.59 827.471 1741.46 826.994 1740.28 826.994C1739.1 826.994 1737.97 827.471 1737.14 828.32C1736.3 829.168 1735.84 830.32 1735.84 831.52C1735.84 832.72 1736.3 833.871 1737.14 834.72C1737.97 835.568 1739.1 836.045 1740.28 836.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask81_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask81_13_16077)">
+<mask id="mask82_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1740" y="847" width="11" height="11">
+<path d="M1740.85 857.555H1750.76V847.46H1740.85V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask82_13_16077)">
+<path d="M1745.8 857.033C1746.98 857.033 1748.11 856.556 1748.94 855.708C1749.78 854.859 1750.25 853.708 1750.25 852.508C1750.25 851.308 1749.78 850.156 1748.94 849.308C1748.11 848.459 1746.98 847.982 1745.8 847.982C1744.62 847.982 1743.49 848.459 1742.66 849.308C1741.83 850.156 1741.36 851.308 1741.36 852.508C1741.36 853.708 1741.83 854.859 1742.66 855.708C1743.49 856.556 1744.62 857.033 1745.8 857.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask83_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask83_13_16077)">
+<mask id="mask84_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1755" y="862" width="11" height="11">
+<path d="M1755.93 872.92H1765.85V862.824H1755.93V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask84_13_16077)">
+<path d="M1760.89 872.397C1762.07 872.397 1763.2 871.92 1764.03 871.072C1764.87 870.223 1765.33 869.072 1765.33 867.872C1765.33 866.672 1764.87 865.521 1764.03 864.672C1763.2 863.823 1762.07 863.347 1760.89 863.347C1759.71 863.347 1758.58 863.823 1757.75 864.672C1756.91 865.521 1756.45 866.672 1756.45 867.872C1756.45 869.072 1756.91 870.223 1757.75 871.072C1758.58 871.92 1759.71 872.397 1760.89 872.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask85_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask85_13_16077)">
+<mask id="mask86_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1776" y="868" width="11" height="11">
+<path d="M1776.54 878.543H1786.46V868.448H1776.54V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask86_13_16077)">
+<path d="M1781.5 878.021C1782.68 878.021 1783.81 877.544 1784.64 876.695C1785.48 875.847 1785.95 874.696 1785.95 873.496C1785.95 872.295 1785.48 871.144 1784.64 870.296C1783.81 869.447 1782.68 868.97 1781.5 868.97C1780.32 868.97 1779.19 869.447 1778.36 870.296C1777.53 871.144 1777.06 872.295 1777.06 873.496C1777.06 874.696 1777.53 875.847 1778.36 876.695C1779.19 877.544 1780.32 878.021 1781.5 878.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask87_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask87_13_16077)">
+<mask id="mask88_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1797" y="862" width="11" height="11">
+<path d="M1797.15 872.92H1807.07V862.824H1797.15V872.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask88_13_16077)">
+<path d="M1802.11 872.397C1803.29 872.397 1804.42 871.92 1805.25 871.072C1806.09 870.223 1806.56 869.072 1806.56 867.872C1806.56 866.672 1806.09 865.521 1805.25 864.672C1804.42 863.823 1803.29 863.347 1802.11 863.347C1800.93 863.347 1799.8 863.823 1798.97 864.672C1798.14 865.521 1797.67 866.672 1797.67 867.872C1797.67 869.072 1798.14 870.223 1798.97 871.072C1799.8 871.92 1800.93 872.397 1802.11 872.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask89_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask89_13_16077)">
+<mask id="mask90_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1812" y="847" width="11" height="11">
+<path d="M1812.24 857.555H1822.16V847.46H1812.24V857.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask90_13_16077)">
+<path d="M1817.2 857.033C1818.38 857.033 1819.51 856.556 1820.34 855.708C1821.18 854.859 1821.64 853.708 1821.64 852.508C1821.64 851.308 1821.18 850.156 1820.34 849.308C1819.51 848.459 1818.38 847.982 1817.2 847.982C1816.02 847.982 1814.89 848.459 1814.06 849.308C1813.22 850.156 1812.76 851.308 1812.76 852.508C1812.76 853.708 1813.22 854.859 1814.06 855.708C1814.89 856.556 1816.02 857.033 1817.2 857.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask91_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask91_13_16077)">
+<path d="M1822.77 828.274C1822.36 828.274 1822.07 828.389 1821.79 828.642C1821.39 829.057 1821.12 829.885 1821.12 830.737C1821.12 831.542 1821.34 832.394 1821.68 832.808C1821.95 833.13 1822.31 833.291 1822.72 833.291C1823.08 833.291 1823.4 833.176 1823.65 832.923C1824.08 832.532 1824.35 831.68 1824.35 830.783C1824.35 829.287 1823.69 828.274 1822.77 828.274ZM1822.74 828.458C1823.33 828.458 1823.65 829.287 1823.65 830.806C1823.65 832.325 1823.35 833.107 1822.72 833.107C1822.11 833.107 1821.79 832.325 1821.79 830.806C1821.79 829.264 1822.11 828.458 1822.74 828.458Z" fill="white"/>
+</g>
+<mask id="mask92_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask92_13_16077)">
+<path d="M1817.49 807.291L1816.2 807.959V808.051C1816.29 808.005 1816.36 807.982 1816.4 807.982C1816.52 807.913 1816.65 807.89 1816.72 807.89C1816.88 807.89 1816.95 808.005 1816.95 808.235V811.549C1816.95 811.779 1816.88 811.94 1816.77 812.009C1816.65 812.078 1816.56 812.101 1816.25 812.101V812.216H1818.24V812.101C1817.67 812.101 1817.56 812.032 1817.56 811.687V807.291H1817.49Z" fill="white"/>
+</g>
+<mask id="mask93_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask93_13_16077)">
+<path d="M1803.74 795.859L1803.62 795.813C1803.38 796.228 1803.29 796.297 1802.95 796.297H1801.25L1802.45 795.008C1803.08 794.34 1803.35 793.788 1803.35 793.213C1803.35 792.476 1802.79 791.924 1802.04 791.924C1801.64 791.924 1801.27 792.085 1801 792.361C1800.78 792.614 1800.66 792.844 1800.55 793.374L1800.69 793.397C1800.98 792.683 1801.25 792.453 1801.73 792.453C1802.34 792.453 1802.74 792.868 1802.74 793.489C1802.74 794.064 1802.43 794.732 1801.82 795.376L1800.55 796.757V796.849H1803.33L1803.74 795.859Z" fill="white"/>
+</g>
+<mask id="mask94_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask94_13_16077)">
+<path d="M1780.82 788.811C1781.23 788.811 1781.39 788.834 1781.57 788.903C1782.02 789.065 1782.29 789.479 1782.29 789.985C1782.29 790.583 1781.88 791.067 1781.36 791.067C1781.16 791.067 1781.02 791.021 1780.75 790.837C1780.53 790.698 1780.41 790.652 1780.3 790.652C1780.12 790.652 1780.03 790.768 1780.03 790.906C1780.03 791.159 1780.32 791.32 1780.82 791.32C1781.39 791.32 1781.95 791.136 1782.29 790.837C1782.63 790.537 1782.81 790.123 1782.81 789.64C1782.81 789.249 1782.7 788.926 1782.49 788.696C1782.33 788.535 1782.2 788.443 1781.88 788.305C1782.38 787.96 1782.56 787.684 1782.56 787.292C1782.56 786.694 1782.11 786.303 1781.45 786.303C1781.09 786.303 1780.78 786.418 1780.53 786.648C1780.3 786.855 1780.19 787.039 1780.03 787.477L1780.14 787.5C1780.44 786.97 1780.75 786.74 1781.2 786.74C1781.68 786.74 1782 787.062 1782 787.523C1782 787.776 1781.88 788.029 1781.7 788.213C1781.5 788.443 1781.3 788.558 1780.82 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask95_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask95_13_16077)">
+<path d="M1762.49 795.169H1761.75V791.924H1761.43L1759.19 795.169V795.629H1761.2V796.849H1761.75V795.629H1762.49V795.169ZM1761.2 795.169H1759.46L1761.2 792.66V795.169Z" fill="white"/>
+</g>
+<mask id="mask96_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask96_13_16077)">
+<path d="M1745.3 807.959H1746.72C1746.84 807.959 1746.86 807.959 1746.88 807.89L1747.15 807.245L1747.08 807.199C1746.97 807.36 1746.9 807.383 1746.75 807.383H1745.25L1744.49 809.109C1744.46 809.132 1744.46 809.132 1744.46 809.156C1744.46 809.179 1744.51 809.202 1744.55 809.202C1744.78 809.202 1745.07 809.271 1745.37 809.363C1746.18 809.616 1746.56 810.076 1746.56 810.812C1746.56 811.503 1746.13 812.055 1745.57 812.055C1745.43 812.055 1745.3 811.986 1745.1 811.848C1744.87 811.664 1744.69 811.595 1744.55 811.595C1744.35 811.595 1744.24 811.687 1744.24 811.871C1744.24 812.147 1744.58 812.308 1745.12 812.308C1745.71 812.308 1746.23 812.124 1746.59 811.756C1746.93 811.411 1747.06 810.997 1747.06 810.444C1747.06 809.915 1746.93 809.593 1746.56 809.225C1746.27 808.902 1745.84 808.741 1745 808.58L1745.3 807.959Z" fill="white"/>
+</g>
+<mask id="mask97_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask97_13_16077)">
+<path d="M1741.68 828.205C1740.86 828.274 1740.46 828.412 1739.94 828.803C1739.15 829.356 1738.74 830.184 1738.74 831.174C1738.74 831.795 1738.92 832.44 1739.24 832.808C1739.51 833.13 1739.89 833.291 1740.34 833.291C1741.22 833.291 1741.84 832.601 1741.84 831.611C1741.84 830.668 1741.32 830.069 1740.5 830.069C1740.19 830.069 1740.03 830.138 1739.58 830.414C1739.78 829.31 1740.57 828.504 1741.7 828.32L1741.68 828.205ZM1740.23 830.414C1740.84 830.414 1741.2 830.944 1741.2 831.841C1741.2 832.647 1740.91 833.107 1740.41 833.107C1739.78 833.107 1739.39 832.417 1739.39 831.289C1739.39 830.898 1739.46 830.714 1739.6 830.599C1739.76 830.483 1739.98 830.414 1740.23 830.414Z" fill="white"/>
+</g>
+<mask id="mask98_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask98_13_16077)">
+<path d="M1747.22 849.355H1744.58L1744.15 850.436L1744.28 850.482C1744.58 849.999 1744.71 849.907 1745.12 849.907H1746.65L1745.25 854.257H1745.71L1747.22 849.47V849.355Z" fill="white"/>
+</g>
+<mask id="mask99_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask99_13_16077)">
+<path d="M1761.18 866.839C1761.88 866.471 1762.13 866.149 1762.13 865.666C1762.13 865.067 1761.63 864.63 1760.91 864.63C1760.12 864.63 1759.55 865.113 1759.55 865.781C1759.55 866.241 1759.69 866.471 1760.44 867.139C1759.67 867.737 1759.51 867.967 1759.51 868.45C1759.51 869.164 1760.07 869.647 1760.89 869.647C1761.75 869.647 1762.29 869.187 1762.29 868.427C1762.29 867.852 1762.04 867.507 1761.18 866.839ZM1761.05 867.599C1761.57 867.99 1761.75 868.243 1761.75 868.657C1761.75 869.118 1761.43 869.463 1760.95 869.463C1760.41 869.463 1760.05 869.026 1760.05 868.404C1760.05 867.921 1760.21 867.622 1760.62 867.277L1761.05 867.599ZM1760.98 866.724C1760.34 866.287 1760.07 865.965 1760.07 865.551C1760.07 865.136 1760.39 864.837 1760.84 864.837C1761.34 864.837 1761.66 865.159 1761.66 865.643C1761.66 866.057 1761.45 866.402 1761.05 866.678C1761 866.701 1761 866.701 1760.98 866.724Z" fill="white"/>
+</g>
+<mask id="mask100_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask100_13_16077)">
+<path d="M1780.14 875.337C1780.93 875.245 1781.34 875.107 1781.81 874.739C1782.56 874.187 1783.01 873.289 1783.01 872.299C1783.01 871.103 1782.33 870.251 1781.41 870.251C1780.57 870.251 1779.94 870.988 1779.94 871.977C1779.94 872.852 1780.44 873.45 1781.23 873.45C1781.61 873.45 1781.91 873.335 1782.29 873.036C1782 874.21 1781.2 874.992 1780.12 875.199L1780.14 875.337ZM1782.31 872.576C1782.31 872.737 1782.27 872.806 1782.2 872.875C1782 873.036 1781.72 873.128 1781.48 873.128C1780.93 873.128 1780.59 872.576 1780.59 871.724C1780.59 871.31 1780.71 870.873 1780.84 870.665C1780.98 870.527 1781.16 870.458 1781.36 870.458C1781.97 870.458 1782.31 871.08 1782.31 872.299V872.576Z" fill="white"/>
+</g>
+<mask id="mask101_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask101_13_16077)">
+<path d="M1800.61 864.63L1799.32 865.297V865.39C1799.41 865.343 1799.48 865.32 1799.53 865.32C1799.64 865.251 1799.78 865.228 1799.84 865.228C1800 865.228 1800.07 865.343 1800.07 865.574V868.888C1800.07 869.118 1800 869.279 1799.89 869.348C1799.78 869.417 1799.69 869.44 1799.37 869.44V869.555H1801.36V869.44C1800.79 869.44 1800.68 869.371 1800.68 869.026V864.63H1800.61ZM1803.94 864.63C1803.53 864.63 1803.24 864.745 1802.97 864.998C1802.56 865.413 1802.29 866.241 1802.29 867.093C1802.29 867.898 1802.52 868.75 1802.86 869.164C1803.13 869.486 1803.49 869.647 1803.9 869.647C1804.26 869.647 1804.57 869.532 1804.82 869.279C1805.25 868.888 1805.52 868.036 1805.52 867.139C1805.52 865.643 1804.87 864.63 1803.94 864.63ZM1803.92 864.814C1804.51 864.814 1804.82 865.643 1804.82 867.162C1804.82 868.68 1804.53 869.463 1803.9 869.463C1803.29 869.463 1802.97 868.68 1802.97 867.162C1802.97 865.62 1803.29 864.814 1803.92 864.814Z" fill="white"/>
+</g>
+<mask id="mask102_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1731" y="780" width="101" height="103">
+<path d="M1731.62 882.31H1831.38V780.729H1731.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask102_13_16077)">
+<path d="M1815.7 849.263L1814.41 849.93V850.022C1814.5 849.976 1814.57 849.953 1814.61 849.953C1814.73 849.884 1814.86 849.861 1814.93 849.861C1815.09 849.861 1815.16 849.976 1815.16 850.206V853.52C1815.16 853.75 1815.09 853.911 1814.98 853.981C1814.86 854.05 1814.77 854.073 1814.46 854.073V854.188H1816.44V854.073C1815.88 854.073 1815.77 854.004 1815.77 853.658V849.263H1815.7ZM1819.28 849.263L1817.99 849.93V850.022C1818.08 849.976 1818.15 849.953 1818.2 849.953C1818.31 849.884 1818.44 849.861 1818.51 849.861C1818.67 849.861 1818.74 849.976 1818.74 850.206V853.52C1818.74 853.75 1818.67 853.911 1818.56 853.981C1818.44 854.05 1818.35 854.073 1818.04 854.073V854.188H1820.03V854.073C1819.46 854.073 1819.35 854.004 1819.35 853.658V849.263H1819.28Z" fill="white"/>
+</g>
+</g>
+<g clip-path="url(#clip0_13_16077)">
+<path d="M1160.83 590.958V383H1152V600H1364V590.958H1160.83Z" fill="#E6711C"/>
+<path d="M1364 464.375H1324.25V572.875H1364V464.375Z" fill="#E6711C"/>
+<path d="M1315.42 482.775H1275.67V572.875H1315.42V482.775Z" fill="#E6711C"/>
+<path d="M1266.83 534.367H1227.08V572.884H1266.83V534.367Z" fill="#E6711C"/>
+<path d="M1218.25 512.26H1178.5V572.884H1218.25V512.26Z" fill="#E6711C"/>
+</g>
+<g clip-path="url(#clip1_13_16077)">
+<path d="M569.958 700.042V609H566V704H661V700.042H569.958Z" fill="#F9D925"/>
+<path d="M661 644.625H643.188V692.125H661V644.625Z" fill="#F9D925"/>
+<path d="M639.229 652.68H621.417V692.125H639.229V652.68Z" fill="#F9D925"/>
+<path d="M617.458 675.267H599.646V692.129H617.458V675.267Z" fill="#F9D925"/>
+<path d="M595.687 665.588H577.875V692.129H595.687V665.588Z" fill="#F9D925"/>
+</g>
+<path d="M569.958 441.042V350H566V445H661V441.042H569.958Z" fill="#E6711C"/>
+<path d="M661 385.625H643.188V433.125H661V385.625Z" fill="#E6711C"/>
+<path d="M639.229 393.68H621.417V433.125H639.229V393.68Z" fill="#E6711C"/>
+<path d="M617.458 416.267H599.646V433.129H617.458V416.267Z" fill="#E6711C"/>
+<path d="M595.687 406.588H577.875V433.129H595.687V406.588Z" fill="#E6711C"/>
+<path d="M569.958 571.042V480H566V575H661V571.042H569.958Z" fill="#5C0B4D"/>
+<path d="M661 515.625H643.188V563.125H661V515.625Z" fill="#5C0B4D"/>
+<path d="M639.229 523.68H621.417V563.125H639.229V523.68Z" fill="#5C0B4D"/>
+<path d="M617.458 546.267H599.646V563.129H617.458V546.267Z" fill="#5C0B4D"/>
+<path d="M595.687 536.588H577.875V563.129H595.687V536.588Z" fill="#5C0B4D"/>
+<g clip-path="url(#clip2_13_16077)">
+<path d="M1664.83 590.958V383H1656V600H1868V590.958H1664.83Z" fill="#5C0B4D"/>
+<path d="M1868 464.375H1828.25V572.875H1868V464.375Z" fill="#5C0B4D"/>
+<path d="M1819.42 482.775H1779.67V572.875H1819.42V482.775Z" fill="#5C0B4D"/>
+<path d="M1770.83 534.367H1731.08V572.884H1770.83V534.367Z" fill="#5C0B4D"/>
+<path d="M1722.25 512.26H1682.5V572.884H1722.25V512.26Z" fill="#5C0B4D"/>
+</g>
+<path d="M1154.25 655V628.818H1164.58C1166.56 628.818 1168.26 629.197 1169.65 629.956C1171.05 630.706 1172.12 631.75 1172.85 633.088C1173.59 634.418 1173.96 635.952 1173.96 637.69C1173.96 639.429 1173.59 640.963 1172.84 642.293C1172.09 643.622 1171 644.658 1169.58 645.399C1168.16 646.141 1166.45 646.511 1164.44 646.511H1157.85V642.075H1163.54C1164.61 642.075 1165.49 641.892 1166.18 641.526C1166.88 641.151 1167.4 640.635 1167.74 639.979C1168.09 639.314 1168.26 638.551 1168.26 637.69C1168.26 636.821 1168.09 636.062 1167.74 635.415C1167.4 634.759 1166.88 634.251 1166.18 633.893C1165.48 633.527 1164.59 633.344 1163.52 633.344H1159.78V655H1154.25ZM1185.37 655.384C1183.35 655.384 1181.61 654.974 1180.15 654.156C1178.7 653.33 1177.59 652.162 1176.8 650.653C1176.02 649.136 1175.63 647.342 1175.63 645.271C1175.63 643.251 1176.02 641.479 1176.8 639.953C1177.59 638.428 1178.69 637.239 1180.11 636.386C1181.55 635.534 1183.22 635.108 1185.15 635.108C1186.45 635.108 1187.65 635.317 1188.77 635.734C1189.89 636.143 1190.87 636.761 1191.71 637.588C1192.55 638.415 1193.21 639.455 1193.68 640.707C1194.15 641.952 1194.38 643.409 1194.38 645.08V646.575H1177.8V643.2H1189.25C1189.25 642.416 1189.08 641.722 1188.74 641.116C1188.4 640.511 1187.93 640.038 1187.32 639.697C1186.73 639.348 1186.03 639.173 1185.24 639.173C1184.41 639.173 1183.68 639.365 1183.04 639.749C1182.41 640.124 1181.92 640.631 1181.56 641.27C1181.2 641.901 1181.02 642.604 1181.01 643.379V646.588C1181.01 647.56 1181.19 648.399 1181.55 649.107C1181.91 649.814 1182.43 650.359 1183.09 650.743C1183.76 651.126 1184.55 651.318 1185.46 651.318C1186.06 651.318 1186.62 651.233 1187.12 651.062C1187.62 650.892 1188.05 650.636 1188.41 650.295C1188.77 649.955 1189.04 649.537 1189.23 649.043L1194.27 649.375C1194.01 650.585 1193.49 651.642 1192.69 652.545C1191.91 653.44 1190.9 654.139 1189.65 654.642C1188.41 655.136 1186.99 655.384 1185.37 655.384ZM1197.21 655V635.364H1202.49V638.79H1202.7C1203.06 637.571 1203.66 636.651 1204.5 636.028C1205.35 635.398 1206.32 635.082 1207.42 635.082C1207.69 635.082 1207.98 635.099 1208.3 635.134C1208.61 635.168 1208.89 635.214 1209.13 635.274V640.107C1208.87 640.03 1208.52 639.962 1208.07 639.902C1207.62 639.842 1207.2 639.812 1206.83 639.812C1206.03 639.812 1205.31 639.987 1204.68 640.337C1204.06 640.678 1203.56 641.155 1203.2 641.768C1202.84 642.382 1202.66 643.089 1202.66 643.891V655H1197.21ZM1222.77 635.364V639.455H1210.65V635.364H1222.77ZM1213.42 655V633.945C1213.42 632.521 1213.7 631.341 1214.26 630.403C1214.82 629.466 1215.58 628.763 1216.56 628.294C1217.53 627.825 1218.63 627.591 1219.87 627.591C1220.7 627.591 1221.47 627.655 1222.16 627.783C1222.85 627.911 1223.37 628.026 1223.72 628.128L1222.74 632.219C1222.53 632.151 1222.27 632.087 1221.95 632.027C1221.64 631.967 1221.33 631.938 1221.01 631.938C1220.2 631.938 1219.65 632.125 1219.33 632.5C1219.02 632.866 1218.86 633.382 1218.86 634.047V655H1213.42ZM1233.55 655.384C1231.56 655.384 1229.84 654.962 1228.39 654.118C1226.95 653.266 1225.84 652.081 1225.06 650.564C1224.27 649.038 1223.88 647.27 1223.88 645.259C1223.88 643.23 1224.27 641.457 1225.06 639.94C1225.84 638.415 1226.95 637.23 1228.39 636.386C1229.84 635.534 1231.56 635.108 1233.55 635.108C1235.53 635.108 1237.24 635.534 1238.68 636.386C1240.13 637.23 1241.25 638.415 1242.03 639.94C1242.82 641.457 1243.21 643.23 1243.21 645.259C1243.21 647.27 1242.82 649.038 1242.03 650.564C1241.25 652.081 1240.13 653.266 1238.68 654.118C1237.24 654.962 1235.53 655.384 1233.55 655.384ZM1233.57 651.165C1234.47 651.165 1235.23 650.909 1235.83 650.398C1236.44 649.878 1236.89 649.17 1237.2 648.276C1237.52 647.381 1237.67 646.362 1237.67 645.22C1237.67 644.078 1237.52 643.06 1237.2 642.165C1236.89 641.27 1236.44 640.562 1235.83 640.043C1235.23 639.523 1234.47 639.263 1233.57 639.263C1232.66 639.263 1231.89 639.523 1231.27 640.043C1230.66 640.562 1230.19 641.27 1229.88 642.165C1229.57 643.06 1229.42 644.078 1229.42 645.22C1229.42 646.362 1229.57 647.381 1229.88 648.276C1230.19 649.17 1230.66 649.878 1231.27 650.398C1231.89 650.909 1232.66 651.165 1233.57 651.165ZM1246.03 655V635.364H1251.31V638.79H1251.52C1251.87 637.571 1252.47 636.651 1253.32 636.028C1254.16 635.398 1255.13 635.082 1256.23 635.082C1256.51 635.082 1256.8 635.099 1257.12 635.134C1257.43 635.168 1257.71 635.214 1257.95 635.274V640.107C1257.69 640.03 1257.34 639.962 1256.89 639.902C1256.43 639.842 1256.02 639.812 1255.64 639.812C1254.84 639.812 1254.13 639.987 1253.5 640.337C1252.88 640.678 1252.38 641.155 1252.01 641.768C1251.66 642.382 1251.48 643.089 1251.48 643.891V655H1246.03ZM1260.04 655V635.364H1265.23V638.828H1265.46C1265.87 637.678 1266.55 636.77 1267.51 636.105C1268.46 635.44 1269.6 635.108 1270.93 635.108C1272.28 635.108 1273.43 635.445 1274.37 636.118C1275.32 636.783 1275.95 637.686 1276.26 638.828H1276.47C1276.87 637.703 1277.59 636.804 1278.64 636.131C1279.7 635.449 1280.95 635.108 1282.39 635.108C1284.22 635.108 1285.71 635.692 1286.85 636.859C1288 638.018 1288.58 639.663 1288.58 641.794V655H1283.14V642.868C1283.14 641.777 1282.85 640.959 1282.27 640.413C1281.69 639.868 1280.97 639.595 1280.1 639.595C1279.11 639.595 1278.34 639.911 1277.79 640.541C1277.23 641.163 1276.96 641.986 1276.96 643.009V655H1271.68V642.753C1271.68 641.79 1271.4 641.023 1270.84 640.452C1270.3 639.881 1269.58 639.595 1268.68 639.595C1268.08 639.595 1267.53 639.749 1267.05 640.055C1266.57 640.354 1266.19 640.776 1265.91 641.321C1265.63 641.858 1265.49 642.489 1265.49 643.213V655H1260.04ZM1297.76 655.371C1296.5 655.371 1295.39 655.153 1294.41 654.719C1293.43 654.276 1292.65 653.624 1292.08 652.763C1291.52 651.893 1291.24 650.811 1291.24 649.516C1291.24 648.425 1291.44 647.509 1291.84 646.767C1292.24 646.026 1292.78 645.429 1293.47 644.977C1294.16 644.526 1294.95 644.185 1295.83 643.955C1296.71 643.724 1297.64 643.562 1298.61 643.469C1299.76 643.349 1300.68 643.239 1301.38 643.136C1302.07 643.026 1302.58 642.864 1302.9 642.651C1303.21 642.437 1303.37 642.122 1303.37 641.705V641.628C1303.37 640.818 1303.11 640.192 1302.6 639.749C1302.1 639.305 1301.38 639.084 1300.45 639.084C1299.47 639.084 1298.69 639.301 1298.12 639.736C1297.54 640.162 1297.15 640.699 1296.96 641.347L1291.93 640.938C1292.18 639.744 1292.69 638.713 1293.44 637.844C1294.19 636.966 1295.15 636.293 1296.34 635.824C1297.53 635.347 1298.91 635.108 1300.48 635.108C1301.57 635.108 1302.62 635.236 1303.61 635.491C1304.62 635.747 1305.51 636.143 1306.28 636.68C1307.07 637.217 1307.69 637.908 1308.14 638.751C1308.59 639.587 1308.82 640.588 1308.82 641.756V655H1303.65V652.277H1303.5C1303.18 652.891 1302.76 653.432 1302.23 653.901C1301.7 654.361 1301.07 654.723 1300.33 654.987C1299.59 655.243 1298.73 655.371 1297.76 655.371ZM1299.32 651.612C1300.12 651.612 1300.83 651.455 1301.44 651.139C1302.05 650.815 1302.53 650.381 1302.88 649.835C1303.23 649.29 1303.41 648.672 1303.41 647.982V645.898C1303.24 646.009 1303 646.111 1302.7 646.205C1302.41 646.29 1302.09 646.371 1301.72 646.447C1301.35 646.516 1300.99 646.58 1300.62 646.639C1300.25 646.69 1299.92 646.737 1299.62 646.78C1298.98 646.874 1298.43 647.023 1297.95 647.227C1297.47 647.432 1297.1 647.709 1296.84 648.058C1296.57 648.399 1296.44 648.825 1296.44 649.337C1296.44 650.078 1296.71 650.645 1297.25 651.037C1297.79 651.42 1298.48 651.612 1299.32 651.612ZM1317.77 643.648V655H1312.32V635.364H1317.51V638.828H1317.74C1318.18 637.686 1318.9 636.783 1319.93 636.118C1320.95 635.445 1322.19 635.108 1323.65 635.108C1325.01 635.108 1326.2 635.406 1327.21 636.003C1328.23 636.599 1329.02 637.452 1329.58 638.56C1330.14 639.659 1330.42 640.972 1330.42 642.497V655H1324.98V643.469C1324.99 642.267 1324.68 641.33 1324.06 640.656C1323.43 639.974 1322.58 639.634 1321.49 639.634C1320.75 639.634 1320.11 639.791 1319.54 640.107C1318.99 640.422 1318.55 640.882 1318.24 641.487C1317.93 642.084 1317.78 642.804 1317.77 643.648ZM1342.87 655.384C1340.86 655.384 1339.13 654.957 1337.68 654.105C1336.24 653.244 1335.13 652.051 1334.35 650.526C1333.59 649 1333.2 647.244 1333.2 645.259C1333.2 643.247 1333.59 641.483 1334.37 639.966C1335.15 638.44 1336.26 637.251 1337.7 636.399C1339.14 635.538 1340.86 635.108 1342.84 635.108C1344.55 635.108 1346.05 635.419 1347.34 636.041C1348.63 636.663 1349.65 637.537 1350.4 638.662C1351.15 639.787 1351.56 641.108 1351.64 642.625H1346.5C1346.35 641.645 1345.97 640.857 1345.35 640.26C1344.73 639.655 1343.93 639.352 1342.93 639.352C1342.09 639.352 1341.35 639.582 1340.72 640.043C1340.1 640.494 1339.61 641.155 1339.26 642.024C1338.91 642.893 1338.74 643.946 1338.74 645.182C1338.74 646.435 1338.91 647.5 1339.25 648.378C1339.6 649.256 1340.09 649.925 1340.72 650.385C1341.35 650.845 1342.09 651.075 1342.93 651.075C1343.55 651.075 1344.11 650.947 1344.61 650.692C1345.11 650.436 1345.52 650.065 1345.85 649.58C1346.18 649.085 1346.4 648.493 1346.5 647.803H1351.64C1351.55 649.303 1351.14 650.624 1350.41 651.766C1349.69 652.899 1348.68 653.786 1347.41 654.425C1346.13 655.064 1344.61 655.384 1342.87 655.384ZM1363.35 655.384C1361.33 655.384 1359.59 654.974 1358.14 654.156C1356.69 653.33 1355.57 652.162 1354.79 650.653C1354 649.136 1353.61 647.342 1353.61 645.271C1353.61 643.251 1354 641.479 1354.79 639.953C1355.57 638.428 1356.68 637.239 1358.1 636.386C1359.53 635.534 1361.21 635.108 1363.14 635.108C1364.43 635.108 1365.64 635.317 1366.75 635.734C1367.88 636.143 1368.86 636.761 1369.69 637.588C1370.54 638.415 1371.19 639.455 1371.66 640.707C1372.13 641.952 1372.37 643.409 1372.37 645.08V646.575H1355.78V643.2H1367.24C1367.24 642.416 1367.07 641.722 1366.73 641.116C1366.39 640.511 1365.91 640.038 1365.31 639.697C1364.71 639.348 1364.02 639.173 1363.23 639.173C1362.4 639.173 1361.67 639.365 1361.03 639.749C1360.4 640.124 1359.9 640.631 1359.54 641.27C1359.19 641.901 1359 642.604 1358.99 643.379V646.588C1358.99 647.56 1359.17 648.399 1359.53 649.107C1359.9 649.814 1360.41 650.359 1361.08 650.743C1361.74 651.126 1362.53 651.318 1363.44 651.318C1364.05 651.318 1364.6 651.233 1365.1 651.062C1365.61 650.892 1366.04 650.636 1366.4 650.295C1366.75 649.955 1367.03 649.537 1367.21 649.043L1372.25 649.375C1371.99 650.585 1371.47 651.642 1370.68 652.545C1369.89 653.44 1368.88 654.139 1367.64 654.642C1366.4 655.136 1364.97 655.384 1363.35 655.384ZM1146.01 703.32C1144.52 703.32 1143.17 702.936 1141.96 702.169C1140.75 701.393 1139.8 700.256 1139.09 698.756C1138.39 697.247 1138.04 695.398 1138.04 693.207C1138.04 690.957 1138.41 689.087 1139.13 687.595C1139.86 686.095 1140.82 684.974 1142.02 684.233C1143.23 683.483 1144.56 683.108 1146 683.108C1147.1 683.108 1148.01 683.295 1148.74 683.67C1149.49 684.037 1150.08 684.497 1150.53 685.051C1150.99 685.597 1151.34 686.134 1151.58 686.662H1151.75V676.818H1157.18V703H1151.81V699.855H1151.58C1151.33 700.401 1150.96 700.942 1150.5 701.479C1150.04 702.007 1149.44 702.446 1148.69 702.795C1147.96 703.145 1147.07 703.32 1146.01 703.32ZM1147.73 698.986C1148.61 698.986 1149.35 698.747 1149.96 698.27C1150.57 697.784 1151.04 697.107 1151.37 696.237C1151.7 695.368 1151.86 694.349 1151.86 693.182C1151.86 692.014 1151.7 691 1151.38 690.139C1151.05 689.278 1150.59 688.614 1149.97 688.145C1149.36 687.676 1148.61 687.442 1147.73 687.442C1146.84 687.442 1146.09 687.685 1145.47 688.17C1144.86 688.656 1144.39 689.33 1144.08 690.19C1143.76 691.051 1143.61 692.048 1143.61 693.182C1143.61 694.324 1143.76 695.334 1144.08 696.212C1144.4 697.081 1144.87 697.763 1145.47 698.257C1146.09 698.743 1146.84 698.986 1147.73 698.986ZM1160.94 703V683.364H1166.39V703H1160.94ZM1163.68 680.832C1162.87 680.832 1162.17 680.564 1161.59 680.027C1161.02 679.482 1160.74 678.83 1160.74 678.071C1160.74 677.321 1161.02 676.678 1161.59 676.141C1162.17 675.595 1162.87 675.322 1163.68 675.322C1164.49 675.322 1165.18 675.595 1165.75 676.141C1166.33 676.678 1166.62 677.321 1166.62 678.071C1166.62 678.83 1166.33 679.482 1165.75 680.027C1165.18 680.564 1164.49 680.832 1163.68 680.832ZM1186.37 688.963L1181.38 689.27C1181.3 688.844 1181.11 688.46 1180.83 688.119C1180.55 687.77 1180.18 687.493 1179.72 687.288C1179.27 687.075 1178.73 686.969 1178.1 686.969C1177.25 686.969 1176.54 687.148 1175.96 687.506C1175.38 687.855 1175.09 688.324 1175.09 688.912C1175.09 689.381 1175.28 689.777 1175.65 690.101C1176.03 690.425 1176.67 690.685 1177.58 690.881L1181.14 691.597C1183.05 691.989 1184.47 692.619 1185.41 693.489C1186.35 694.358 1186.81 695.5 1186.81 696.915C1186.81 698.202 1186.43 699.331 1185.68 700.303C1184.93 701.274 1183.89 702.033 1182.58 702.578C1181.28 703.115 1179.77 703.384 1178.07 703.384C1175.47 703.384 1173.4 702.842 1171.86 701.76C1170.32 700.669 1169.42 699.186 1169.16 697.311L1174.52 697.03C1174.68 697.822 1175.07 698.428 1175.69 698.845C1176.31 699.254 1177.11 699.459 1178.08 699.459C1179.04 699.459 1179.8 699.276 1180.38 698.909C1180.97 698.534 1181.27 698.053 1181.28 697.464C1181.27 696.97 1181.06 696.565 1180.65 696.25C1180.24 695.926 1179.61 695.679 1178.76 695.509L1175.36 694.831C1173.44 694.447 1172.01 693.783 1171.08 692.837C1170.15 691.891 1169.68 690.685 1169.68 689.219C1169.68 687.957 1170.02 686.871 1170.71 685.959C1171.4 685.047 1172.36 684.344 1173.61 683.849C1174.86 683.355 1176.33 683.108 1178.01 683.108C1180.49 683.108 1182.44 683.632 1183.86 684.68C1185.29 685.729 1186.13 687.156 1186.37 688.963ZM1199.97 683.364V687.455H1188.14V683.364H1199.97ZM1190.83 678.659H1196.27V696.966C1196.27 697.469 1196.35 697.861 1196.5 698.142C1196.66 698.415 1196.87 698.607 1197.14 698.717C1197.42 698.828 1197.75 698.884 1198.11 698.884C1198.37 698.884 1198.63 698.862 1198.88 698.82C1199.14 698.768 1199.33 698.73 1199.47 698.705L1200.33 702.757C1200.05 702.842 1199.67 702.94 1199.18 703.051C1198.68 703.17 1198.08 703.243 1197.37 703.268C1196.06 703.32 1194.91 703.145 1193.92 702.744C1192.94 702.344 1192.18 701.722 1191.63 700.878C1191.09 700.034 1190.82 698.969 1190.83 697.682V678.659ZM1202.8 703V683.364H1208.08V686.79H1208.28C1208.64 685.571 1209.24 684.651 1210.08 684.028C1210.93 683.398 1211.9 683.082 1213 683.082C1213.27 683.082 1213.56 683.099 1213.88 683.134C1214.19 683.168 1214.47 683.214 1214.71 683.274V688.107C1214.45 688.03 1214.1 687.962 1213.65 687.902C1213.2 687.842 1212.78 687.812 1212.41 687.812C1211.61 687.812 1210.89 687.987 1210.26 688.337C1209.64 688.678 1209.14 689.155 1208.78 689.768C1208.42 690.382 1208.24 691.089 1208.24 691.891V703H1202.8ZM1216.81 703V683.364H1222.25V703H1216.81ZM1219.54 680.832C1218.73 680.832 1218.04 680.564 1217.46 680.027C1216.89 679.482 1216.6 678.83 1216.6 678.071C1216.6 677.321 1216.89 676.678 1217.46 676.141C1218.04 675.595 1218.73 675.322 1219.54 675.322C1220.35 675.322 1221.04 675.595 1221.61 676.141C1222.19 676.678 1222.48 677.321 1222.48 678.071C1222.48 678.83 1222.19 679.482 1221.61 680.027C1221.04 680.564 1220.35 680.832 1219.54 680.832ZM1226 703V676.818H1231.44V686.662H1231.61C1231.85 686.134 1232.19 685.597 1232.64 685.051C1233.1 684.497 1233.7 684.037 1234.43 683.67C1235.18 683.295 1236.1 683.108 1237.2 683.108C1238.63 683.108 1239.95 683.483 1241.16 684.233C1242.37 684.974 1243.34 686.095 1244.06 687.595C1244.79 689.087 1245.15 690.957 1245.15 693.207C1245.15 695.398 1244.79 697.247 1244.09 698.756C1243.39 700.256 1242.43 701.393 1241.22 702.169C1240.02 702.936 1238.67 703.32 1237.18 703.32C1236.13 703.32 1235.23 703.145 1234.49 702.795C1233.75 702.446 1233.15 702.007 1232.68 701.479C1232.21 700.942 1231.86 700.401 1231.61 699.855H1231.37V703H1226ZM1231.33 693.182C1231.33 694.349 1231.49 695.368 1231.81 696.237C1232.14 697.107 1232.61 697.784 1233.22 698.27C1233.83 698.747 1234.58 698.986 1235.46 698.986C1236.34 698.986 1237.09 698.743 1237.71 698.257C1238.32 697.763 1238.79 697.081 1239.1 696.212C1239.42 695.334 1239.59 694.324 1239.59 693.182C1239.59 692.048 1239.43 691.051 1239.11 690.19C1238.8 689.33 1238.33 688.656 1237.72 688.17C1237.11 687.685 1236.35 687.442 1235.46 687.442C1234.57 687.442 1233.82 687.676 1233.21 688.145C1232.6 688.614 1232.14 689.278 1231.81 690.139C1231.49 691 1231.33 692.014 1231.33 693.182ZM1260.65 694.639V683.364H1266.1V703H1260.87V699.433H1260.67C1260.22 700.584 1259.49 701.509 1258.45 702.207C1257.43 702.906 1256.18 703.256 1254.71 703.256C1253.4 703.256 1252.24 702.957 1251.24 702.361C1250.25 701.764 1249.47 700.916 1248.91 699.817C1248.35 698.717 1248.07 697.401 1248.06 695.866V683.364H1253.51V694.895C1253.52 696.054 1253.83 696.97 1254.44 697.643C1255.05 698.317 1255.88 698.653 1256.91 698.653C1257.56 698.653 1258.18 698.504 1258.75 698.206C1259.32 697.899 1259.78 697.447 1260.13 696.851C1260.49 696.254 1260.66 695.517 1260.65 694.639ZM1280.18 683.364V687.455H1268.36V683.364H1280.18ZM1271.04 678.659H1276.49V696.966C1276.49 697.469 1276.56 697.861 1276.72 698.142C1276.87 698.415 1277.08 698.607 1277.36 698.717C1277.64 698.828 1277.96 698.884 1278.33 698.884C1278.58 698.884 1278.84 698.862 1279.09 698.82C1279.35 698.768 1279.55 698.73 1279.68 698.705L1280.54 702.757C1280.27 702.842 1279.88 702.94 1279.39 703.051C1278.89 703.17 1278.29 703.243 1277.59 703.268C1276.27 703.32 1275.12 703.145 1274.13 702.744C1273.15 702.344 1272.39 701.722 1271.85 700.878C1271.3 700.034 1271.03 698.969 1271.04 697.682V678.659ZM1283.01 703V683.364H1288.45V703H1283.01ZM1285.74 680.832C1284.93 680.832 1284.24 680.564 1283.66 680.027C1283.09 679.482 1282.8 678.83 1282.8 678.071C1282.8 677.321 1283.09 676.678 1283.66 676.141C1284.24 675.595 1284.93 675.322 1285.74 675.322C1286.55 675.322 1287.24 675.595 1287.81 676.141C1288.39 676.678 1288.68 677.321 1288.68 678.071C1288.68 678.83 1288.39 679.482 1287.81 680.027C1287.24 680.564 1286.55 680.832 1285.74 680.832ZM1300.97 703.384C1298.98 703.384 1297.27 702.962 1295.82 702.118C1294.38 701.266 1293.26 700.081 1292.48 698.564C1291.7 697.038 1291.3 695.27 1291.3 693.259C1291.3 691.23 1291.7 689.457 1292.48 687.94C1293.26 686.415 1294.38 685.23 1295.82 684.386C1297.27 683.534 1298.98 683.108 1300.97 683.108C1302.95 683.108 1304.67 683.534 1306.11 684.386C1307.56 685.23 1308.67 686.415 1309.46 687.94C1310.24 689.457 1310.63 691.23 1310.63 693.259C1310.63 695.27 1310.24 697.038 1309.46 698.564C1308.67 700.081 1307.56 701.266 1306.11 702.118C1304.67 702.962 1302.95 703.384 1300.97 703.384ZM1300.99 699.165C1301.9 699.165 1302.65 698.909 1303.26 698.398C1303.86 697.878 1304.32 697.17 1304.62 696.276C1304.94 695.381 1305.1 694.362 1305.1 693.22C1305.1 692.078 1304.94 691.06 1304.62 690.165C1304.32 689.27 1303.86 688.562 1303.26 688.043C1302.65 687.523 1301.9 687.263 1300.99 687.263C1300.08 687.263 1299.32 687.523 1298.69 688.043C1298.08 688.562 1297.62 689.27 1297.3 690.165C1296.99 691.06 1296.84 692.078 1296.84 693.22C1296.84 694.362 1296.99 695.381 1297.3 696.276C1297.62 697.17 1298.08 697.878 1298.69 698.398C1299.32 698.909 1300.08 699.165 1300.99 699.165ZM1318.9 691.648V703H1313.45V683.364H1318.65V686.828H1318.88C1319.31 685.686 1320.04 684.783 1321.06 684.118C1322.08 683.445 1323.32 683.108 1324.78 683.108C1326.15 683.108 1327.33 683.406 1328.35 684.003C1329.36 684.599 1330.15 685.452 1330.71 686.56C1331.28 687.659 1331.56 688.972 1331.56 690.497V703H1326.11V691.469C1326.12 690.267 1325.81 689.33 1325.19 688.656C1324.57 687.974 1323.71 687.634 1322.62 687.634C1321.89 687.634 1321.24 687.791 1320.68 688.107C1320.12 688.422 1319.69 688.882 1319.37 689.487C1319.07 690.084 1318.91 690.804 1318.9 691.648ZM1353.3 683.364V687.455H1341.18V683.364H1353.3ZM1343.96 703V681.945C1343.96 680.521 1344.23 679.341 1344.79 678.403C1345.35 677.466 1346.12 676.763 1347.09 676.294C1348.06 675.825 1349.16 675.591 1350.4 675.591C1351.23 675.591 1352 675.655 1352.69 675.783C1353.39 675.911 1353.91 676.026 1354.25 676.128L1353.28 680.219C1353.06 680.151 1352.8 680.087 1352.48 680.027C1352.18 679.967 1351.86 679.938 1351.54 679.938C1350.74 679.938 1350.18 680.125 1349.86 680.5C1349.55 680.866 1349.39 681.382 1349.39 682.047V703H1343.96ZM1364.08 703.384C1362.09 703.384 1360.37 702.962 1358.93 702.118C1357.48 701.266 1356.37 700.081 1355.59 698.564C1354.8 697.038 1354.41 695.27 1354.41 693.259C1354.41 691.23 1354.8 689.457 1355.59 687.94C1356.37 686.415 1357.48 685.23 1358.93 684.386C1360.37 683.534 1362.09 683.108 1364.08 683.108C1366.06 683.108 1367.78 683.534 1369.22 684.386C1370.67 685.23 1371.78 686.415 1372.57 687.94C1373.35 689.457 1373.74 691.23 1373.74 693.259C1373.74 695.27 1373.35 697.038 1372.57 698.564C1371.78 700.081 1370.67 701.266 1369.22 702.118C1367.78 702.962 1366.06 703.384 1364.08 703.384ZM1364.1 699.165C1365.01 699.165 1365.76 698.909 1366.37 698.398C1366.97 697.878 1367.43 697.17 1367.73 696.276C1368.05 695.381 1368.21 694.362 1368.21 693.22C1368.21 692.078 1368.05 691.06 1367.73 690.165C1367.43 689.27 1366.97 688.562 1366.37 688.043C1365.76 687.523 1365.01 687.263 1364.1 687.263C1363.19 687.263 1362.42 687.523 1361.8 688.043C1361.19 688.562 1360.72 689.27 1360.41 690.165C1360.1 691.06 1359.95 692.078 1359.95 693.22C1359.95 694.362 1360.1 695.381 1360.41 696.276C1360.72 697.17 1361.19 697.878 1361.8 698.398C1362.42 698.909 1363.19 699.165 1364.1 699.165ZM1376.56 703V683.364H1381.84V686.79H1382.05C1382.41 685.571 1383.01 684.651 1383.85 684.028C1384.69 683.398 1385.67 683.082 1386.76 683.082C1387.04 683.082 1387.33 683.099 1387.65 683.134C1387.96 683.168 1388.24 683.214 1388.48 683.274V688.107C1388.22 688.03 1387.87 687.962 1387.42 687.902C1386.96 687.842 1386.55 687.812 1386.18 687.812C1385.38 687.812 1384.66 687.987 1384.03 688.337C1383.41 688.678 1382.91 689.155 1382.55 689.768C1382.19 690.382 1382.01 691.089 1382.01 691.891V703H1376.56Z" fill="black"/>
+<path d="M1140.14 758.364V731.364H1145.51V734.662H1145.75C1145.99 734.134 1146.33 733.597 1146.78 733.051C1147.24 732.497 1147.84 732.037 1148.57 731.67C1149.32 731.295 1150.24 731.108 1151.34 731.108C1152.77 731.108 1154.09 731.483 1155.3 732.233C1156.51 732.974 1157.48 734.095 1158.2 735.595C1158.92 737.087 1159.29 738.957 1159.29 741.207C1159.29 743.398 1158.93 745.247 1158.23 746.756C1157.53 748.256 1156.57 749.393 1155.36 750.169C1154.16 750.936 1152.81 751.32 1151.32 751.32C1150.27 751.32 1149.37 751.145 1148.63 750.795C1147.89 750.446 1147.29 750.007 1146.82 749.479C1146.35 748.942 1146 748.401 1145.75 747.855H1145.58V758.364H1140.14ZM1145.47 741.182C1145.47 742.349 1145.63 743.368 1145.95 744.237C1146.28 745.107 1146.75 745.784 1147.36 746.27C1147.97 746.747 1148.72 746.986 1149.6 746.986C1150.48 746.986 1151.23 746.743 1151.85 746.257C1152.46 745.763 1152.92 745.081 1153.24 744.212C1153.56 743.334 1153.73 742.324 1153.73 741.182C1153.73 740.048 1153.57 739.051 1153.25 738.19C1152.94 737.33 1152.47 736.656 1151.86 736.17C1151.25 735.685 1150.49 735.442 1149.6 735.442C1148.71 735.442 1147.96 735.676 1147.35 736.145C1146.74 736.614 1146.28 737.278 1145.95 738.139C1145.63 739 1145.47 740.014 1145.47 741.182ZM1171.15 751.384C1169.13 751.384 1167.39 750.974 1165.93 750.156C1164.48 749.33 1163.37 748.162 1162.58 746.653C1161.8 745.136 1161.41 743.342 1161.41 741.271C1161.41 739.251 1161.8 737.479 1162.58 735.953C1163.37 734.428 1164.47 733.239 1165.89 732.386C1167.32 731.534 1169 731.108 1170.93 731.108C1172.22 731.108 1173.43 731.317 1174.55 731.734C1175.67 732.143 1176.65 732.761 1177.49 733.588C1178.33 734.415 1178.99 735.455 1179.46 736.707C1179.93 737.952 1180.16 739.409 1180.16 741.08V742.575H1163.58V739.2H1175.03C1175.03 738.416 1174.86 737.722 1174.52 737.116C1174.18 736.511 1173.71 736.038 1173.1 735.697C1172.51 735.348 1171.81 735.173 1171.02 735.173C1170.19 735.173 1169.46 735.365 1168.82 735.749C1168.19 736.124 1167.69 736.631 1167.34 737.27C1166.98 737.901 1166.8 738.604 1166.79 739.379V742.588C1166.79 743.56 1166.97 744.399 1167.32 745.107C1167.69 745.814 1168.21 746.359 1168.87 746.743C1169.54 747.126 1170.32 747.318 1171.24 747.318C1171.84 747.318 1172.4 747.233 1172.9 747.062C1173.4 746.892 1173.83 746.636 1174.19 746.295C1174.55 745.955 1174.82 745.537 1175.01 745.043L1180.04 745.375C1179.79 746.585 1179.26 747.642 1178.47 748.545C1177.69 749.44 1176.67 750.139 1175.43 750.642C1174.19 751.136 1172.77 751.384 1171.15 751.384ZM1182.99 751V731.364H1188.27V734.79H1188.48C1188.84 733.571 1189.44 732.651 1190.28 732.028C1191.12 731.398 1192.1 731.082 1193.2 731.082C1193.47 731.082 1193.76 731.099 1194.08 731.134C1194.39 731.168 1194.67 731.214 1194.91 731.274V736.107C1194.65 736.03 1194.3 735.962 1193.85 735.902C1193.4 735.842 1192.98 735.812 1192.61 735.812C1191.81 735.812 1191.09 735.987 1190.46 736.337C1189.84 736.678 1189.34 737.155 1188.98 737.768C1188.62 738.382 1188.44 739.089 1188.44 739.891V751H1182.99ZM1208.43 731.364V735.455H1196.61V731.364H1208.43ZM1199.29 726.659H1204.74V744.966C1204.74 745.469 1204.81 745.861 1204.97 746.142C1205.12 746.415 1205.33 746.607 1205.61 746.717C1205.89 746.828 1206.21 746.884 1206.58 746.884C1206.83 746.884 1207.09 746.862 1207.35 746.82C1207.6 746.768 1207.8 746.73 1207.93 746.705L1208.79 750.757C1208.52 750.842 1208.13 750.94 1207.64 751.051C1207.15 751.17 1206.55 751.243 1205.84 751.268C1204.53 751.32 1203.37 751.145 1202.39 750.744C1201.41 750.344 1200.64 749.722 1200.1 748.878C1199.55 748.034 1199.28 746.969 1199.29 745.682V726.659ZM1223.85 742.639V731.364H1229.3V751H1224.07V747.433H1223.87C1223.42 748.584 1222.69 749.509 1221.65 750.207C1220.63 750.906 1219.38 751.256 1217.91 751.256C1216.6 751.256 1215.44 750.957 1214.44 750.361C1213.45 749.764 1212.67 748.916 1212.1 747.817C1211.55 746.717 1211.27 745.401 1211.26 743.866V731.364H1216.71V742.895C1216.71 744.054 1217.03 744.97 1217.64 745.643C1218.25 746.317 1219.08 746.653 1220.11 746.653C1220.76 746.653 1221.38 746.504 1221.95 746.206C1222.52 745.899 1222.98 745.447 1223.33 744.851C1223.69 744.254 1223.86 743.517 1223.85 742.639ZM1232.93 751V731.364H1238.21V734.79H1238.42C1238.78 733.571 1239.38 732.651 1240.22 732.028C1241.07 731.398 1242.04 731.082 1243.14 731.082C1243.41 731.082 1243.7 731.099 1244.02 731.134C1244.33 731.168 1244.61 731.214 1244.85 731.274V736.107C1244.59 736.03 1244.24 735.962 1243.79 735.902C1243.34 735.842 1242.92 735.812 1242.55 735.812C1241.75 735.812 1241.03 735.987 1240.4 736.337C1239.78 736.678 1239.28 737.155 1238.92 737.768C1238.56 738.382 1238.38 739.089 1238.38 739.891V751H1232.93ZM1247.05 751V724.818H1252.49V734.662H1252.66C1252.9 734.134 1253.24 733.597 1253.7 733.051C1254.16 732.497 1254.75 732.037 1255.49 731.67C1256.23 731.295 1257.15 731.108 1258.25 731.108C1259.68 731.108 1261 731.483 1262.21 732.233C1263.42 732.974 1264.39 734.095 1265.11 735.595C1265.84 737.087 1266.2 738.957 1266.2 741.207C1266.2 743.398 1265.84 745.247 1265.14 746.756C1264.44 748.256 1263.48 749.393 1262.27 750.169C1261.07 750.936 1259.73 751.32 1258.23 751.32C1257.18 751.32 1256.28 751.145 1255.54 750.795C1254.8 750.446 1254.2 750.007 1253.73 749.479C1253.27 748.942 1252.91 748.401 1252.66 747.855H1252.42V751H1247.05ZM1252.38 741.182C1252.38 742.349 1252.54 743.368 1252.86 744.237C1253.19 745.107 1253.66 745.784 1254.27 746.27C1254.88 746.747 1255.63 746.986 1256.51 746.986C1257.39 746.986 1258.14 746.743 1258.76 746.257C1259.37 745.763 1259.84 745.081 1260.15 744.212C1260.48 743.334 1260.64 742.324 1260.64 741.182C1260.64 740.048 1260.48 739.051 1260.16 738.19C1259.85 737.33 1259.38 736.656 1258.77 736.17C1258.16 735.685 1257.4 735.442 1256.51 735.442C1255.62 735.442 1254.87 735.676 1254.26 736.145C1253.65 736.614 1253.19 737.278 1252.86 738.139C1252.54 739 1252.38 740.014 1252.38 741.182ZM1274.71 751.371C1273.46 751.371 1272.34 751.153 1271.36 750.719C1270.38 750.276 1269.61 749.624 1269.04 748.763C1268.47 747.893 1268.19 746.811 1268.19 745.516C1268.19 744.425 1268.39 743.509 1268.79 742.767C1269.19 742.026 1269.74 741.429 1270.43 740.977C1271.12 740.526 1271.9 740.185 1272.78 739.955C1273.67 739.724 1274.6 739.562 1275.57 739.469C1276.71 739.349 1277.63 739.239 1278.33 739.136C1279.03 739.026 1279.54 738.864 1279.85 738.651C1280.17 738.437 1280.32 738.122 1280.32 737.705V737.628C1280.32 736.818 1280.07 736.192 1279.56 735.749C1279.05 735.305 1278.34 735.084 1277.41 735.084C1276.43 735.084 1275.65 735.301 1275.07 735.736C1274.49 736.162 1274.11 736.699 1273.92 737.347L1268.88 736.938C1269.14 735.744 1269.64 734.713 1270.39 733.844C1271.14 732.966 1272.11 732.293 1273.29 731.824C1274.49 731.347 1275.87 731.108 1277.43 731.108C1278.53 731.108 1279.57 731.236 1280.57 731.491C1281.57 731.747 1282.46 732.143 1283.24 732.68C1284.02 733.217 1284.64 733.908 1285.09 734.751C1285.54 735.587 1285.77 736.588 1285.77 737.756V751H1280.61V748.277H1280.45C1280.14 748.891 1279.71 749.432 1279.19 749.901C1278.66 750.361 1278.02 750.723 1277.28 750.987C1276.54 751.243 1275.68 751.371 1274.71 751.371ZM1276.27 747.612C1277.07 747.612 1277.78 747.455 1278.39 747.139C1279.01 746.815 1279.49 746.381 1279.84 745.835C1280.19 745.29 1280.36 744.672 1280.36 743.982V741.898C1280.19 742.009 1279.96 742.111 1279.66 742.205C1279.37 742.29 1279.04 742.371 1278.67 742.447C1278.31 742.516 1277.94 742.58 1277.58 742.639C1277.21 742.69 1276.88 742.737 1276.58 742.78C1275.94 742.874 1275.38 743.023 1274.9 743.227C1274.43 743.432 1274.06 743.709 1273.79 744.058C1273.53 744.399 1273.39 744.825 1273.39 745.337C1273.39 746.078 1273.66 746.645 1274.2 747.037C1274.75 747.42 1275.44 747.612 1276.27 747.612ZM1299.72 731.364V735.455H1287.89V731.364H1299.72ZM1290.58 726.659H1296.02V744.966C1296.02 745.469 1296.1 745.861 1296.26 746.142C1296.41 746.415 1296.62 746.607 1296.89 746.717C1297.18 746.828 1297.5 746.884 1297.87 746.884C1298.12 746.884 1298.38 746.862 1298.63 746.82C1298.89 746.768 1299.08 746.73 1299.22 746.705L1300.08 750.757C1299.8 750.842 1299.42 750.94 1298.93 751.051C1298.43 751.17 1297.83 751.243 1297.12 751.268C1295.81 751.32 1294.66 751.145 1293.67 750.744C1292.69 750.344 1291.93 749.722 1291.38 748.878C1290.84 748.034 1290.57 746.969 1290.58 745.682V726.659ZM1302.55 751V731.364H1307.99V751H1302.55ZM1305.28 728.832C1304.47 728.832 1303.78 728.564 1303.2 728.027C1302.63 727.482 1302.34 726.83 1302.34 726.071C1302.34 725.321 1302.63 724.678 1303.2 724.141C1303.78 723.595 1304.47 723.322 1305.28 723.322C1306.09 723.322 1306.78 723.595 1307.35 724.141C1307.93 724.678 1308.22 725.321 1308.22 726.071C1308.22 726.83 1307.93 727.482 1307.35 728.027C1306.78 728.564 1306.09 728.832 1305.28 728.832ZM1320.51 751.384C1318.52 751.384 1316.8 750.962 1315.36 750.118C1313.92 749.266 1312.8 748.081 1312.02 746.564C1311.24 745.038 1310.84 743.27 1310.84 741.259C1310.84 739.23 1311.24 737.457 1312.02 735.94C1312.8 734.415 1313.92 733.23 1315.36 732.386C1316.8 731.534 1318.52 731.108 1320.51 731.108C1322.49 731.108 1324.21 731.534 1325.65 732.386C1327.1 733.23 1328.21 734.415 1329 735.94C1329.78 737.457 1330.17 739.23 1330.17 741.259C1330.17 743.27 1329.78 745.038 1329 746.564C1328.21 748.081 1327.1 749.266 1325.65 750.118C1324.21 750.962 1322.49 751.384 1320.51 751.384ZM1320.53 747.165C1321.44 747.165 1322.19 746.909 1322.8 746.398C1323.4 745.878 1323.86 745.17 1324.16 744.276C1324.48 743.381 1324.64 742.362 1324.64 741.22C1324.64 740.078 1324.48 739.06 1324.16 738.165C1323.86 737.27 1323.4 736.562 1322.8 736.043C1322.19 735.523 1321.44 735.263 1320.53 735.263C1319.62 735.263 1318.85 735.523 1318.23 736.043C1317.62 736.562 1317.15 737.27 1316.84 738.165C1316.53 739.06 1316.38 740.078 1316.38 741.22C1316.38 742.362 1316.53 743.381 1316.84 744.276C1317.15 745.17 1317.62 745.878 1318.23 746.398C1318.85 746.909 1319.62 747.165 1320.53 747.165ZM1338.44 739.648V751H1332.99V731.364H1338.18V734.828H1338.41C1338.85 733.686 1339.58 732.783 1340.6 732.118C1341.62 731.445 1342.86 731.108 1344.32 731.108C1345.68 731.108 1346.87 731.406 1347.89 732.003C1348.9 732.599 1349.69 733.452 1350.25 734.56C1350.81 735.659 1351.1 736.972 1351.1 738.497V751H1345.65V739.469C1345.66 738.267 1345.35 737.33 1344.73 736.656C1344.11 735.974 1343.25 735.634 1342.16 735.634C1341.43 735.634 1340.78 735.791 1340.22 736.107C1339.66 736.422 1339.23 736.882 1338.91 737.487C1338.61 738.084 1338.45 738.804 1338.44 739.648ZM1366.9 751H1360.96L1370 724.818H1377.14L1386.16 751H1380.23L1373.67 730.801H1373.47L1366.9 751ZM1366.52 740.709H1380.54V745.03H1366.52V740.709Z" fill="#E6711C"/>
+<path d="M1673.25 655V628.818H1683.58C1685.56 628.818 1687.26 629.197 1688.65 629.956C1690.05 630.706 1691.12 631.75 1691.85 633.088C1692.59 634.418 1692.96 635.952 1692.96 637.69C1692.96 639.429 1692.59 640.963 1691.84 642.293C1691.09 643.622 1690 644.658 1688.58 645.399C1687.16 646.141 1685.45 646.511 1683.44 646.511H1676.85V642.075H1682.54C1683.61 642.075 1684.49 641.892 1685.18 641.526C1685.88 641.151 1686.4 640.635 1686.74 639.979C1687.09 639.314 1687.26 638.551 1687.26 637.69C1687.26 636.821 1687.09 636.062 1686.74 635.415C1686.4 634.759 1685.88 634.251 1685.18 633.893C1684.48 633.527 1683.59 633.344 1682.52 633.344H1678.78V655H1673.25ZM1704.37 655.384C1702.35 655.384 1700.61 654.974 1699.15 654.156C1697.7 653.33 1696.59 652.162 1695.8 650.653C1695.02 649.136 1694.63 647.342 1694.63 645.271C1694.63 643.251 1695.02 641.479 1695.8 639.953C1696.59 638.428 1697.69 637.239 1699.11 636.386C1700.55 635.534 1702.22 635.108 1704.15 635.108C1705.45 635.108 1706.65 635.317 1707.77 635.734C1708.89 636.143 1709.87 636.761 1710.71 637.588C1711.55 638.415 1712.21 639.455 1712.68 640.707C1713.15 641.952 1713.38 643.409 1713.38 645.08V646.575H1696.8V643.2H1708.25C1708.25 642.416 1708.08 641.722 1707.74 641.116C1707.4 640.511 1706.93 640.038 1706.32 639.697C1705.73 639.348 1705.03 639.173 1704.24 639.173C1703.41 639.173 1702.68 639.365 1702.04 639.749C1701.41 640.124 1700.92 640.631 1700.56 641.27C1700.2 641.901 1700.02 642.604 1700.01 643.379V646.588C1700.01 647.56 1700.19 648.399 1700.55 649.107C1700.91 649.814 1701.43 650.359 1702.09 650.743C1702.76 651.126 1703.55 651.318 1704.46 651.318C1705.06 651.318 1705.62 651.233 1706.12 651.062C1706.62 650.892 1707.05 650.636 1707.41 650.295C1707.77 649.955 1708.04 649.537 1708.23 649.043L1713.27 649.375C1713.01 650.585 1712.49 651.642 1711.69 652.545C1710.91 653.44 1709.9 654.139 1708.65 654.642C1707.41 655.136 1705.99 655.384 1704.37 655.384ZM1716.21 655V635.364H1721.49V638.79H1721.7C1722.06 637.571 1722.66 636.651 1723.5 636.028C1724.35 635.398 1725.32 635.082 1726.42 635.082C1726.69 635.082 1726.98 635.099 1727.3 635.134C1727.61 635.168 1727.89 635.214 1728.13 635.274V640.107C1727.87 640.03 1727.52 639.962 1727.07 639.902C1726.62 639.842 1726.2 639.812 1725.83 639.812C1725.03 639.812 1724.31 639.987 1723.68 640.337C1723.06 640.678 1722.56 641.155 1722.2 641.768C1721.84 642.382 1721.66 643.089 1721.66 643.891V655H1716.21ZM1741.77 635.364V639.455H1729.65V635.364H1741.77ZM1732.42 655V633.945C1732.42 632.521 1732.7 631.341 1733.26 630.403C1733.82 629.466 1734.58 628.763 1735.56 628.294C1736.53 627.825 1737.63 627.591 1738.87 627.591C1739.7 627.591 1740.47 627.655 1741.16 627.783C1741.85 627.911 1742.37 628.026 1742.72 628.128L1741.74 632.219C1741.53 632.151 1741.27 632.087 1740.95 632.027C1740.64 631.967 1740.33 631.938 1740.01 631.938C1739.2 631.938 1738.65 632.125 1738.33 632.5C1738.02 632.866 1737.86 633.382 1737.86 634.047V655H1732.42ZM1752.55 655.384C1750.56 655.384 1748.84 654.962 1747.39 654.118C1745.95 653.266 1744.84 652.081 1744.06 650.564C1743.27 649.038 1742.88 647.27 1742.88 645.259C1742.88 643.23 1743.27 641.457 1744.06 639.94C1744.84 638.415 1745.95 637.23 1747.39 636.386C1748.84 635.534 1750.56 635.108 1752.55 635.108C1754.53 635.108 1756.24 635.534 1757.68 636.386C1759.13 637.23 1760.25 638.415 1761.03 639.94C1761.82 641.457 1762.21 643.23 1762.21 645.259C1762.21 647.27 1761.82 649.038 1761.03 650.564C1760.25 652.081 1759.13 653.266 1757.68 654.118C1756.24 654.962 1754.53 655.384 1752.55 655.384ZM1752.57 651.165C1753.47 651.165 1754.23 650.909 1754.83 650.398C1755.44 649.878 1755.89 649.17 1756.2 648.276C1756.52 647.381 1756.67 646.362 1756.67 645.22C1756.67 644.078 1756.52 643.06 1756.2 642.165C1755.89 641.27 1755.44 640.562 1754.83 640.043C1754.23 639.523 1753.47 639.263 1752.57 639.263C1751.66 639.263 1750.89 639.523 1750.27 640.043C1749.66 640.562 1749.19 641.27 1748.88 642.165C1748.57 643.06 1748.42 644.078 1748.42 645.22C1748.42 646.362 1748.57 647.381 1748.88 648.276C1749.19 649.17 1749.66 649.878 1750.27 650.398C1750.89 650.909 1751.66 651.165 1752.57 651.165ZM1765.03 655V635.364H1770.31V638.79H1770.52C1770.87 637.571 1771.47 636.651 1772.32 636.028C1773.16 635.398 1774.13 635.082 1775.23 635.082C1775.51 635.082 1775.8 635.099 1776.12 635.134C1776.43 635.168 1776.71 635.214 1776.95 635.274V640.107C1776.69 640.03 1776.34 639.962 1775.89 639.902C1775.43 639.842 1775.02 639.812 1774.64 639.812C1773.84 639.812 1773.13 639.987 1772.5 640.337C1771.88 640.678 1771.38 641.155 1771.01 641.768C1770.66 642.382 1770.48 643.089 1770.48 643.891V655H1765.03ZM1779.04 655V635.364H1784.23V638.828H1784.46C1784.87 637.678 1785.55 636.77 1786.51 636.105C1787.46 635.44 1788.6 635.108 1789.93 635.108C1791.28 635.108 1792.43 635.445 1793.37 636.118C1794.32 636.783 1794.95 637.686 1795.26 638.828H1795.47C1795.87 637.703 1796.59 636.804 1797.64 636.131C1798.7 635.449 1799.95 635.108 1801.39 635.108C1803.22 635.108 1804.71 635.692 1805.85 636.859C1807 638.018 1807.58 639.663 1807.58 641.794V655H1802.14V642.868C1802.14 641.777 1801.85 640.959 1801.27 640.413C1800.69 639.868 1799.97 639.595 1799.1 639.595C1798.11 639.595 1797.34 639.911 1796.79 640.541C1796.23 641.163 1795.96 641.986 1795.96 643.009V655H1790.68V642.753C1790.68 641.79 1790.4 641.023 1789.84 640.452C1789.3 639.881 1788.58 639.595 1787.68 639.595C1787.08 639.595 1786.53 639.749 1786.05 640.055C1785.57 640.354 1785.19 640.776 1784.91 641.321C1784.63 641.858 1784.49 642.489 1784.49 643.213V655H1779.04ZM1816.76 655.371C1815.5 655.371 1814.39 655.153 1813.41 654.719C1812.43 654.276 1811.65 653.624 1811.08 652.763C1810.52 651.893 1810.24 650.811 1810.24 649.516C1810.24 648.425 1810.44 647.509 1810.84 646.767C1811.24 646.026 1811.78 645.429 1812.47 644.977C1813.16 644.526 1813.95 644.185 1814.83 643.955C1815.71 643.724 1816.64 643.562 1817.61 643.469C1818.76 643.349 1819.68 643.239 1820.38 643.136C1821.07 643.026 1821.58 642.864 1821.9 642.651C1822.21 642.437 1822.37 642.122 1822.37 641.705V641.628C1822.37 640.818 1822.11 640.192 1821.6 639.749C1821.1 639.305 1820.38 639.084 1819.45 639.084C1818.47 639.084 1817.69 639.301 1817.12 639.736C1816.54 640.162 1816.15 640.699 1815.96 641.347L1810.93 640.938C1811.18 639.744 1811.69 638.713 1812.44 637.844C1813.19 636.966 1814.15 636.293 1815.34 635.824C1816.53 635.347 1817.91 635.108 1819.48 635.108C1820.57 635.108 1821.62 635.236 1822.61 635.491C1823.62 635.747 1824.51 636.143 1825.28 636.68C1826.07 637.217 1826.69 637.908 1827.14 638.751C1827.59 639.587 1827.82 640.588 1827.82 641.756V655H1822.65V652.277H1822.5C1822.18 652.891 1821.76 653.432 1821.23 653.901C1820.7 654.361 1820.07 654.723 1819.33 654.987C1818.59 655.243 1817.73 655.371 1816.76 655.371ZM1818.32 651.612C1819.12 651.612 1819.83 651.455 1820.44 651.139C1821.05 650.815 1821.53 650.381 1821.88 649.835C1822.23 649.29 1822.41 648.672 1822.41 647.982V645.898C1822.24 646.009 1822 646.111 1821.7 646.205C1821.41 646.29 1821.09 646.371 1820.72 646.447C1820.35 646.516 1819.99 646.58 1819.62 646.639C1819.25 646.69 1818.92 646.737 1818.62 646.78C1817.98 646.874 1817.43 647.023 1816.95 647.227C1816.47 647.432 1816.1 647.709 1815.84 648.058C1815.57 648.399 1815.44 648.825 1815.44 649.337C1815.44 650.078 1815.71 650.645 1816.25 651.037C1816.79 651.42 1817.48 651.612 1818.32 651.612ZM1836.77 643.648V655H1831.32V635.364H1836.51V638.828H1836.74C1837.18 637.686 1837.9 636.783 1838.93 636.118C1839.95 635.445 1841.19 635.108 1842.65 635.108C1844.01 635.108 1845.2 635.406 1846.21 636.003C1847.23 636.599 1848.02 637.452 1848.58 638.56C1849.14 639.659 1849.42 640.972 1849.42 642.497V655H1843.98V643.469C1843.99 642.267 1843.68 641.33 1843.06 640.656C1842.43 639.974 1841.58 639.634 1840.49 639.634C1839.75 639.634 1839.11 639.791 1838.54 640.107C1837.99 640.422 1837.55 640.882 1837.24 641.487C1836.93 642.084 1836.78 642.804 1836.77 643.648ZM1861.87 655.384C1859.86 655.384 1858.13 654.957 1856.68 654.105C1855.24 653.244 1854.13 652.051 1853.35 650.526C1852.59 649 1852.2 647.244 1852.2 645.259C1852.2 643.247 1852.59 641.483 1853.37 639.966C1854.15 638.44 1855.26 637.251 1856.7 636.399C1858.14 635.538 1859.86 635.108 1861.84 635.108C1863.55 635.108 1865.05 635.419 1866.34 636.041C1867.63 636.663 1868.65 637.537 1869.4 638.662C1870.15 639.787 1870.56 641.108 1870.64 642.625H1865.5C1865.35 641.645 1864.97 640.857 1864.35 640.26C1863.73 639.655 1862.93 639.352 1861.93 639.352C1861.09 639.352 1860.35 639.582 1859.72 640.043C1859.1 640.494 1858.61 641.155 1858.26 642.024C1857.91 642.893 1857.74 643.946 1857.74 645.182C1857.74 646.435 1857.91 647.5 1858.25 648.378C1858.6 649.256 1859.09 649.925 1859.72 650.385C1860.35 650.845 1861.09 651.075 1861.93 651.075C1862.55 651.075 1863.11 650.947 1863.61 650.692C1864.11 650.436 1864.52 650.065 1864.85 649.58C1865.18 649.085 1865.4 648.493 1865.5 647.803H1870.64C1870.55 649.303 1870.14 650.624 1869.41 651.766C1868.69 652.899 1867.68 653.786 1866.41 654.425C1865.13 655.064 1863.61 655.384 1861.87 655.384ZM1882.35 655.384C1880.33 655.384 1878.59 654.974 1877.14 654.156C1875.69 653.33 1874.57 652.162 1873.79 650.653C1873 649.136 1872.61 647.342 1872.61 645.271C1872.61 643.251 1873 641.479 1873.79 639.953C1874.57 638.428 1875.68 637.239 1877.1 636.386C1878.53 635.534 1880.21 635.108 1882.14 635.108C1883.43 635.108 1884.64 635.317 1885.75 635.734C1886.88 636.143 1887.86 636.761 1888.69 637.588C1889.54 638.415 1890.19 639.455 1890.66 640.707C1891.13 641.952 1891.37 643.409 1891.37 645.08V646.575H1874.78V643.2H1886.24C1886.24 642.416 1886.07 641.722 1885.73 641.116C1885.39 640.511 1884.91 640.038 1884.31 639.697C1883.71 639.348 1883.02 639.173 1882.23 639.173C1881.4 639.173 1880.67 639.365 1880.03 639.749C1879.4 640.124 1878.9 640.631 1878.54 641.27C1878.19 641.901 1878 642.604 1877.99 643.379V646.588C1877.99 647.56 1878.17 648.399 1878.53 649.107C1878.9 649.814 1879.41 650.359 1880.08 650.743C1880.74 651.126 1881.53 651.318 1882.44 651.318C1883.05 651.318 1883.6 651.233 1884.1 651.062C1884.61 650.892 1885.04 650.636 1885.4 650.295C1885.75 649.955 1886.03 649.537 1886.21 649.043L1891.25 649.375C1890.99 650.585 1890.47 651.642 1889.68 652.545C1888.89 653.44 1887.88 654.139 1886.64 654.642C1885.4 655.136 1883.97 655.384 1882.35 655.384ZM1665.01 703.32C1663.52 703.32 1662.17 702.936 1660.96 702.169C1659.75 701.393 1658.8 700.256 1658.09 698.756C1657.39 697.247 1657.04 695.398 1657.04 693.207C1657.04 690.957 1657.41 689.087 1658.13 687.595C1658.86 686.095 1659.82 684.974 1661.02 684.233C1662.23 683.483 1663.56 683.108 1665 683.108C1666.1 683.108 1667.01 683.295 1667.74 683.67C1668.49 684.037 1669.08 684.497 1669.53 685.051C1669.99 685.597 1670.34 686.134 1670.58 686.662H1670.75V676.818H1676.18V703H1670.81V699.855H1670.58C1670.33 700.401 1669.96 700.942 1669.5 701.479C1669.04 702.007 1668.44 702.446 1667.69 702.795C1666.96 703.145 1666.07 703.32 1665.01 703.32ZM1666.73 698.986C1667.61 698.986 1668.35 698.747 1668.96 698.27C1669.57 697.784 1670.04 697.107 1670.37 696.237C1670.7 695.368 1670.86 694.349 1670.86 693.182C1670.86 692.014 1670.7 691 1670.38 690.139C1670.05 689.278 1669.59 688.614 1668.97 688.145C1668.36 687.676 1667.61 687.442 1666.73 687.442C1665.84 687.442 1665.09 687.685 1664.47 688.17C1663.86 688.656 1663.39 689.33 1663.08 690.19C1662.76 691.051 1662.61 692.048 1662.61 693.182C1662.61 694.324 1662.76 695.334 1663.08 696.212C1663.4 697.081 1663.87 697.763 1664.47 698.257C1665.09 698.743 1665.84 698.986 1666.73 698.986ZM1679.94 703V683.364H1685.39V703H1679.94ZM1682.68 680.832C1681.87 680.832 1681.17 680.564 1680.59 680.027C1680.02 679.482 1679.74 678.83 1679.74 678.071C1679.74 677.321 1680.02 676.678 1680.59 676.141C1681.17 675.595 1681.87 675.322 1682.68 675.322C1683.49 675.322 1684.18 675.595 1684.75 676.141C1685.33 676.678 1685.62 677.321 1685.62 678.071C1685.62 678.83 1685.33 679.482 1684.75 680.027C1684.18 680.564 1683.49 680.832 1682.68 680.832ZM1705.37 688.963L1700.38 689.27C1700.3 688.844 1700.11 688.46 1699.83 688.119C1699.55 687.77 1699.18 687.493 1698.72 687.288C1698.27 687.075 1697.73 686.969 1697.1 686.969C1696.25 686.969 1695.54 687.148 1694.96 687.506C1694.38 687.855 1694.09 688.324 1694.09 688.912C1694.09 689.381 1694.28 689.777 1694.65 690.101C1695.03 690.425 1695.67 690.685 1696.58 690.881L1700.14 691.597C1702.05 691.989 1703.47 692.619 1704.41 693.489C1705.35 694.358 1705.81 695.5 1705.81 696.915C1705.81 698.202 1705.43 699.331 1704.68 700.303C1703.93 701.274 1702.89 702.033 1701.58 702.578C1700.28 703.115 1698.77 703.384 1697.07 703.384C1694.47 703.384 1692.4 702.842 1690.86 701.76C1689.32 700.669 1688.42 699.186 1688.16 697.311L1693.52 697.03C1693.68 697.822 1694.07 698.428 1694.69 698.845C1695.31 699.254 1696.11 699.459 1697.08 699.459C1698.04 699.459 1698.8 699.276 1699.38 698.909C1699.97 698.534 1700.27 698.053 1700.28 697.464C1700.27 696.97 1700.06 696.565 1699.65 696.25C1699.24 695.926 1698.61 695.679 1697.76 695.509L1694.36 694.831C1692.44 694.447 1691.01 693.783 1690.08 692.837C1689.15 691.891 1688.68 690.685 1688.68 689.219C1688.68 687.957 1689.02 686.871 1689.71 685.959C1690.4 685.047 1691.36 684.344 1692.61 683.849C1693.86 683.355 1695.33 683.108 1697.01 683.108C1699.49 683.108 1701.44 683.632 1702.86 684.68C1704.29 685.729 1705.13 687.156 1705.37 688.963ZM1718.97 683.364V687.455H1707.14V683.364H1718.97ZM1709.83 678.659H1715.27V696.966C1715.27 697.469 1715.35 697.861 1715.5 698.142C1715.66 698.415 1715.87 698.607 1716.14 698.717C1716.42 698.828 1716.75 698.884 1717.11 698.884C1717.37 698.884 1717.63 698.862 1717.88 698.82C1718.14 698.768 1718.33 698.73 1718.47 698.705L1719.33 702.757C1719.05 702.842 1718.67 702.94 1718.18 703.051C1717.68 703.17 1717.08 703.243 1716.37 703.268C1715.06 703.32 1713.91 703.145 1712.92 702.744C1711.94 702.344 1711.18 701.722 1710.63 700.878C1710.09 700.034 1709.82 698.969 1709.83 697.682V678.659ZM1721.8 703V683.364H1727.08V686.79H1727.28C1727.64 685.571 1728.24 684.651 1729.08 684.028C1729.93 683.398 1730.9 683.082 1732 683.082C1732.27 683.082 1732.56 683.099 1732.88 683.134C1733.19 683.168 1733.47 683.214 1733.71 683.274V688.107C1733.45 688.03 1733.1 687.962 1732.65 687.902C1732.2 687.842 1731.78 687.812 1731.41 687.812C1730.61 687.812 1729.89 687.987 1729.26 688.337C1728.64 688.678 1728.14 689.155 1727.78 689.768C1727.42 690.382 1727.24 691.089 1727.24 691.891V703H1721.8ZM1735.81 703V683.364H1741.25V703H1735.81ZM1738.54 680.832C1737.73 680.832 1737.04 680.564 1736.46 680.027C1735.89 679.482 1735.6 678.83 1735.6 678.071C1735.6 677.321 1735.89 676.678 1736.46 676.141C1737.04 675.595 1737.73 675.322 1738.54 675.322C1739.35 675.322 1740.04 675.595 1740.61 676.141C1741.19 676.678 1741.48 677.321 1741.48 678.071C1741.48 678.83 1741.19 679.482 1740.61 680.027C1740.04 680.564 1739.35 680.832 1738.54 680.832ZM1745 703V676.818H1750.44V686.662H1750.61C1750.85 686.134 1751.19 685.597 1751.64 685.051C1752.1 684.497 1752.7 684.037 1753.43 683.67C1754.18 683.295 1755.1 683.108 1756.2 683.108C1757.63 683.108 1758.95 683.483 1760.16 684.233C1761.37 684.974 1762.34 686.095 1763.06 687.595C1763.79 689.087 1764.15 690.957 1764.15 693.207C1764.15 695.398 1763.79 697.247 1763.09 698.756C1762.39 700.256 1761.43 701.393 1760.22 702.169C1759.02 702.936 1757.67 703.32 1756.18 703.32C1755.13 703.32 1754.23 703.145 1753.49 702.795C1752.75 702.446 1752.15 702.007 1751.68 701.479C1751.21 700.942 1750.86 700.401 1750.61 699.855H1750.37V703H1745ZM1750.33 693.182C1750.33 694.349 1750.49 695.368 1750.81 696.237C1751.14 697.107 1751.61 697.784 1752.22 698.27C1752.83 698.747 1753.58 698.986 1754.46 698.986C1755.34 698.986 1756.09 698.743 1756.71 698.257C1757.32 697.763 1757.79 697.081 1758.1 696.212C1758.42 695.334 1758.59 694.324 1758.59 693.182C1758.59 692.048 1758.43 691.051 1758.11 690.19C1757.8 689.33 1757.33 688.656 1756.72 688.17C1756.11 687.685 1755.35 687.442 1754.46 687.442C1753.57 687.442 1752.82 687.676 1752.21 688.145C1751.6 688.614 1751.14 689.278 1750.81 690.139C1750.49 691 1750.33 692.014 1750.33 693.182ZM1779.65 694.639V683.364H1785.1V703H1779.87V699.433H1779.67C1779.22 700.584 1778.49 701.509 1777.45 702.207C1776.43 702.906 1775.18 703.256 1773.71 703.256C1772.4 703.256 1771.24 702.957 1770.24 702.361C1769.25 701.764 1768.47 700.916 1767.91 699.817C1767.35 698.717 1767.07 697.401 1767.06 695.866V683.364H1772.51V694.895C1772.52 696.054 1772.83 696.97 1773.44 697.643C1774.05 698.317 1774.88 698.653 1775.91 698.653C1776.56 698.653 1777.18 698.504 1777.75 698.206C1778.32 697.899 1778.78 697.447 1779.13 696.851C1779.49 696.254 1779.66 695.517 1779.65 694.639ZM1799.18 683.364V687.455H1787.36V683.364H1799.18ZM1790.04 678.659H1795.49V696.966C1795.49 697.469 1795.56 697.861 1795.72 698.142C1795.87 698.415 1796.08 698.607 1796.36 698.717C1796.64 698.828 1796.96 698.884 1797.33 698.884C1797.58 698.884 1797.84 698.862 1798.09 698.82C1798.35 698.768 1798.55 698.73 1798.68 698.705L1799.54 702.757C1799.27 702.842 1798.88 702.94 1798.39 703.051C1797.89 703.17 1797.29 703.243 1796.59 703.268C1795.27 703.32 1794.12 703.145 1793.13 702.744C1792.15 702.344 1791.39 701.722 1790.85 700.878C1790.3 700.034 1790.03 698.969 1790.04 697.682V678.659ZM1802.01 703V683.364H1807.45V703H1802.01ZM1804.74 680.832C1803.93 680.832 1803.24 680.564 1802.66 680.027C1802.09 679.482 1801.8 678.83 1801.8 678.071C1801.8 677.321 1802.09 676.678 1802.66 676.141C1803.24 675.595 1803.93 675.322 1804.74 675.322C1805.55 675.322 1806.24 675.595 1806.81 676.141C1807.39 676.678 1807.68 677.321 1807.68 678.071C1807.68 678.83 1807.39 679.482 1806.81 680.027C1806.24 680.564 1805.55 680.832 1804.74 680.832ZM1819.97 703.384C1817.98 703.384 1816.27 702.962 1814.82 702.118C1813.38 701.266 1812.26 700.081 1811.48 698.564C1810.7 697.038 1810.3 695.27 1810.3 693.259C1810.3 691.23 1810.7 689.457 1811.48 687.94C1812.26 686.415 1813.38 685.23 1814.82 684.386C1816.27 683.534 1817.98 683.108 1819.97 683.108C1821.95 683.108 1823.67 683.534 1825.11 684.386C1826.56 685.23 1827.67 686.415 1828.46 687.94C1829.24 689.457 1829.63 691.23 1829.63 693.259C1829.63 695.27 1829.24 697.038 1828.46 698.564C1827.67 700.081 1826.56 701.266 1825.11 702.118C1823.67 702.962 1821.95 703.384 1819.97 703.384ZM1819.99 699.165C1820.9 699.165 1821.65 698.909 1822.26 698.398C1822.86 697.878 1823.32 697.17 1823.62 696.276C1823.94 695.381 1824.1 694.362 1824.1 693.22C1824.1 692.078 1823.94 691.06 1823.62 690.165C1823.32 689.27 1822.86 688.562 1822.26 688.043C1821.65 687.523 1820.9 687.263 1819.99 687.263C1819.08 687.263 1818.32 687.523 1817.69 688.043C1817.08 688.562 1816.62 689.27 1816.3 690.165C1815.99 691.06 1815.84 692.078 1815.84 693.22C1815.84 694.362 1815.99 695.381 1816.3 696.276C1816.62 697.17 1817.08 697.878 1817.69 698.398C1818.32 698.909 1819.08 699.165 1819.99 699.165ZM1837.9 691.648V703H1832.45V683.364H1837.65V686.828H1837.88C1838.31 685.686 1839.04 684.783 1840.06 684.118C1841.08 683.445 1842.32 683.108 1843.78 683.108C1845.15 683.108 1846.33 683.406 1847.35 684.003C1848.36 684.599 1849.15 685.452 1849.71 686.56C1850.28 687.659 1850.56 688.972 1850.56 690.497V703H1845.11V691.469C1845.12 690.267 1844.81 689.33 1844.19 688.656C1843.57 687.974 1842.71 687.634 1841.62 687.634C1840.89 687.634 1840.24 687.791 1839.68 688.107C1839.12 688.422 1838.69 688.882 1838.37 689.487C1838.07 690.084 1837.91 690.804 1837.9 691.648ZM1872.3 683.364V687.455H1860.18V683.364H1872.3ZM1862.96 703V681.945C1862.96 680.521 1863.23 679.341 1863.79 678.403C1864.35 677.466 1865.12 676.763 1866.09 676.294C1867.06 675.825 1868.16 675.591 1869.4 675.591C1870.23 675.591 1871 675.655 1871.69 675.783C1872.39 675.911 1872.91 676.026 1873.25 676.128L1872.28 680.219C1872.06 680.151 1871.8 680.087 1871.48 680.027C1871.18 679.967 1870.86 679.938 1870.54 679.938C1869.74 679.938 1869.18 680.125 1868.86 680.5C1868.55 680.866 1868.39 681.382 1868.39 682.047V703H1862.96ZM1883.08 703.384C1881.09 703.384 1879.37 702.962 1877.93 702.118C1876.48 701.266 1875.37 700.081 1874.59 698.564C1873.8 697.038 1873.41 695.27 1873.41 693.259C1873.41 691.23 1873.8 689.457 1874.59 687.94C1875.37 686.415 1876.48 685.23 1877.93 684.386C1879.37 683.534 1881.09 683.108 1883.08 683.108C1885.06 683.108 1886.78 683.534 1888.22 684.386C1889.67 685.23 1890.78 686.415 1891.57 687.94C1892.35 689.457 1892.74 691.23 1892.74 693.259C1892.74 695.27 1892.35 697.038 1891.57 698.564C1890.78 700.081 1889.67 701.266 1888.22 702.118C1886.78 702.962 1885.06 703.384 1883.08 703.384ZM1883.1 699.165C1884.01 699.165 1884.76 698.909 1885.37 698.398C1885.97 697.878 1886.43 697.17 1886.73 696.276C1887.05 695.381 1887.21 694.362 1887.21 693.22C1887.21 692.078 1887.05 691.06 1886.73 690.165C1886.43 689.27 1885.97 688.562 1885.37 688.043C1884.76 687.523 1884.01 687.263 1883.1 687.263C1882.19 687.263 1881.42 687.523 1880.8 688.043C1880.19 688.562 1879.72 689.27 1879.41 690.165C1879.1 691.06 1878.95 692.078 1878.95 693.22C1878.95 694.362 1879.1 695.381 1879.41 696.276C1879.72 697.17 1880.19 697.878 1880.8 698.398C1881.42 698.909 1882.19 699.165 1883.1 699.165ZM1895.56 703V683.364H1900.84V686.79H1901.05C1901.41 685.571 1902.01 684.651 1902.85 684.028C1903.69 683.398 1904.67 683.082 1905.76 683.082C1906.04 683.082 1906.33 683.099 1906.65 683.134C1906.96 683.168 1907.24 683.214 1907.48 683.274V688.107C1907.22 688.03 1906.87 687.962 1906.42 687.902C1905.96 687.842 1905.55 687.812 1905.18 687.812C1904.38 687.812 1903.66 687.987 1903.03 688.337C1902.41 688.678 1901.91 689.155 1901.55 689.768C1901.19 690.382 1901.01 691.089 1901.01 691.891V703H1895.56Z" fill="black"/>
+<path d="M1660.7 758.364V731.364H1666.07V734.662H1666.31C1666.55 734.134 1666.9 733.597 1667.35 733.051C1667.81 732.497 1668.41 732.037 1669.14 731.67C1669.88 731.295 1670.8 731.108 1671.9 731.108C1673.33 731.108 1674.65 731.483 1675.86 732.233C1677.07 732.974 1678.04 734.095 1678.76 735.595C1679.49 737.087 1679.85 738.957 1679.85 741.207C1679.85 743.398 1679.5 745.247 1678.79 746.756C1678.09 748.256 1677.14 749.393 1675.93 750.169C1674.73 750.936 1673.38 751.32 1671.89 751.32C1670.83 751.32 1669.93 751.145 1669.19 750.795C1668.46 750.446 1667.86 750.007 1667.39 749.479C1666.92 748.942 1666.56 748.401 1666.31 747.855H1666.15V758.364H1660.7ZM1666.03 741.182C1666.03 742.349 1666.19 743.368 1666.52 744.237C1666.84 745.107 1667.31 745.784 1667.92 746.27C1668.54 746.747 1669.28 746.986 1670.16 746.986C1671.05 746.986 1671.8 746.743 1672.41 746.257C1673.02 745.763 1673.49 745.081 1673.8 744.212C1674.13 743.334 1674.29 742.324 1674.29 741.182C1674.29 740.048 1674.13 739.051 1673.82 738.19C1673.5 737.33 1673.04 736.656 1672.42 736.17C1671.81 735.685 1671.06 735.442 1670.16 735.442C1669.27 735.442 1668.52 735.676 1667.91 736.145C1667.31 736.614 1666.84 737.278 1666.52 738.139C1666.19 739 1666.03 740.014 1666.03 741.182ZM1691.71 751.384C1689.69 751.384 1687.95 750.974 1686.5 750.156C1685.05 749.33 1683.93 748.162 1683.15 746.653C1682.36 745.136 1681.97 743.342 1681.97 741.271C1681.97 739.251 1682.36 737.479 1683.15 735.953C1683.93 734.428 1685.03 733.239 1686.46 732.386C1687.89 731.534 1689.57 731.108 1691.49 731.108C1692.79 731.108 1694 731.317 1695.11 731.734C1696.24 732.143 1697.22 732.761 1698.05 733.588C1698.9 734.415 1699.55 735.455 1700.02 736.707C1700.49 737.952 1700.72 739.409 1700.72 741.08V742.575H1684.14V739.2H1695.6C1695.6 738.416 1695.43 737.722 1695.09 737.116C1694.75 736.511 1694.27 736.038 1693.67 735.697C1693.07 735.348 1692.38 735.173 1691.58 735.173C1690.76 735.173 1690.02 735.365 1689.38 735.749C1688.75 736.124 1688.26 736.631 1687.9 737.27C1687.54 737.901 1687.36 738.604 1687.35 739.379V742.588C1687.35 743.56 1687.53 744.399 1687.89 745.107C1688.26 745.814 1688.77 746.359 1689.44 746.743C1690.1 747.126 1690.89 747.318 1691.8 747.318C1692.41 747.318 1692.96 747.233 1693.46 747.062C1693.97 746.892 1694.4 746.636 1694.75 746.295C1695.11 745.955 1695.38 745.537 1695.57 745.043L1700.61 745.375C1700.35 746.585 1699.83 747.642 1699.04 748.545C1698.25 749.44 1697.24 750.139 1695.99 750.642C1694.76 751.136 1693.33 751.384 1691.71 751.384ZM1703.56 751V731.364H1708.84V734.79H1709.04C1709.4 733.571 1710 732.651 1710.84 732.028C1711.69 731.398 1712.66 731.082 1713.76 731.082C1714.03 731.082 1714.33 731.099 1714.64 731.134C1714.96 731.168 1715.23 731.214 1715.47 731.274V736.107C1715.22 736.03 1714.86 735.962 1714.41 735.902C1713.96 735.842 1713.55 735.812 1713.17 735.812C1712.37 735.812 1711.65 735.987 1711.02 736.337C1710.4 736.678 1709.91 737.155 1709.54 737.768C1709.18 738.382 1709 739.089 1709 739.891V751H1703.56ZM1729 731.364V735.455H1717.17V731.364H1729ZM1719.86 726.659H1725.3V744.966C1725.3 745.469 1725.38 745.861 1725.53 746.142C1725.69 746.415 1725.9 746.607 1726.17 746.717C1726.45 746.828 1726.78 746.884 1727.14 746.884C1727.4 746.884 1727.65 746.862 1727.91 746.82C1728.17 746.768 1728.36 746.73 1728.5 746.705L1729.36 750.757C1729.08 750.842 1728.7 750.94 1728.2 751.051C1727.71 751.17 1727.11 751.243 1726.4 751.268C1725.09 751.32 1723.94 751.145 1722.95 750.744C1721.97 750.344 1721.21 749.722 1720.66 748.878C1720.12 748.034 1719.85 746.969 1719.86 745.682V726.659ZM1744.42 742.639V731.364H1749.86V751H1744.63V747.433H1744.43C1743.99 748.584 1743.25 749.509 1742.22 750.207C1741.2 750.906 1739.95 751.256 1738.47 751.256C1737.16 751.256 1736.01 750.957 1735.01 750.361C1734.01 749.764 1733.23 748.916 1732.67 747.817C1732.11 746.717 1731.83 745.401 1731.82 743.866V731.364H1737.27V742.895C1737.28 744.054 1737.59 744.97 1738.2 745.643C1738.82 746.317 1739.64 746.653 1740.67 746.653C1741.33 746.653 1741.94 746.504 1742.51 746.206C1743.08 745.899 1743.54 745.447 1743.89 744.851C1744.25 744.254 1744.43 743.517 1744.42 742.639ZM1753.5 751V731.364H1758.78V734.79H1758.98C1759.34 733.571 1759.94 732.651 1760.79 732.028C1761.63 731.398 1762.6 731.082 1763.7 731.082C1763.97 731.082 1764.27 731.099 1764.58 731.134C1764.9 731.168 1765.18 731.214 1765.41 731.274V736.107C1765.16 736.03 1764.8 735.962 1764.35 735.902C1763.9 735.842 1763.49 735.812 1763.11 735.812C1762.31 735.812 1761.6 735.987 1760.97 736.337C1760.34 736.678 1759.85 737.155 1759.48 737.768C1759.12 738.382 1758.95 739.089 1758.95 739.891V751H1753.5ZM1767.61 751V724.818H1773.06V734.662H1773.22C1773.46 734.134 1773.81 733.597 1774.26 733.051C1774.72 732.497 1775.32 732.037 1776.05 731.67C1776.79 731.295 1777.71 731.108 1778.81 731.108C1780.24 731.108 1781.56 731.483 1782.77 732.233C1783.98 732.974 1784.95 734.095 1785.68 735.595C1786.4 737.087 1786.76 738.957 1786.76 741.207C1786.76 743.398 1786.41 745.247 1785.7 746.756C1785 748.256 1784.05 749.393 1782.84 750.169C1781.64 750.936 1780.29 751.32 1778.8 751.32C1777.74 751.32 1776.84 751.145 1776.1 750.795C1775.37 750.446 1774.77 750.007 1774.3 749.479C1773.83 748.942 1773.47 748.401 1773.22 747.855H1772.98V751H1767.61ZM1772.94 741.182C1772.94 742.349 1773.11 743.368 1773.43 744.237C1773.75 745.107 1774.22 745.784 1774.84 746.27C1775.45 746.747 1776.19 746.986 1777.07 746.986C1777.96 746.986 1778.71 746.743 1779.32 746.257C1779.94 745.763 1780.4 745.081 1780.72 744.212C1781.04 743.334 1781.2 742.324 1781.2 741.182C1781.2 740.048 1781.04 739.051 1780.73 738.19C1780.41 737.33 1779.95 736.656 1779.34 736.17C1778.72 735.685 1777.97 735.442 1777.07 735.442C1776.19 735.442 1775.44 735.676 1774.82 736.145C1774.22 736.614 1773.75 737.278 1773.43 738.139C1773.11 739 1772.94 740.014 1772.94 741.182ZM1795.28 751.371C1794.02 751.371 1792.91 751.153 1791.93 750.719C1790.95 750.276 1790.17 749.624 1789.6 748.763C1789.04 747.893 1788.76 746.811 1788.76 745.516C1788.76 744.425 1788.96 743.509 1789.36 742.767C1789.76 742.026 1790.3 741.429 1790.99 740.977C1791.68 740.526 1792.47 740.185 1793.35 739.955C1794.23 739.724 1795.16 739.562 1796.13 739.469C1797.27 739.349 1798.2 739.239 1798.89 739.136C1799.59 739.026 1800.1 738.864 1800.42 738.651C1800.73 738.437 1800.89 738.122 1800.89 737.705V737.628C1800.89 736.818 1800.63 736.192 1800.12 735.749C1799.62 735.305 1798.9 735.084 1797.97 735.084C1796.99 735.084 1796.21 735.301 1795.63 735.736C1795.05 736.162 1794.67 736.699 1794.48 737.347L1789.45 736.938C1789.7 735.744 1790.21 734.713 1790.96 733.844C1791.71 732.966 1792.67 732.293 1793.86 731.824C1795.05 731.347 1796.43 731.108 1798 731.108C1799.09 731.108 1800.13 731.236 1801.13 731.491C1802.14 731.747 1803.03 732.143 1803.8 732.68C1804.59 733.217 1805.21 733.908 1805.66 734.751C1806.11 735.587 1806.33 736.588 1806.33 737.756V751H1801.17V748.277H1801.02C1800.7 748.891 1800.28 749.432 1799.75 749.901C1799.22 750.361 1798.59 750.723 1797.85 750.987C1797.1 751.243 1796.25 751.371 1795.28 751.371ZM1796.84 747.612C1797.64 747.612 1798.34 747.455 1798.96 747.139C1799.57 746.815 1800.05 746.381 1800.4 745.835C1800.75 745.29 1800.93 744.672 1800.93 743.982V741.898C1800.76 742.009 1800.52 742.111 1800.22 742.205C1799.93 742.29 1799.61 742.371 1799.24 742.447C1798.87 742.516 1798.51 742.58 1798.14 742.639C1797.77 742.69 1797.44 742.737 1797.14 742.78C1796.5 742.874 1795.95 743.023 1795.47 743.227C1794.99 743.432 1794.62 743.709 1794.36 744.058C1794.09 744.399 1793.96 744.825 1793.96 745.337C1793.96 746.078 1794.23 746.645 1794.76 747.037C1795.31 747.42 1796 747.612 1796.84 747.612ZM1820.28 731.364V735.455H1808.46V731.364H1820.28ZM1811.14 726.659H1816.59V744.966C1816.59 745.469 1816.67 745.861 1816.82 746.142C1816.97 746.415 1817.19 746.607 1817.46 746.717C1817.74 746.828 1818.06 746.884 1818.43 746.884C1818.69 746.884 1818.94 746.862 1819.2 746.82C1819.45 746.768 1819.65 746.73 1819.79 746.705L1820.64 750.757C1820.37 750.842 1819.99 750.94 1819.49 751.051C1819 751.17 1818.4 751.243 1817.69 751.268C1816.38 751.32 1815.23 751.145 1814.24 750.744C1813.26 750.344 1812.49 749.722 1811.95 748.878C1811.4 748.034 1811.13 746.969 1811.14 745.682V726.659ZM1823.11 751V731.364H1828.56V751H1823.11ZM1825.85 728.832C1825.04 728.832 1824.34 728.564 1823.76 728.027C1823.19 727.482 1822.91 726.83 1822.91 726.071C1822.91 725.321 1823.19 724.678 1823.76 724.141C1824.34 723.595 1825.04 723.322 1825.85 723.322C1826.66 723.322 1827.35 723.595 1827.92 724.141C1828.5 724.678 1828.79 725.321 1828.79 726.071C1828.79 726.83 1828.5 727.482 1827.92 728.027C1827.35 728.564 1826.66 728.832 1825.85 728.832ZM1841.07 751.384C1839.09 751.384 1837.37 750.962 1835.92 750.118C1834.48 749.266 1833.37 748.081 1832.58 746.564C1831.8 745.038 1831.41 743.27 1831.41 741.259C1831.41 739.23 1831.8 737.457 1832.58 735.94C1833.37 734.415 1834.48 733.23 1835.92 732.386C1837.37 731.534 1839.09 731.108 1841.07 731.108C1843.06 731.108 1844.77 731.534 1846.21 732.386C1847.66 733.23 1848.78 734.415 1849.56 735.94C1850.35 737.457 1850.74 739.23 1850.74 741.259C1850.74 743.27 1850.35 745.038 1849.56 746.564C1848.78 748.081 1847.66 749.266 1846.21 750.118C1844.77 750.962 1843.06 751.384 1841.07 751.384ZM1841.1 747.165C1842 747.165 1842.76 746.909 1843.36 746.398C1843.97 745.878 1844.42 745.17 1844.73 744.276C1845.04 743.381 1845.2 742.362 1845.2 741.22C1845.2 740.078 1845.04 739.06 1844.73 738.165C1844.42 737.27 1843.97 736.562 1843.36 736.043C1842.76 735.523 1842 735.263 1841.1 735.263C1840.19 735.263 1839.42 735.523 1838.8 736.043C1838.18 736.562 1837.72 737.27 1837.4 738.165C1837.1 739.06 1836.94 740.078 1836.94 741.22C1836.94 742.362 1837.1 743.381 1837.4 744.276C1837.72 745.17 1838.18 745.878 1838.8 746.398C1839.42 746.909 1840.19 747.165 1841.1 747.165ZM1859 739.648V751H1853.56V731.364H1858.75V734.828H1858.98C1859.41 733.686 1860.14 732.783 1861.16 732.118C1862.19 731.445 1863.43 731.108 1864.89 731.108C1866.25 731.108 1867.44 731.406 1868.45 732.003C1869.47 732.599 1870.25 733.452 1870.82 734.56C1871.38 735.659 1871.66 736.972 1871.66 738.497V751H1866.21V739.469C1866.22 738.267 1865.92 737.33 1865.29 736.656C1864.67 735.974 1863.82 735.634 1862.72 735.634C1861.99 735.634 1861.34 735.791 1860.78 736.107C1860.23 736.422 1859.79 736.882 1859.48 737.487C1859.17 738.084 1859.01 738.804 1859 739.648ZM1882.95 751V724.818H1893.43C1895.36 724.818 1896.96 725.104 1898.25 725.675C1899.54 726.246 1900.5 727.038 1901.15 728.053C1901.8 729.058 1902.12 730.217 1902.12 731.53C1902.12 732.553 1901.92 733.452 1901.51 734.227C1901.1 734.994 1900.54 735.625 1899.82 736.119C1899.11 736.605 1898.31 736.95 1897.39 737.155V737.411C1898.39 737.453 1899.32 737.734 1900.19 738.254C1901.07 738.774 1901.78 739.503 1902.33 740.44C1902.87 741.369 1903.15 742.477 1903.15 743.764C1903.15 745.153 1902.8 746.393 1902.11 747.484C1901.43 748.567 1900.42 749.423 1899.08 750.054C1897.74 750.685 1896.09 751 1894.13 751H1882.95ZM1888.48 746.474H1893C1894.54 746.474 1895.66 746.18 1896.37 745.592C1897.08 744.996 1897.43 744.203 1897.43 743.214C1897.43 742.49 1897.26 741.851 1896.91 741.297C1896.56 740.743 1896.06 740.308 1895.41 739.993C1894.77 739.678 1894.01 739.52 1893.12 739.52H1888.48V746.474ZM1888.48 735.774H1892.59C1893.34 735.774 1894.02 735.642 1894.61 735.378C1895.2 735.105 1895.67 734.722 1896.01 734.227C1896.36 733.733 1896.54 733.141 1896.54 732.45C1896.54 731.504 1896.2 730.741 1895.53 730.162C1894.86 729.582 1893.92 729.293 1892.69 729.293H1888.48V735.774Z" fill="#5C0B4D"/>
+<rect x="1069" y="268" width="285.028" height="61.8182" rx="22" fill="white" stroke="black" stroke-width="4"/>
+<path d="M1098.35 312.384C1096.34 312.384 1094.61 311.957 1093.16 311.105C1091.72 310.244 1090.61 309.051 1089.83 307.526C1089.07 306 1088.68 304.244 1088.68 302.259C1088.68 300.247 1089.07 298.483 1089.85 296.966C1090.63 295.44 1091.74 294.251 1093.18 293.399C1094.62 292.538 1096.34 292.108 1098.32 292.108C1100.04 292.108 1101.54 292.419 1102.82 293.041C1104.11 293.663 1105.13 294.537 1105.88 295.662C1106.63 296.787 1107.04 298.108 1107.12 299.625H1101.98C1101.83 298.645 1101.45 297.857 1100.83 297.26C1100.21 296.655 1099.41 296.352 1098.41 296.352C1097.57 296.352 1096.83 296.582 1096.2 297.043C1095.58 297.494 1095.09 298.155 1094.74 299.024C1094.39 299.893 1094.22 300.946 1094.22 302.182C1094.22 303.435 1094.39 304.5 1094.73 305.378C1095.08 306.256 1095.57 306.925 1096.2 307.385C1096.83 307.845 1097.57 308.075 1098.41 308.075C1099.03 308.075 1099.59 307.947 1100.09 307.692C1100.59 307.436 1101 307.065 1101.33 306.58C1101.66 306.085 1101.88 305.493 1101.98 304.803H1107.12C1107.03 306.303 1106.62 307.624 1105.89 308.766C1105.17 309.899 1104.16 310.786 1102.89 311.425C1101.61 312.064 1100.1 312.384 1098.35 312.384ZM1118.76 312.384C1116.77 312.384 1115.05 311.962 1113.61 311.118C1112.16 310.266 1111.05 309.081 1110.27 307.564C1109.48 306.038 1109.09 304.27 1109.09 302.259C1109.09 300.23 1109.48 298.457 1110.27 296.94C1111.05 295.415 1112.16 294.23 1113.61 293.386C1115.05 292.534 1116.77 292.108 1118.76 292.108C1120.74 292.108 1122.46 292.534 1123.9 293.386C1125.35 294.23 1126.46 295.415 1127.25 296.94C1128.03 298.457 1128.42 300.23 1128.42 302.259C1128.42 304.27 1128.03 306.038 1127.25 307.564C1126.46 309.081 1125.35 310.266 1123.9 311.118C1122.46 311.962 1120.74 312.384 1118.76 312.384ZM1118.78 308.165C1119.69 308.165 1120.44 307.909 1121.05 307.398C1121.65 306.878 1122.11 306.17 1122.41 305.276C1122.73 304.381 1122.89 303.362 1122.89 302.22C1122.89 301.078 1122.73 300.06 1122.41 299.165C1122.11 298.27 1121.65 297.562 1121.05 297.043C1120.44 296.523 1119.69 296.263 1118.78 296.263C1117.87 296.263 1117.1 296.523 1116.48 297.043C1115.87 297.562 1115.4 298.27 1115.09 299.165C1114.78 300.06 1114.63 301.078 1114.63 302.22C1114.63 303.362 1114.78 304.381 1115.09 305.276C1115.4 306.17 1115.87 306.878 1116.48 307.398C1117.1 307.909 1117.87 308.165 1118.78 308.165ZM1131.24 312V292.364H1136.43V295.828H1136.66C1137.07 294.678 1137.75 293.77 1138.71 293.105C1139.66 292.44 1140.81 292.108 1142.14 292.108C1143.48 292.108 1144.63 292.445 1145.57 293.118C1146.52 293.783 1147.15 294.686 1147.47 295.828H1147.67C1148.07 294.703 1148.8 293.804 1149.84 293.131C1150.9 292.449 1152.15 292.108 1153.59 292.108C1155.42 292.108 1156.91 292.692 1158.05 293.859C1159.2 295.018 1159.78 296.663 1159.78 298.794V312H1154.34V299.868C1154.34 298.777 1154.05 297.959 1153.47 297.413C1152.9 296.868 1152.17 296.595 1151.3 296.595C1150.31 296.595 1149.54 296.911 1148.99 297.541C1148.43 298.163 1148.16 298.986 1148.16 300.009V312H1142.88V299.753C1142.88 298.79 1142.6 298.023 1142.05 297.452C1141.5 296.881 1140.78 296.595 1139.89 296.595C1139.28 296.595 1138.73 296.749 1138.25 297.055C1137.77 297.354 1137.39 297.776 1137.11 298.321C1136.83 298.858 1136.69 299.489 1136.69 300.213V312H1131.24ZM1163.36 319.364V292.364H1168.73V295.662H1168.97C1169.21 295.134 1169.55 294.597 1170.01 294.051C1170.47 293.497 1171.06 293.037 1171.8 292.67C1172.54 292.295 1173.46 292.108 1174.56 292.108C1175.99 292.108 1177.31 292.483 1178.52 293.233C1179.73 293.974 1180.7 295.095 1181.42 296.595C1182.15 298.087 1182.51 299.957 1182.51 302.207C1182.51 304.398 1182.16 306.247 1181.45 307.756C1180.75 309.256 1179.8 310.393 1178.58 311.169C1177.38 311.936 1176.04 312.32 1174.55 312.32C1173.49 312.32 1172.59 312.145 1171.85 311.795C1171.11 311.446 1170.51 311.007 1170.05 310.479C1169.58 309.942 1169.22 309.401 1168.97 308.855H1168.8V319.364H1163.36ZM1168.69 302.182C1168.69 303.349 1168.85 304.368 1169.18 305.237C1169.5 306.107 1169.97 306.784 1170.58 307.27C1171.2 307.747 1171.94 307.986 1172.82 307.986C1173.71 307.986 1174.46 307.743 1175.07 307.257C1175.68 306.763 1176.15 306.081 1176.46 305.212C1176.79 304.334 1176.95 303.324 1176.95 302.182C1176.95 301.048 1176.79 300.051 1176.48 299.19C1176.16 298.33 1175.7 297.656 1175.08 297.17C1174.47 296.685 1173.71 296.442 1172.82 296.442C1171.93 296.442 1171.18 296.676 1170.57 297.145C1169.96 297.614 1169.5 298.278 1169.18 299.139C1168.85 300 1168.69 301.014 1168.69 302.182ZM1191.02 312.371C1189.77 312.371 1188.65 312.153 1187.67 311.719C1186.69 311.276 1185.91 310.624 1185.34 309.763C1184.78 308.893 1184.5 307.811 1184.5 306.516C1184.5 305.425 1184.7 304.509 1185.1 303.767C1185.5 303.026 1186.05 302.429 1186.74 301.977C1187.43 301.526 1188.21 301.185 1189.09 300.955C1189.98 300.724 1190.9 300.562 1191.88 300.469C1193.02 300.349 1193.94 300.239 1194.64 300.136C1195.34 300.026 1195.84 299.864 1196.16 299.651C1196.47 299.437 1196.63 299.122 1196.63 298.705V298.628C1196.63 297.818 1196.38 297.192 1195.86 296.749C1195.36 296.305 1194.65 296.084 1193.72 296.084C1192.74 296.084 1191.96 296.301 1191.38 296.736C1190.8 297.162 1190.41 297.699 1190.23 298.347L1185.19 297.938C1185.45 296.744 1185.95 295.713 1186.7 294.844C1187.45 293.966 1188.42 293.293 1189.6 292.824C1190.79 292.347 1192.17 292.108 1193.74 292.108C1194.83 292.108 1195.88 292.236 1196.87 292.491C1197.88 292.747 1198.77 293.143 1199.55 293.68C1200.33 294.217 1200.95 294.908 1201.4 295.751C1201.85 296.587 1202.08 297.588 1202.08 298.756V312H1196.91V309.277H1196.76C1196.44 309.891 1196.02 310.432 1195.49 310.901C1194.97 311.361 1194.33 311.723 1193.59 311.987C1192.85 312.243 1191.99 312.371 1191.02 312.371ZM1192.58 308.612C1193.38 308.612 1194.09 308.455 1194.7 308.139C1195.32 307.815 1195.8 307.381 1196.15 306.835C1196.5 306.29 1196.67 305.672 1196.67 304.982V302.898C1196.5 303.009 1196.27 303.111 1195.97 303.205C1195.68 303.29 1195.35 303.371 1194.98 303.447C1194.62 303.516 1194.25 303.58 1193.88 303.639C1193.52 303.69 1193.18 303.737 1192.89 303.78C1192.25 303.874 1191.69 304.023 1191.21 304.227C1190.73 304.432 1190.36 304.709 1190.1 305.058C1189.83 305.399 1189.7 305.825 1189.7 306.337C1189.7 307.078 1189.97 307.645 1190.51 308.037C1191.05 308.42 1191.74 308.612 1192.58 308.612ZM1205.58 312V292.364H1210.86V295.79H1211.07C1211.43 294.571 1212.03 293.651 1212.87 293.028C1213.71 292.398 1214.69 292.082 1215.78 292.082C1216.06 292.082 1216.35 292.099 1216.67 292.134C1216.98 292.168 1217.26 292.214 1217.5 292.274V297.107C1217.24 297.03 1216.89 296.962 1216.44 296.902C1215.99 296.842 1215.57 296.812 1215.2 296.812C1214.4 296.812 1213.68 296.987 1213.05 297.337C1212.43 297.678 1211.93 298.155 1211.57 298.768C1211.21 299.382 1211.03 300.089 1211.03 300.891V312H1205.58ZM1224.63 312.371C1223.38 312.371 1222.26 312.153 1221.28 311.719C1220.3 311.276 1219.53 310.624 1218.95 309.763C1218.39 308.893 1218.11 307.811 1218.11 306.516C1218.11 305.425 1218.31 304.509 1218.71 303.767C1219.11 303.026 1219.66 302.429 1220.35 301.977C1221.04 301.526 1221.82 301.185 1222.7 300.955C1223.59 300.724 1224.52 300.562 1225.49 300.469C1226.63 300.349 1227.55 300.239 1228.25 300.136C1228.95 300.026 1229.45 299.864 1229.77 299.651C1230.08 299.437 1230.24 299.122 1230.24 298.705V298.628C1230.24 297.818 1229.99 297.192 1229.48 296.749C1228.97 296.305 1228.26 296.084 1227.33 296.084C1226.35 296.084 1225.57 296.301 1224.99 296.736C1224.41 297.162 1224.03 297.699 1223.84 298.347L1218.8 297.938C1219.06 296.744 1219.56 295.713 1220.31 294.844C1221.06 293.966 1222.03 293.293 1223.21 292.824C1224.4 292.347 1225.79 292.108 1227.35 292.108C1228.44 292.108 1229.49 292.236 1230.49 292.491C1231.49 292.747 1232.38 293.143 1233.16 293.68C1233.94 294.217 1234.56 294.908 1235.01 295.751C1235.46 296.587 1235.69 297.588 1235.69 298.756V312H1230.52V309.277H1230.37C1230.06 309.891 1229.63 310.432 1229.1 310.901C1228.58 311.361 1227.94 311.723 1227.2 311.987C1226.46 312.243 1225.6 312.371 1224.63 312.371ZM1226.19 308.612C1226.99 308.612 1227.7 308.455 1228.31 308.139C1228.93 307.815 1229.41 307.381 1229.76 306.835C1230.11 306.29 1230.28 305.672 1230.28 304.982V302.898C1230.11 303.009 1229.88 303.111 1229.58 303.205C1229.29 303.29 1228.96 303.371 1228.59 303.447C1228.23 303.516 1227.86 303.58 1227.49 303.639C1227.13 303.69 1226.8 303.737 1226.5 303.78C1225.86 303.874 1225.3 304.023 1224.82 304.227C1224.34 304.432 1223.97 304.709 1223.71 305.058C1223.45 305.399 1223.31 305.825 1223.31 306.337C1223.31 307.078 1223.58 307.645 1224.12 308.037C1224.66 308.42 1225.35 308.612 1226.19 308.612ZM1249.64 292.364V296.455H1237.81V292.364H1249.64ZM1240.5 287.659H1245.94V305.966C1245.94 306.469 1246.02 306.861 1246.17 307.142C1246.33 307.415 1246.54 307.607 1246.81 307.717C1247.09 307.828 1247.42 307.884 1247.78 307.884C1248.04 307.884 1248.3 307.862 1248.55 307.82C1248.81 307.768 1249 307.73 1249.14 307.705L1250 311.757C1249.72 311.842 1249.34 311.94 1248.85 312.051C1248.35 312.17 1247.75 312.243 1247.04 312.268C1245.73 312.32 1244.58 312.145 1243.59 311.744C1242.61 311.344 1241.85 310.722 1241.3 309.878C1240.76 309.034 1240.49 307.969 1240.5 306.682V287.659ZM1261.13 312.384C1259.14 312.384 1257.42 311.962 1255.98 311.118C1254.53 310.266 1253.42 309.081 1252.64 307.564C1251.85 306.038 1251.46 304.27 1251.46 302.259C1251.46 300.23 1251.85 298.457 1252.64 296.94C1253.42 295.415 1254.53 294.23 1255.98 293.386C1257.42 292.534 1259.14 292.108 1261.13 292.108C1263.11 292.108 1264.83 292.534 1266.27 293.386C1267.72 294.23 1268.83 295.415 1269.62 296.94C1270.4 298.457 1270.79 300.23 1270.79 302.259C1270.79 304.27 1270.4 306.038 1269.62 307.564C1268.83 309.081 1267.72 310.266 1266.27 311.118C1264.83 311.962 1263.11 312.384 1261.13 312.384ZM1261.15 308.165C1262.06 308.165 1262.81 307.909 1263.42 307.398C1264.02 306.878 1264.48 306.17 1264.78 305.276C1265.1 304.381 1265.26 303.362 1265.26 302.22C1265.26 301.078 1265.1 300.06 1264.78 299.165C1264.48 298.27 1264.02 297.562 1263.42 297.043C1262.81 296.523 1262.06 296.263 1261.15 296.263C1260.24 296.263 1259.47 296.523 1258.85 297.043C1258.24 297.562 1257.77 298.27 1257.46 299.165C1257.15 300.06 1257 301.078 1257 302.22C1257 303.362 1257.15 304.381 1257.46 305.276C1257.77 306.17 1258.24 306.878 1258.85 307.398C1259.47 307.909 1260.24 308.165 1261.15 308.165ZM1273.61 312V292.364H1278.89V295.79H1279.1C1279.46 294.571 1280.06 293.651 1280.9 293.028C1281.74 292.398 1282.72 292.082 1283.81 292.082C1284.09 292.082 1284.38 292.099 1284.7 292.134C1285.01 292.168 1285.29 292.214 1285.53 292.274V297.107C1285.27 297.03 1284.92 296.962 1284.47 296.902C1284.02 296.842 1283.6 296.812 1283.23 296.812C1282.43 296.812 1281.71 296.987 1281.08 297.337C1280.46 297.678 1279.96 298.155 1279.6 298.768C1279.24 299.382 1279.06 300.089 1279.06 300.891V312H1273.61ZM1288.56 312.332C1287.71 312.332 1286.99 312.034 1286.38 311.438C1285.79 310.832 1285.49 310.108 1285.49 309.264C1285.49 308.429 1285.79 307.713 1286.38 307.116C1286.99 306.52 1287.71 306.222 1288.56 306.222C1289.38 306.222 1290.09 306.52 1290.7 307.116C1291.32 307.713 1291.63 308.429 1291.63 309.264C1291.63 309.827 1291.48 310.342 1291.19 310.811C1290.91 311.271 1290.54 311.642 1290.08 311.923C1289.62 312.196 1289.11 312.332 1288.56 312.332ZM1295.38 319.364V292.364H1300.75V295.662H1300.99C1301.23 295.134 1301.57 294.597 1302.02 294.051C1302.48 293.497 1303.08 293.037 1303.81 292.67C1304.56 292.295 1305.48 292.108 1306.58 292.108C1308.01 292.108 1309.33 292.483 1310.54 293.233C1311.75 293.974 1312.72 295.095 1313.44 296.595C1314.16 298.087 1314.53 299.957 1314.53 302.207C1314.53 304.398 1314.17 306.247 1313.47 307.756C1312.77 309.256 1311.81 310.393 1310.6 311.169C1309.4 311.936 1308.05 312.32 1306.56 312.32C1305.51 312.32 1304.61 312.145 1303.86 311.795C1303.13 311.446 1302.53 311.007 1302.06 310.479C1301.59 309.942 1301.24 309.401 1300.99 308.855H1300.82V319.364H1295.38ZM1300.71 302.182C1300.71 303.349 1300.87 304.368 1301.19 305.237C1301.52 306.107 1301.99 306.784 1302.6 307.27C1303.21 307.747 1303.96 307.986 1304.84 307.986C1305.72 307.986 1306.47 307.743 1307.09 307.257C1307.7 306.763 1308.16 306.081 1308.48 305.212C1308.8 304.334 1308.97 303.324 1308.97 302.182C1308.97 301.048 1308.81 300.051 1308.49 299.19C1308.18 298.33 1307.71 297.656 1307.1 297.17C1306.49 296.685 1305.73 296.442 1304.84 296.442C1303.95 296.442 1303.2 296.676 1302.59 297.145C1301.98 297.614 1301.52 298.278 1301.19 299.139C1300.87 300 1300.71 301.014 1300.71 302.182ZM1320.17 319.364C1319.48 319.364 1318.83 319.308 1318.22 319.197C1317.63 319.095 1317.13 318.963 1316.74 318.801L1317.97 314.736C1318.61 314.932 1319.18 315.038 1319.69 315.055C1320.21 315.072 1320.66 314.953 1321.04 314.697C1321.42 314.442 1321.73 314.007 1321.97 313.393L1322.29 312.562L1315.25 292.364H1320.97L1325.04 306.784H1325.24L1329.35 292.364H1335.11L1327.48 314.122C1327.11 315.179 1326.61 316.099 1325.98 316.884C1325.36 317.676 1324.57 318.286 1323.62 318.712C1322.66 319.146 1321.51 319.364 1320.17 319.364Z" fill="black"/>
+<rect x="46" y="113" width="241.149" height="61.8182" rx="22" fill="white" stroke="black" stroke-width="4"/>
+<path d="M91.4928 137.364V141.455H79.3735V137.364H91.4928ZM82.1476 157V135.945C82.1476 134.521 82.4246 133.341 82.9786 132.403C83.5411 131.466 84.3081 130.763 85.2797 130.294C86.2513 129.825 87.355 129.591 88.5908 129.591C89.426 129.591 90.1888 129.655 90.8792 129.783C91.578 129.911 92.0979 130.026 92.4388 130.128L91.4672 134.219C91.2542 134.151 90.99 134.087 90.6746 134.027C90.3678 133.967 90.0525 133.938 89.7286 133.938C88.9275 133.938 88.3692 134.125 88.0539 134.5C87.7385 134.866 87.5809 135.382 87.5809 136.047V157H82.1476ZM106.692 148.639V137.364H112.138V157H106.91V153.433H106.705C106.262 154.584 105.525 155.509 104.493 156.207C103.471 156.906 102.222 157.256 100.748 157.256C99.4351 157.256 98.2803 156.957 97.2831 156.361C96.2859 155.764 95.5061 154.916 94.9436 153.817C94.3896 152.717 94.1084 151.401 94.0999 149.866V137.364H99.5459V148.895C99.5544 150.054 99.8655 150.97 100.479 151.643C101.093 152.317 101.915 152.653 102.946 152.653C103.603 152.653 104.216 152.504 104.787 152.206C105.358 151.899 105.819 151.447 106.168 150.851C106.526 150.254 106.701 149.517 106.692 148.639ZM121.22 145.648V157H115.774V137.364H120.965V140.828H121.195C121.63 139.686 122.358 138.783 123.381 138.118C124.404 137.445 125.644 137.108 127.101 137.108C128.465 137.108 129.654 137.406 130.668 138.003C131.682 138.599 132.47 139.452 133.033 140.56C133.595 141.659 133.877 142.972 133.877 144.497V157H128.431V145.469C128.439 144.267 128.132 143.33 127.51 142.656C126.888 141.974 126.031 141.634 124.941 141.634C124.208 141.634 123.56 141.791 122.997 142.107C122.443 142.422 122.009 142.882 121.693 143.487C121.387 144.084 121.229 144.804 121.22 145.648ZM146.321 157.384C144.31 157.384 142.58 156.957 141.131 156.105C139.69 155.244 138.582 154.051 137.807 152.526C137.04 151 136.656 149.244 136.656 147.259C136.656 145.247 137.044 143.483 137.82 141.966C138.604 140.44 139.716 139.251 141.156 138.399C142.597 137.538 144.31 137.108 146.296 137.108C148.009 137.108 149.509 137.419 150.796 138.041C152.082 138.663 153.101 139.537 153.851 140.662C154.601 141.787 155.014 143.108 155.091 144.625H149.952C149.807 143.645 149.423 142.857 148.801 142.26C148.188 141.655 147.382 141.352 146.385 141.352C145.541 141.352 144.804 141.582 144.173 142.043C143.551 142.494 143.065 143.155 142.716 144.024C142.367 144.893 142.192 145.946 142.192 147.182C142.192 148.435 142.362 149.5 142.703 150.378C143.053 151.256 143.543 151.925 144.173 152.385C144.804 152.845 145.541 153.075 146.385 153.075C147.007 153.075 147.565 152.947 148.06 152.692C148.563 152.436 148.976 152.065 149.3 151.58C149.632 151.085 149.849 150.493 149.952 149.803H155.091C155.006 151.303 154.597 152.624 153.864 153.766C153.139 154.899 152.138 155.786 150.859 156.425C149.581 157.064 148.068 157.384 146.321 157.384ZM168.302 137.364V141.455H156.477V137.364H168.302ZM159.162 132.659H164.608V150.966C164.608 151.469 164.685 151.861 164.838 152.142C164.991 152.415 165.204 152.607 165.477 152.717C165.758 152.828 166.082 152.884 166.449 152.884C166.704 152.884 166.96 152.862 167.216 152.82C167.471 152.768 167.667 152.73 167.804 152.705L168.66 156.757C168.388 156.842 168.004 156.94 167.51 157.051C167.015 157.17 166.415 157.243 165.707 157.268C164.395 157.32 163.244 157.145 162.256 156.744C161.275 156.344 160.513 155.722 159.967 154.878C159.422 154.034 159.153 152.969 159.162 151.682V132.659ZM179.791 157.384C177.805 157.384 176.088 156.962 174.639 156.118C173.199 155.266 172.087 154.081 171.303 152.564C170.519 151.038 170.126 149.27 170.126 147.259C170.126 145.23 170.519 143.457 171.303 141.94C172.087 140.415 173.199 139.23 174.639 138.386C176.088 137.534 177.805 137.108 179.791 137.108C181.777 137.108 183.49 137.534 184.93 138.386C186.379 139.23 187.496 140.415 188.28 141.94C189.064 143.457 189.456 145.23 189.456 147.259C189.456 149.27 189.064 151.038 188.28 152.564C187.496 154.081 186.379 155.266 184.93 156.118C183.49 156.962 181.777 157.384 179.791 157.384ZM179.817 153.165C180.72 153.165 181.474 152.909 182.08 152.398C182.685 151.878 183.141 151.17 183.447 150.276C183.763 149.381 183.92 148.362 183.92 147.22C183.92 146.078 183.763 145.06 183.447 144.165C183.141 143.27 182.685 142.562 182.08 142.043C181.474 141.523 180.72 141.263 179.817 141.263C178.905 141.263 178.138 141.523 177.516 142.043C176.902 142.562 176.438 143.27 176.122 144.165C175.815 145.06 175.662 146.078 175.662 147.22C175.662 148.362 175.815 149.381 176.122 150.276C176.438 151.17 176.902 151.878 177.516 152.398C178.138 152.909 178.905 153.165 179.817 153.165ZM192.277 157V137.364H197.557V140.79H197.762C198.12 139.571 198.72 138.651 199.564 138.028C200.408 137.398 201.379 137.082 202.479 137.082C202.752 137.082 203.046 137.099 203.361 137.134C203.676 137.168 203.953 137.214 204.192 137.274V142.107C203.936 142.03 203.583 141.962 203.131 141.902C202.679 141.842 202.266 141.812 201.891 141.812C201.09 141.812 200.374 141.987 199.743 142.337C199.121 142.678 198.627 143.155 198.26 143.768C197.902 144.382 197.723 145.089 197.723 145.891V157H192.277ZM207.221 157.332C206.377 157.332 205.653 157.034 205.048 156.438C204.451 155.832 204.153 155.108 204.153 154.264C204.153 153.429 204.451 152.713 205.048 152.116C205.653 151.52 206.377 151.222 207.221 151.222C208.039 151.222 208.755 151.52 209.369 152.116C209.982 152.713 210.289 153.429 210.289 154.264C210.289 154.827 210.144 155.342 209.854 155.811C209.573 156.271 209.202 156.642 208.742 156.923C208.282 157.196 207.775 157.332 207.221 157.332ZM214.04 164.364V137.364H219.41V140.662H219.653C219.891 140.134 220.236 139.597 220.688 139.051C221.148 138.497 221.745 138.037 222.478 137.67C223.219 137.295 224.14 137.108 225.239 137.108C226.671 137.108 227.992 137.483 229.202 138.233C230.412 138.974 231.38 140.095 232.104 141.595C232.829 143.087 233.191 144.957 233.191 147.207C233.191 149.398 232.837 151.247 232.13 152.756C231.431 154.256 230.476 155.393 229.266 156.169C228.064 156.936 226.718 157.32 225.226 157.32C224.17 157.32 223.27 157.145 222.529 156.795C221.796 156.446 221.195 156.007 220.726 155.479C220.258 154.942 219.9 154.401 219.653 153.855H219.486V164.364H214.04ZM219.371 147.182C219.371 148.349 219.533 149.368 219.857 150.237C220.181 151.107 220.65 151.784 221.263 152.27C221.877 152.747 222.623 152.986 223.501 152.986C224.387 152.986 225.137 152.743 225.751 152.257C226.364 151.763 226.829 151.081 227.144 150.212C227.468 149.334 227.63 148.324 227.63 147.182C227.63 146.048 227.472 145.051 227.157 144.19C226.841 143.33 226.377 142.656 225.763 142.17C225.15 141.685 224.395 141.442 223.501 141.442C222.614 141.442 221.864 141.676 221.251 142.145C220.645 142.614 220.181 143.278 219.857 144.139C219.533 145 219.371 146.014 219.371 147.182ZM238.831 164.364C238.141 164.364 237.493 164.308 236.888 164.197C236.291 164.095 235.797 163.963 235.405 163.801L236.632 159.736C237.271 159.932 237.847 160.038 238.358 160.055C238.878 160.072 239.325 159.953 239.7 159.697C240.084 159.442 240.395 159.007 240.634 158.393L240.953 157.562L233.909 137.364H239.636L243.702 151.784H243.906L248.01 137.364H253.776L246.143 159.122C245.777 160.179 245.278 161.099 244.648 161.884C244.026 162.676 243.237 163.286 242.283 163.712C241.328 164.146 240.178 164.364 238.831 164.364Z" fill="black"/>
+<rect x="4" y="2" width="456" height="62" rx="22" fill="#E6711C" stroke="black" stroke-width="4"/>
+<path d="M84.3929 46V26.3636H89.6727V29.7898H89.8773C90.2352 28.571 90.8361 27.6506 91.6798 27.0284C92.5236 26.3977 93.4952 26.0824 94.5946 26.0824C94.8673 26.0824 95.1614 26.0994 95.4767 26.1335C95.792 26.1676 96.069 26.2145 96.3077 26.2741V31.1065C96.052 31.0298 95.6983 30.9616 95.2466 30.902C94.7949 30.8423 94.3815 30.8125 94.0065 30.8125C93.2054 30.8125 92.4895 30.9872 91.8588 31.3366C91.2367 31.6776 90.7423 32.1548 90.3759 32.7685C90.0179 33.3821 89.8389 34.0895 89.8389 34.8906V46H84.3929ZM98.4034 46V26.3636H103.849V46H98.4034ZM101.139 23.8324C100.33 23.8324 99.6349 23.5639 99.0554 23.027C98.4843 22.4815 98.1988 21.8295 98.1988 21.071C98.1988 20.321 98.4843 19.6776 99.0554 19.1406C99.6349 18.5952 100.33 18.3224 101.139 18.3224C101.949 18.3224 102.639 18.5952 103.21 19.1406C103.79 19.6776 104.08 20.321 104.08 21.071C104.08 21.8295 103.79 22.4815 103.21 23.027C102.639 23.5639 101.949 23.8324 101.139 23.8324ZM112.938 34.6477V46H107.492V26.3636H112.682V29.8281H112.912C113.347 28.6861 114.076 27.7827 115.098 27.1179C116.121 26.4446 117.361 26.108 118.819 26.108C120.182 26.108 121.371 26.4062 122.385 27.0028C123.4 27.5994 124.188 28.4517 124.75 29.5597C125.313 30.6591 125.594 31.9716 125.594 33.4972V46H120.148V34.4688C120.157 33.267 119.85 32.3295 119.228 31.6562C118.606 30.9744 117.749 30.6335 116.658 30.6335C115.925 30.6335 115.277 30.7912 114.715 31.1065C114.161 31.4219 113.726 31.8821 113.411 32.4872C113.104 33.0838 112.947 33.804 112.938 34.6477ZM138.013 53.7727C136.249 53.7727 134.736 53.5298 133.475 53.044C132.222 52.5668 131.225 51.9148 130.483 51.0881C129.742 50.2614 129.26 49.3324 129.039 48.3011L134.076 47.6236C134.229 48.0156 134.472 48.3821 134.804 48.723C135.137 49.0639 135.576 49.3366 136.121 49.5412C136.675 49.7543 137.348 49.8608 138.141 49.8608C139.326 49.8608 140.301 49.571 141.068 48.9915C141.844 48.4205 142.232 47.4616 142.232 46.1151V42.5227H142.002C141.763 43.0682 141.405 43.5838 140.928 44.0696C140.451 44.5554 139.837 44.9517 139.087 45.2585C138.337 45.5653 137.442 45.7188 136.402 45.7188C134.928 45.7188 133.586 45.3778 132.375 44.696C131.174 44.0057 130.215 42.9531 129.499 41.5384C128.791 40.1151 128.438 38.3168 128.438 36.1435C128.438 33.919 128.8 32.0611 129.524 30.5696C130.249 29.0781 131.212 27.9616 132.414 27.2202C133.624 26.4787 134.949 26.108 136.39 26.108C137.489 26.108 138.409 26.2955 139.151 26.6705C139.892 27.0369 140.489 27.4972 140.941 28.0511C141.401 28.5966 141.755 29.1335 142.002 29.6619H142.206V26.3636H147.614V46.1918C147.614 47.8622 147.205 49.2599 146.387 50.3849C145.568 51.5099 144.435 52.3537 142.986 52.9162C141.546 53.4872 139.888 53.7727 138.013 53.7727ZM138.128 41.6278C139.006 41.6278 139.747 41.4105 140.353 40.9759C140.966 40.5327 141.435 39.902 141.759 39.0838C142.091 38.2571 142.257 37.2685 142.257 36.1179C142.257 34.9673 142.095 33.9702 141.772 33.1264C141.448 32.2741 140.979 31.6136 140.365 31.1449C139.752 30.6761 139.006 30.4418 138.128 30.4418C137.233 30.4418 136.479 30.6847 135.865 31.1705C135.252 31.6477 134.787 32.3125 134.472 33.1648C134.157 34.017 133.999 35.0014 133.999 36.1179C133.999 37.2514 134.157 38.2315 134.472 39.0582C134.796 39.8764 135.26 40.5114 135.865 40.9631C136.479 41.4062 137.233 41.6278 138.128 41.6278ZM167.566 31.9631L162.58 32.2699C162.495 31.8437 162.312 31.4602 162.03 31.1193C161.749 30.7699 161.378 30.4929 160.918 30.2884C160.466 30.0753 159.925 29.9688 159.295 29.9688C158.451 29.9688 157.739 30.1477 157.16 30.5057C156.58 30.8551 156.29 31.3239 156.29 31.9119C156.29 32.3807 156.478 32.777 156.853 33.1009C157.228 33.4247 157.871 33.6847 158.783 33.8807L162.337 34.5966C164.246 34.9886 165.67 35.6193 166.607 36.4886C167.545 37.358 168.013 38.5 168.013 39.9148C168.013 41.2017 167.634 42.331 166.875 43.3026C166.125 44.2741 165.094 45.0327 163.782 45.5781C162.478 46.1151 160.973 46.3835 159.269 46.3835C156.67 46.3835 154.598 45.8423 153.056 44.7599C151.522 43.669 150.623 42.1861 150.358 40.3111L155.715 40.0298C155.877 40.8224 156.269 41.4276 156.891 41.8452C157.513 42.2543 158.31 42.4588 159.282 42.4588C160.236 42.4588 161.003 42.2756 161.583 41.9091C162.171 41.5341 162.469 41.0526 162.478 40.4645C162.469 39.9702 162.26 39.5653 161.851 39.25C161.442 38.9261 160.812 38.679 159.959 38.5085L156.559 37.831C154.641 37.4474 153.214 36.7827 152.276 35.8366C151.347 34.8906 150.883 33.6847 150.883 32.2188C150.883 30.9574 151.223 29.8707 151.905 28.9588C152.596 28.0469 153.563 27.3438 154.807 26.8494C156.06 26.3551 157.526 26.108 159.205 26.108C161.685 26.108 163.637 26.6321 165.06 27.6804C166.492 28.7287 167.327 30.1562 167.566 31.9631ZM182.126 18.5909L173.688 49.9375H168.997L177.434 18.5909H182.126ZM200.368 31.9631L195.382 32.2699C195.297 31.8437 195.114 31.4602 194.832 31.1193C194.551 30.7699 194.18 30.4929 193.72 30.2884C193.269 30.0753 192.727 29.9688 192.097 29.9688C191.253 29.9688 190.541 30.1477 189.962 30.5057C189.382 30.8551 189.092 31.3239 189.092 31.9119C189.092 32.3807 189.28 32.777 189.655 33.1009C190.03 33.4247 190.673 33.6847 191.585 33.8807L195.139 34.5966C197.048 34.9886 198.472 35.6193 199.409 36.4886C200.347 37.358 200.815 38.5 200.815 39.9148C200.815 41.2017 200.436 42.331 199.678 43.3026C198.928 44.2741 197.896 45.0327 196.584 45.5781C195.28 46.1151 193.776 46.3835 192.071 46.3835C189.472 46.3835 187.401 45.8423 185.858 44.7599C184.324 43.669 183.425 42.1861 183.161 40.3111L188.517 40.0298C188.679 40.8224 189.071 41.4276 189.693 41.8452C190.315 42.2543 191.112 42.4588 192.084 42.4588C193.038 42.4588 193.805 42.2756 194.385 41.9091C194.973 41.5341 195.271 41.0526 195.28 40.4645C195.271 39.9702 195.063 39.5653 194.654 39.25C194.244 38.9261 193.614 38.679 192.761 38.5085L189.361 37.831C187.443 37.4474 186.016 36.7827 185.078 35.8366C184.149 34.8906 183.685 33.6847 183.685 32.2188C183.685 30.9574 184.026 29.8707 184.707 28.9588C185.398 28.0469 186.365 27.3438 187.609 26.8494C188.862 26.3551 190.328 26.108 192.007 26.108C194.487 26.108 196.439 26.6321 197.862 27.6804C199.294 28.7287 200.129 30.1562 200.368 31.9631ZM212.474 46.3835C210.454 46.3835 208.715 45.9744 207.258 45.1562C205.809 44.3295 204.692 43.1619 203.908 41.6534C203.124 40.1364 202.732 38.3423 202.732 36.2713C202.732 34.2514 203.124 32.4787 203.908 30.9531C204.692 29.4276 205.796 28.2386 207.219 27.3864C208.651 26.5341 210.33 26.108 212.256 26.108C213.552 26.108 214.758 26.3168 215.874 26.7344C216.999 27.1435 217.979 27.7614 218.815 28.5881C219.658 29.4148 220.315 30.4545 220.783 31.7074C221.252 32.9517 221.486 34.4091 221.486 36.0795V37.5753H204.905V34.2003H216.36C216.36 33.4162 216.19 32.7216 215.849 32.1165C215.508 31.5114 215.035 31.0384 214.43 30.6974C213.833 30.348 213.138 30.1733 212.346 30.1733C211.519 30.1733 210.786 30.3651 210.147 30.7486C209.516 31.1236 209.022 31.6307 208.664 32.2699C208.306 32.9006 208.123 33.6037 208.114 34.3793V37.5881C208.114 38.5597 208.293 39.3991 208.651 40.1065C209.018 40.8139 209.533 41.3594 210.198 41.7429C210.863 42.1264 211.651 42.3182 212.563 42.3182C213.168 42.3182 213.722 42.233 214.225 42.0625C214.728 41.892 215.158 41.6364 215.516 41.2955C215.874 40.9545 216.147 40.5369 216.334 40.0426L221.371 40.375C221.116 41.5852 220.592 42.642 219.799 43.5455C219.015 44.4403 218.001 45.1392 216.756 45.642C215.521 46.1364 214.093 46.3835 212.474 46.3835ZM224.32 53.3636V26.3636H229.69V29.6619H229.933C230.171 29.1335 230.516 28.5966 230.968 28.0511C231.428 27.4972 232.025 27.0369 232.758 26.6705C233.499 26.2955 234.42 26.108 235.519 26.108C236.951 26.108 238.272 26.483 239.482 27.233C240.693 27.9744 241.66 29.0952 242.384 30.5952C243.109 32.0866 243.471 33.9574 243.471 36.2074C243.471 38.3977 243.117 40.2472 242.41 41.7557C241.711 43.2557 240.756 44.3935 239.546 45.169C238.345 45.9361 236.998 46.3196 235.506 46.3196C234.45 46.3196 233.551 46.1449 232.809 45.7955C232.076 45.446 231.475 45.0071 231.006 44.4787C230.538 43.9418 230.18 43.4006 229.933 42.8551H229.766V53.3636H224.32ZM229.651 36.1818C229.651 37.3494 229.813 38.3679 230.137 39.2372C230.461 40.1065 230.93 40.7841 231.543 41.2699C232.157 41.7472 232.903 41.9858 233.781 41.9858C234.667 41.9858 235.417 41.7429 236.031 41.2571C236.644 40.7628 237.109 40.081 237.424 39.2116C237.748 38.3338 237.91 37.3239 237.91 36.1818C237.91 35.0483 237.752 34.0511 237.437 33.1903C237.122 32.3295 236.657 31.6562 236.043 31.1705C235.43 30.6847 234.676 30.4418 233.781 30.4418C232.894 30.4418 232.144 30.6761 231.531 31.1449C230.926 31.6136 230.461 32.2784 230.137 33.1392C229.813 34 229.651 35.0142 229.651 36.1818ZM251.981 46.3707C250.728 46.3707 249.612 46.1534 248.632 45.7188C247.652 45.2756 246.876 44.6236 246.305 43.7628C245.742 42.8935 245.461 41.8111 245.461 40.5156C245.461 39.4247 245.661 38.5085 246.062 37.767C246.463 37.0256 247.008 36.429 247.698 35.9773C248.389 35.5256 249.173 35.1847 250.051 34.9545C250.937 34.7244 251.866 34.5625 252.838 34.4688C253.98 34.3494 254.9 34.2386 255.599 34.1364C256.298 34.0256 256.805 33.8636 257.12 33.6506C257.436 33.4375 257.593 33.1222 257.593 32.7045V32.6278C257.593 31.8182 257.338 31.1918 256.826 30.7486C256.323 30.3054 255.608 30.0838 254.679 30.0838C253.698 30.0838 252.919 30.3011 252.339 30.7358C251.759 31.1619 251.376 31.6989 251.188 32.3466L246.152 31.9375C246.407 30.7443 246.91 29.7131 247.66 28.8438C248.41 27.9659 249.377 27.2926 250.562 26.8239C251.755 26.3466 253.136 26.108 254.704 26.108C255.795 26.108 256.839 26.2358 257.836 26.4915C258.842 26.7472 259.733 27.1435 260.508 27.6804C261.292 28.2173 261.91 28.9077 262.362 29.7514C262.813 30.5866 263.039 31.5881 263.039 32.7557V46H257.875V43.277H257.721C257.406 43.8906 256.984 44.4318 256.456 44.9006C255.927 45.3608 255.292 45.723 254.551 45.9872C253.809 46.2429 252.953 46.3707 251.981 46.3707ZM253.541 42.6122C254.342 42.6122 255.049 42.4545 255.663 42.1392C256.277 41.8153 256.758 41.3807 257.108 40.8352C257.457 40.2898 257.632 39.6719 257.632 38.9815V36.8977C257.461 37.0085 257.227 37.1108 256.929 37.2045C256.639 37.2898 256.311 37.3707 255.944 37.4474C255.578 37.5156 255.211 37.5795 254.845 37.6392C254.478 37.6903 254.146 37.7372 253.848 37.7798C253.208 37.8736 252.65 38.0227 252.173 38.2273C251.696 38.4318 251.325 38.7088 251.061 39.0582C250.796 39.3991 250.664 39.8253 250.664 40.3366C250.664 41.0781 250.933 41.6449 251.47 42.0369C252.015 42.4205 252.706 42.6122 253.541 42.6122ZM266.544 46V26.3636H271.824V29.7898H272.029C272.387 28.571 272.988 27.6506 273.831 27.0284C274.675 26.3977 275.647 26.0824 276.746 26.0824C277.019 26.0824 277.313 26.0994 277.628 26.1335C277.944 26.1676 278.221 26.2145 278.459 26.2741V31.1065C278.204 31.0298 277.85 30.9616 277.398 30.902C276.946 30.8423 276.533 30.8125 276.158 30.8125C275.357 30.8125 274.641 30.9872 274.01 31.3366C273.388 31.6776 272.894 32.1548 272.527 32.7685C272.169 33.3821 271.99 34.0895 271.99 34.8906V46H266.544ZM285.592 46.3707C284.339 46.3707 283.223 46.1534 282.242 45.7188C281.262 45.2756 280.487 44.6236 279.916 43.7628C279.353 42.8935 279.072 41.8111 279.072 40.5156C279.072 39.4247 279.272 38.5085 279.673 37.767C280.073 37.0256 280.619 36.429 281.309 35.9773C282 35.5256 282.784 35.1847 283.661 34.9545C284.548 34.7244 285.477 34.5625 286.448 34.4688C287.59 34.3494 288.511 34.2386 289.21 34.1364C289.909 34.0256 290.416 33.8636 290.731 33.6506C291.046 33.4375 291.204 33.1222 291.204 32.7045V32.6278C291.204 31.8182 290.948 31.1918 290.437 30.7486C289.934 30.3054 289.218 30.0838 288.289 30.0838C287.309 30.0838 286.529 30.3011 285.95 30.7358C285.37 31.1619 284.987 31.6989 284.799 32.3466L279.762 31.9375C280.018 30.7443 280.521 29.7131 281.271 28.8438C282.021 27.9659 282.988 27.2926 284.173 26.8239C285.366 26.3466 286.747 26.108 288.315 26.108C289.406 26.108 290.45 26.2358 291.447 26.4915C292.453 26.7472 293.343 27.1435 294.119 27.6804C294.903 28.2173 295.521 28.9077 295.973 29.7514C296.424 30.5866 296.65 31.5881 296.65 32.7557V46H291.485V43.277H291.332C291.017 43.8906 290.595 44.4318 290.066 44.9006C289.538 45.3608 288.903 45.723 288.161 45.9872C287.42 46.2429 286.563 46.3707 285.592 46.3707ZM287.152 42.6122C287.953 42.6122 288.66 42.4545 289.274 42.1392C289.887 41.8153 290.369 41.3807 290.718 40.8352C291.068 40.2898 291.242 39.6719 291.242 38.9815V36.8977C291.072 37.0085 290.838 37.1108 290.539 37.2045C290.25 37.2898 289.921 37.3707 289.555 37.4474C289.188 37.5156 288.822 37.5795 288.456 37.6392C288.089 37.6903 287.757 37.7372 287.458 37.7798C286.819 37.8736 286.261 38.0227 285.784 38.2273C285.306 38.4318 284.936 38.7088 284.671 39.0582C284.407 39.3991 284.275 39.8253 284.275 40.3366C284.275 41.0781 284.544 41.6449 285.081 42.0369C285.626 42.4205 286.316 42.6122 287.152 42.6122ZM300.258 46V19.8182H305.704V29.6619H305.87C306.108 29.1335 306.454 28.5966 306.905 28.0511C307.365 27.4972 307.962 27.0369 308.695 26.6705C309.436 26.2955 310.357 26.108 311.456 26.108C312.888 26.108 314.209 26.483 315.419 27.233C316.63 27.9744 317.597 29.0952 318.321 30.5952C319.046 32.0866 319.408 33.9574 319.408 36.2074C319.408 38.3977 319.054 40.2472 318.347 41.7557C317.648 43.2557 316.694 44.3935 315.483 45.169C314.282 45.9361 312.935 46.3196 311.444 46.3196C310.387 46.3196 309.488 46.1449 308.746 45.7955C308.013 45.446 307.412 45.0071 306.944 44.4787C306.475 43.9418 306.117 43.4006 305.87 42.8551H305.627V46H300.258ZM305.588 36.1818C305.588 37.3494 305.75 38.3679 306.074 39.2372C306.398 40.1065 306.867 40.7841 307.481 41.2699C308.094 41.7472 308.84 41.9858 309.718 41.9858C310.604 41.9858 311.354 41.7429 311.968 41.2571C312.581 40.7628 313.046 40.081 313.361 39.2116C313.685 38.3338 313.847 37.3239 313.847 36.1818C313.847 35.0483 313.689 34.0511 313.374 33.1903C313.059 32.3295 312.594 31.6562 311.981 31.1705C311.367 30.6847 310.613 30.4418 309.718 30.4418C308.831 30.4418 308.081 30.6761 307.468 31.1449C306.863 31.6136 306.398 32.2784 306.074 33.1392C305.75 34 305.588 35.0142 305.588 36.1818ZM322.322 46V26.3636H327.768V46H322.322ZM325.058 23.8324C324.248 23.8324 323.554 23.5639 322.974 23.027C322.403 22.4815 322.117 21.8295 322.117 21.071C322.117 20.321 322.403 19.6776 322.974 19.1406C323.554 18.5952 324.248 18.3224 325.058 18.3224C325.867 18.3224 326.558 18.5952 327.129 19.1406C327.708 19.6776 327.998 20.321 327.998 21.071C327.998 21.8295 327.708 22.4815 327.129 23.027C326.558 23.5639 325.867 23.8324 325.058 23.8324ZM336.857 19.8182V46H331.411V19.8182H336.857ZM340.499 46V26.3636H345.945V46H340.499ZM343.235 23.8324C342.425 23.8324 341.731 23.5639 341.151 23.027C340.58 22.4815 340.295 21.8295 340.295 21.071C340.295 20.321 340.58 19.6776 341.151 19.1406C341.731 18.5952 342.425 18.3224 343.235 18.3224C344.045 18.3224 344.735 18.5952 345.306 19.1406C345.886 19.6776 346.175 20.321 346.175 21.071C346.175 21.8295 345.886 22.4815 345.306 23.027C344.735 23.5639 344.045 23.8324 343.235 23.8324ZM360.032 26.3636V30.4545H348.207V26.3636H360.032ZM350.892 21.6591H356.338V39.9659C356.338 40.4687 356.414 40.8608 356.568 41.142C356.721 41.4148 356.934 41.6065 357.207 41.7173C357.488 41.8281 357.812 41.8835 358.179 41.8835C358.434 41.8835 358.69 41.8622 358.946 41.8196C359.201 41.7685 359.397 41.7301 359.534 41.7045L360.39 45.7571C360.118 45.8423 359.734 45.9403 359.24 46.0511C358.745 46.1705 358.145 46.2429 357.437 46.2685C356.125 46.3196 354.974 46.1449 353.985 45.7443C353.005 45.3437 352.243 44.7216 351.697 43.8778C351.152 43.0341 350.883 41.9687 350.892 40.6818V21.6591ZM366.222 53.3636C365.532 53.3636 364.884 53.3082 364.279 53.1974C363.682 53.0952 363.188 52.9631 362.796 52.8011L364.023 48.7358C364.662 48.9318 365.238 49.0384 365.749 49.0554C366.269 49.0724 366.716 48.9531 367.091 48.6974C367.475 48.4418 367.786 48.0071 368.025 47.3935L368.344 46.5625L361.3 26.3636H367.028L371.093 40.7841H371.297L375.401 26.3636H381.167L373.535 48.1222C373.168 49.179 372.67 50.0994 372.039 50.8835C371.417 51.6761 370.628 52.2855 369.674 52.7116C368.719 53.1463 367.569 53.3636 366.222 53.3636Z" fill="white"/>
+<rect x="1451" y="528" width="144" height="156" rx="6" fill="#D9D9D9" stroke="black" stroke-width="4"/>
+<path d="M1531.5 554.78L1513.5 562.706V557.528L1525.82 552.581L1525.66 552.849V552.21L1525.82 552.479L1513.5 547.531V542.354L1531.5 550.28V554.78ZM1529.06 583.591L1520.63 614.938H1515.93L1524.37 583.591H1529.06ZM1513.5 650.78V646.28L1531.5 638.354V643.531L1519.18 648.479L1519.34 648.21V648.849L1519.18 648.581L1531.5 653.528V658.706L1513.5 650.78Z" fill="black"/>
+<path d="M1526.19 465.375H1514.56C1514.6 461.375 1514.96 458.104 1515.62 455.562C1516.33 452.979 1517.48 450.625 1519.06 448.5C1520.65 446.375 1522.75 443.958 1525.38 441.25C1527.29 439.292 1529.04 437.458 1530.62 435.75C1532.25 434 1533.56 432.125 1534.56 430.125C1535.56 428.083 1536.06 425.646 1536.06 422.812C1536.06 419.938 1535.54 417.458 1534.5 415.375C1533.5 413.292 1532 411.688 1530 410.562C1528.04 409.438 1525.6 408.875 1522.69 408.875C1520.27 408.875 1517.98 409.312 1515.81 410.188C1513.65 411.062 1511.9 412.417 1510.56 414.25C1509.23 416.042 1508.54 418.396 1508.5 421.312H1496.94C1497.02 416.604 1498.19 412.562 1500.44 409.188C1502.73 405.812 1505.81 403.229 1509.69 401.438C1513.56 399.646 1517.9 398.75 1522.69 398.75C1527.98 398.75 1532.48 399.708 1536.19 401.625C1539.94 403.542 1542.79 406.292 1544.75 409.875C1546.71 413.417 1547.69 417.625 1547.69 422.5C1547.69 426.25 1546.92 429.708 1545.38 432.875C1543.88 436 1541.94 438.938 1539.56 441.688C1537.19 444.438 1534.67 447.062 1532 449.562C1529.71 451.688 1528.17 454.083 1527.38 456.75C1526.58 459.417 1526.19 462.292 1526.19 465.375ZM1514.06 485.188C1514.06 483.312 1514.65 481.729 1515.81 480.438C1516.98 479.146 1518.67 478.5 1520.88 478.5C1523.12 478.5 1524.83 479.146 1526 480.438C1527.17 481.729 1527.75 483.312 1527.75 485.188C1527.75 486.979 1527.17 488.521 1526 489.812C1524.83 491.104 1523.12 491.75 1520.88 491.75C1518.67 491.75 1516.98 491.104 1515.81 489.812C1514.65 488.521 1514.06 486.979 1514.06 485.188Z" fill="black"/>
+<mask id="mask103_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="536" y="854" width="112" height="114">
+<path d="M536 967.037H647.004V854H536V967.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask103_13_16077)">
+<mask id="mask104_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask104_13_16077)">
+<path d="M632.723 910.52L627.2 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask105_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask105_13_16077)">
+<path d="M632.723 910.52L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask106_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask106_13_16077)">
+<path d="M632.723 910.52L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask107_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask107_13_16077)">
+<path d="M632.723 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask108_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask108_13_16077)">
+<path d="M627.2 889.532L612.112 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask109_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask109_13_16077)">
+<path d="M627.2 889.532L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask110_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask110_13_16077)">
+<path d="M627.2 889.532L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask111_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask111_13_16077)">
+<path d="M612.112 874.168L591.501 868.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask112_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask112_13_16077)">
+<path d="M570.89 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask113_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask113_13_16077)">
+<path d="M570.891 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask114_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask114_13_16077)">
+<path d="M570.89 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask115_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask115_13_16077)">
+<path d="M555.802 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask116_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask116_13_16077)">
+<path d="M555.802 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask117_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask117_13_16077)">
+<path d="M555.802 889.532L570.89 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask118_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask118_13_16077)">
+<path d="M550.28 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask119_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask119_13_16077)">
+<path d="M570.891 946.872L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask120_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask120_13_16077)">
+<path d="M570.891 946.872H612.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask121_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask121_13_16077)">
+<path d="M570.891 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask122_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask122_13_16077)">
+<path d="M591.501 952.495L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask123_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask123_13_16077)">
+<path d="M591.501 952.495L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask124_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask124_13_16077)">
+<path d="M612.112 946.872L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask125_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask125_13_16077)">
+<path d="M632.723 910.52L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask126_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask126_13_16077)">
+<path d="M632.723 910.52L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask127_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask127_13_16077)">
+<path d="M632.723 910.52L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask128_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask128_13_16077)">
+<path d="M632.723 910.52L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask129_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask129_13_16077)">
+<path d="M632.723 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask130_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask130_13_16077)">
+<path d="M632.723 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask131_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask131_13_16077)">
+<path d="M632.723 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask132_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask132_13_16077)">
+<path d="M627.2 889.532H555.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask133_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask133_13_16077)">
+<path d="M627.2 889.532L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask134_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask134_13_16077)">
+<path d="M627.2 889.532L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask135_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask135_13_16077)">
+<path d="M627.2 889.532L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask136_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask136_13_16077)">
+<path d="M627.2 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask137_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask137_13_16077)">
+<path d="M627.2 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask138_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask138_13_16077)">
+<path d="M627.2 889.532V931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask139_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask139_13_16077)">
+<path d="M612.112 874.168H570.891" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask140_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask140_13_16077)">
+<path d="M612.112 874.168L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask141_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask141_13_16077)">
+<path d="M612.112 874.168L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask142_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask142_13_16077)">
+<path d="M612.112 874.168L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask143_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask143_13_16077)">
+<path d="M612.112 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask144_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask144_13_16077)">
+<path d="M612.112 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask145_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask145_13_16077)">
+<path d="M612.112 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask146_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask146_13_16077)">
+<path d="M612.112 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask147_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask147_13_16077)">
+<path d="M591.501 868.544L570.891 874.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask148_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask148_13_16077)">
+<path d="M591.501 868.544L555.802 889.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask149_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask149_13_16077)">
+<path d="M591.501 868.544L550.28 910.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask150_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask150_13_16077)">
+<path d="M591.501 868.544L555.802 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask151_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask151_13_16077)">
+<path d="M591.501 868.544L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask152_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask152_13_16077)">
+<path d="M591.501 868.544V952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask153_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask153_13_16077)">
+<path d="M591.501 868.544L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask154_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask154_13_16077)">
+<path d="M591.501 868.544L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask155_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask155_13_16077)">
+<path d="M570.891 874.168L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask156_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask156_13_16077)">
+<path d="M570.891 874.168L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask157_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask157_13_16077)">
+<path d="M570.891 874.168L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask158_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask158_13_16077)">
+<path d="M570.891 874.168L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask159_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask159_13_16077)">
+<path d="M555.802 889.532L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask160_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask160_13_16077)">
+<path d="M555.802 889.532L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask161_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask161_13_16077)">
+<path d="M555.802 889.532L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask162_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask162_13_16077)">
+<path d="M550.28 910.52L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask163_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask163_13_16077)">
+<path d="M550.28 910.52L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask164_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask164_13_16077)">
+<path d="M550.28 910.52L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask165_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask165_13_16077)">
+<path d="M550.28 910.52L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask166_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask166_13_16077)">
+<path d="M555.802 931.508L570.891 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask167_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask167_13_16077)">
+<path d="M555.802 931.508L591.501 952.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask168_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask168_13_16077)">
+<path d="M555.802 931.508L612.112 946.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask169_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask169_13_16077)">
+<path d="M555.802 931.508L627.2 931.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask170_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask170_13_16077)">
+<mask id="mask171_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="627" y="905" width="11" height="11">
+<path d="M627.766 915.568H637.68V905.472H627.766V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask171_13_16077)">
+<path d="M632.723 915.045C633.901 915.045 635.032 914.568 635.865 913.72C636.699 912.871 637.167 911.72 637.167 910.52C637.167 909.32 636.699 908.168 635.865 907.32C635.032 906.471 633.901 905.994 632.723 905.994C631.544 905.994 630.414 906.471 629.58 907.32C628.747 908.168 628.279 909.32 628.279 910.52C628.279 911.72 628.747 912.871 629.58 913.72C630.414 914.568 631.544 915.045 632.723 915.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask172_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask172_13_16077)">
+<mask id="mask173_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="884" width="11" height="11">
+<path d="M622.243 894.58H632.157V884.484H622.243V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask173_13_16077)">
+<path d="M627.2 894.057C628.379 894.057 629.509 893.58 630.343 892.732C631.176 891.883 631.644 890.732 631.644 889.532C631.644 888.332 631.176 887.181 630.343 886.332C629.509 885.483 628.379 885.007 627.2 885.007C626.022 885.007 624.891 885.483 624.058 886.332C623.224 887.181 622.756 888.332 622.756 889.532C622.756 890.732 623.224 891.883 624.058 892.732C624.891 893.58 626.022 894.057 627.2 894.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask174_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask174_13_16077)">
+<mask id="mask175_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="869" width="11" height="11">
+<path d="M607.155 879.215H617.069V869.12H607.155V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask175_13_16077)">
+<path d="M612.112 878.693C613.291 878.693 614.421 878.216 615.254 877.367C616.088 876.519 616.556 875.368 616.556 874.168C616.556 872.967 616.088 871.816 615.254 870.968C614.421 870.119 613.291 869.642 612.112 869.642C610.933 869.642 609.803 870.119 608.97 870.968C608.136 871.816 607.668 872.967 607.668 874.168C607.668 875.368 608.136 876.519 608.97 877.367C609.803 878.216 610.933 878.693 612.112 878.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask176_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask176_13_16077)">
+<mask id="mask177_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="863" width="11" height="11">
+<path d="M586.544 873.592H596.458V863.496H586.544V873.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask177_13_16077)">
+<path d="M591.501 873.069C592.68 873.069 593.81 872.592 594.644 871.744C595.477 870.895 595.945 869.744 595.945 868.544C595.945 867.344 595.477 866.193 594.644 865.344C593.81 864.495 592.68 864.019 591.501 864.019C590.323 864.019 589.192 864.495 588.359 865.344C587.526 866.193 587.057 867.344 587.057 868.544C587.057 869.744 587.526 870.895 588.359 871.744C589.192 872.592 590.323 873.069 591.501 873.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask178_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask178_13_16077)">
+<mask id="mask179_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="869" width="11" height="11">
+<path d="M565.933 879.215H575.848V869.12H565.933V879.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask179_13_16077)">
+<path d="M570.891 878.693C572.069 878.693 573.2 878.216 574.033 877.367C574.866 876.519 575.334 875.368 575.334 874.168C575.334 872.967 574.866 871.816 574.033 870.968C573.2 870.119 572.069 869.642 570.891 869.642C569.712 869.642 568.581 870.119 567.748 870.968C566.915 871.816 566.447 872.967 566.447 874.168C566.447 875.368 566.915 876.519 567.748 877.367C568.581 878.216 569.712 878.693 570.891 878.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask180_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask180_13_16077)">
+<mask id="mask181_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="884" width="11" height="11">
+<path d="M550.845 894.58H560.76V884.484H550.845V894.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask181_13_16077)">
+<path d="M555.802 894.057C556.981 894.057 558.111 893.58 558.945 892.732C559.778 891.883 560.246 890.732 560.246 889.532C560.246 888.332 559.778 887.181 558.945 886.332C558.111 885.483 556.981 885.007 555.802 885.007C554.624 885.007 553.493 885.483 552.66 886.332C551.827 887.181 551.358 888.332 551.358 889.532C551.358 890.732 551.827 891.883 552.66 892.732C553.493 893.58 554.624 894.057 555.802 894.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask182_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask182_13_16077)">
+<mask id="mask183_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="545" y="905" width="11" height="11">
+<path d="M545.323 915.568H555.237V905.472H545.323V915.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask183_13_16077)">
+<path d="M550.28 915.045C551.458 915.045 552.589 914.568 553.422 913.72C554.255 912.871 554.724 911.72 554.724 910.52C554.724 909.32 554.255 908.168 553.422 907.32C552.589 906.471 551.458 905.994 550.28 905.994C549.101 905.994 547.971 906.471 547.137 907.32C546.304 908.168 545.836 909.32 545.836 910.52C545.836 911.72 546.304 912.871 547.137 913.72C547.971 914.568 549.101 915.045 550.28 915.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask184_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask184_13_16077)">
+<mask id="mask185_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="550" y="926" width="11" height="11">
+<path d="M550.845 936.555H560.76V926.46H550.845V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask185_13_16077)">
+<path d="M555.802 936.033C556.981 936.033 558.111 935.556 558.945 934.708C559.778 933.859 560.246 932.708 560.246 931.508C560.246 930.308 559.778 929.156 558.945 928.308C558.111 927.459 556.981 926.982 555.802 926.982C554.624 926.982 553.493 927.459 552.66 928.308C551.827 929.156 551.358 930.308 551.358 931.508C551.358 932.708 551.827 933.859 552.66 934.708C553.493 935.556 554.624 936.033 555.802 936.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask186_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask186_13_16077)">
+<mask id="mask187_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="565" y="941" width="11" height="11">
+<path d="M565.933 951.92H575.848V941.824H565.933V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask187_13_16077)">
+<path d="M570.891 951.397C572.069 951.397 573.2 950.92 574.033 950.072C574.866 949.223 575.334 948.072 575.334 946.872C575.334 945.672 574.866 944.521 574.033 943.672C573.2 942.823 572.069 942.347 570.891 942.347C569.712 942.347 568.581 942.823 567.748 943.672C566.915 944.521 566.447 945.672 566.447 946.872C566.447 948.072 566.915 949.223 567.748 950.072C568.581 950.92 569.712 951.397 570.891 951.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask188_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask188_13_16077)">
+<mask id="mask189_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="586" y="947" width="11" height="11">
+<path d="M586.544 957.543H596.458V947.448H586.544V957.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask189_13_16077)">
+<path d="M591.501 957.021C592.68 957.021 593.81 956.544 594.644 955.695C595.477 954.847 595.945 953.696 595.945 952.496C595.945 951.295 595.477 950.144 594.644 949.296C593.81 948.447 592.68 947.97 591.501 947.97C590.323 947.97 589.192 948.447 588.359 949.296C587.526 950.144 587.057 951.295 587.057 952.496C587.057 953.696 587.526 954.847 588.359 955.695C589.192 956.544 590.323 957.021 591.501 957.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask190_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask190_13_16077)">
+<mask id="mask191_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="607" y="941" width="11" height="11">
+<path d="M607.155 951.92H617.069V941.824H607.155V951.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask191_13_16077)">
+<path d="M612.112 951.397C613.291 951.397 614.421 950.92 615.254 950.072C616.088 949.223 616.556 948.072 616.556 946.872C616.556 945.672 616.088 944.521 615.254 943.672C614.421 942.823 613.291 942.347 612.112 942.347C610.933 942.347 609.803 942.823 608.97 943.672C608.136 944.521 607.668 945.672 607.668 946.872C607.668 948.072 608.136 949.223 608.97 950.072C609.803 950.92 610.933 951.397 612.112 951.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask192_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask192_13_16077)">
+<mask id="mask193_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="622" y="926" width="11" height="11">
+<path d="M622.243 936.555H632.157V926.46H622.243V936.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask193_13_16077)">
+<path d="M627.2 936.033C628.379 936.033 629.509 935.556 630.343 934.708C631.176 933.859 631.644 932.708 631.644 931.508C631.644 930.308 631.176 929.156 630.343 928.308C629.509 927.459 628.379 926.982 627.2 926.982C626.022 926.982 624.891 927.459 624.058 928.308C623.224 929.156 622.756 930.308 622.756 931.508C622.756 932.708 623.224 933.859 624.058 934.708C624.891 935.556 626.022 936.033 627.2 936.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask194_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask194_13_16077)">
+<path d="M632.767 907.274C632.36 907.274 632.066 907.389 631.795 907.642C631.388 908.057 631.117 908.885 631.117 909.737C631.117 910.542 631.343 911.394 631.682 911.808C631.953 912.13 632.315 912.291 632.721 912.291C633.083 912.291 633.399 912.176 633.648 911.923C634.077 911.532 634.349 910.68 634.349 909.783C634.349 908.287 633.693 907.274 632.767 907.274ZM632.744 907.458C633.332 907.458 633.648 908.287 633.648 909.806C633.648 911.325 633.354 912.107 632.721 912.107C632.111 912.107 631.795 911.325 631.795 909.806C631.795 908.264 632.111 907.458 632.744 907.458Z" fill="white"/>
+</g>
+<mask id="mask195_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask195_13_16077)">
+<path d="M627.489 886.291L626.201 886.959V887.051C626.292 887.005 626.359 886.982 626.405 886.982C626.518 886.913 626.653 886.89 626.721 886.89C626.879 886.89 626.947 887.005 626.947 887.235V890.549C626.947 890.779 626.879 890.94 626.766 891.009C626.653 891.078 626.563 891.101 626.246 891.101V891.216H628.235V891.101C627.67 891.101 627.557 891.032 627.557 890.687V886.291H627.489Z" fill="white"/>
+</g>
+<mask id="mask196_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask196_13_16077)">
+<path d="M613.737 874.859L613.624 874.813C613.376 875.228 613.285 875.297 612.946 875.297H611.251L612.449 874.008C613.082 873.34 613.353 872.788 613.353 872.213C613.353 871.476 612.788 870.924 612.042 870.924C611.635 870.924 611.274 871.085 611.003 871.361C610.777 871.614 610.664 871.844 610.551 872.374L610.686 872.397C610.98 871.683 611.251 871.453 611.726 871.453C612.336 871.453 612.743 871.868 612.743 872.489C612.743 873.064 612.426 873.732 611.816 874.376L610.551 875.757V875.849H613.33L613.737 874.859Z" fill="white"/>
+</g>
+<mask id="mask197_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask197_13_16077)">
+<path d="M590.821 867.811C591.227 867.811 591.386 867.834 591.566 867.903C592.018 868.065 592.29 868.479 592.29 868.985C592.29 869.583 591.883 870.067 591.363 870.067C591.16 870.067 591.024 870.021 590.753 869.837C590.527 869.698 590.414 869.652 590.301 869.652C590.12 869.652 590.03 869.768 590.03 869.906C590.03 870.159 590.323 870.32 590.821 870.32C591.386 870.32 591.951 870.136 592.29 869.837C592.629 869.537 592.809 869.123 592.809 868.64C592.809 868.249 592.696 867.926 592.493 867.696C592.335 867.535 592.199 867.443 591.883 867.305C592.38 866.96 592.561 866.684 592.561 866.292C592.561 865.694 592.109 865.303 591.453 865.303C591.092 865.303 590.775 865.418 590.527 865.648C590.301 865.855 590.188 866.039 590.03 866.477L590.143 866.5C590.436 865.97 590.753 865.74 591.205 865.74C591.679 865.74 591.996 866.062 591.996 866.523C591.996 866.776 591.883 867.029 591.702 867.213C591.499 867.443 591.295 867.558 590.821 867.719V867.811Z" fill="white"/>
+</g>
+<mask id="mask198_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask198_13_16077)">
+<path d="M572.492 874.169H571.746V870.924H571.43L569.192 874.169V874.629H571.204V875.849H571.746V874.629H572.492V874.169ZM571.204 874.169H569.463L571.204 871.66V874.169Z" fill="white"/>
+</g>
+<mask id="mask199_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask199_13_16077)">
+<path d="M555.299 886.959H556.722C556.835 886.959 556.858 886.959 556.881 886.89L557.152 886.245L557.084 886.199C556.971 886.36 556.903 886.383 556.745 886.383H555.253L554.485 888.109C554.462 888.132 554.462 888.132 554.462 888.156C554.462 888.179 554.508 888.202 554.553 888.202C554.779 888.202 555.073 888.271 555.366 888.363C556.18 888.616 556.564 889.076 556.564 889.812C556.564 890.503 556.135 891.055 555.57 891.055C555.434 891.055 555.299 890.986 555.095 890.848C554.869 890.664 554.688 890.595 554.553 890.595C554.349 890.595 554.236 890.687 554.236 890.871C554.236 891.147 554.575 891.308 555.118 891.308C555.705 891.308 556.225 891.124 556.587 890.756C556.926 890.411 557.061 889.997 557.061 889.444C557.061 888.915 556.926 888.593 556.564 888.225C556.27 887.902 555.841 887.741 555.005 887.58L555.299 886.959Z" fill="white"/>
+</g>
+<mask id="mask200_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask200_13_16077)">
+<path d="M551.677 907.205C550.863 907.274 550.457 907.412 549.937 907.803C549.146 908.356 548.739 909.184 548.739 910.174C548.739 910.795 548.92 911.44 549.236 911.808C549.507 912.13 549.892 912.291 550.344 912.291C551.225 912.291 551.835 911.601 551.835 910.611C551.835 909.668 551.315 909.069 550.502 909.069C550.185 909.069 550.027 909.138 549.575 909.414C549.779 908.31 550.57 907.504 551.7 907.32L551.677 907.205ZM550.231 909.414C550.841 909.414 551.202 909.944 551.202 910.841C551.202 911.647 550.909 912.107 550.411 912.107C549.779 912.107 549.394 911.417 549.394 910.289C549.394 909.898 549.462 909.714 549.598 909.599C549.756 909.483 549.982 909.414 550.231 909.414Z" fill="white"/>
+</g>
+<mask id="mask201_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask201_13_16077)">
+<path d="M557.22 928.355H554.575L554.146 929.436L554.282 929.482C554.575 928.999 554.711 928.907 555.118 928.907H556.655L555.253 933.257H555.705L557.22 928.47V928.355Z" fill="white"/>
+</g>
+<mask id="mask202_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask202_13_16077)">
+<path d="M571.181 945.839C571.882 945.471 572.13 945.149 572.13 944.666C572.13 944.067 571.633 943.63 570.91 943.63C570.119 943.63 569.554 944.113 569.554 944.781C569.554 945.241 569.689 945.471 570.435 946.139C569.667 946.737 569.509 946.967 569.509 947.45C569.509 948.164 570.074 948.647 570.887 948.647C571.746 948.647 572.288 948.187 572.288 947.427C572.288 946.852 572.04 946.507 571.181 945.839ZM571.045 946.599C571.565 946.99 571.746 947.243 571.746 947.657C571.746 948.118 571.43 948.463 570.955 948.463C570.413 948.463 570.051 948.026 570.051 947.404C570.051 946.921 570.209 946.622 570.616 946.277L571.045 946.599ZM570.978 945.724C570.345 945.287 570.074 944.965 570.074 944.551C570.074 944.136 570.39 943.837 570.842 943.837C571.339 943.837 571.656 944.159 571.656 944.643C571.656 945.057 571.452 945.402 571.045 945.678C571 945.701 571 945.701 570.978 945.724Z" fill="white"/>
+</g>
+<mask id="mask203_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask203_13_16077)">
+<path d="M590.143 954.337C590.934 954.245 591.34 954.107 591.815 953.739C592.561 953.187 593.013 952.289 593.013 951.299C593.013 950.103 592.335 949.251 591.408 949.251C590.572 949.251 589.939 949.988 589.939 950.977C589.939 951.852 590.436 952.45 591.227 952.45C591.612 952.45 591.905 952.335 592.29 952.036C591.996 953.21 591.205 953.992 590.12 954.199L590.143 954.337ZM592.312 951.576C592.312 951.737 592.267 951.806 592.199 951.875C591.996 952.036 591.725 952.128 591.476 952.128C590.934 952.128 590.595 951.576 590.595 950.724C590.595 950.31 590.708 949.873 590.843 949.665C590.979 949.527 591.16 949.458 591.363 949.458C591.973 949.458 592.312 950.08 592.312 951.299V951.576Z" fill="white"/>
+</g>
+<mask id="mask204_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask204_13_16077)">
+<path d="M610.613 943.63L609.324 944.297V944.39C609.415 944.343 609.483 944.32 609.528 944.32C609.641 944.251 609.776 944.228 609.844 944.228C610.002 944.228 610.07 944.343 610.07 944.574V947.888C610.07 948.118 610.002 948.279 609.889 948.348C609.776 948.417 609.686 948.44 609.37 948.44V948.555H611.358V948.44C610.793 948.44 610.68 948.371 610.68 948.026V943.63H610.613ZM613.941 943.63C613.534 943.63 613.24 943.745 612.969 943.998C612.562 944.413 612.291 945.241 612.291 946.093C612.291 946.898 612.517 947.75 612.856 948.164C613.127 948.486 613.489 948.647 613.895 948.647C614.257 948.647 614.573 948.532 614.822 948.279C615.251 947.888 615.523 947.036 615.523 946.139C615.523 944.643 614.867 943.63 613.941 943.63ZM613.918 943.814C614.506 943.814 614.822 944.643 614.822 946.162C614.822 947.68 614.528 948.463 613.895 948.463C613.285 948.463 612.969 947.68 612.969 946.162C612.969 944.62 613.285 943.814 613.918 943.814Z" fill="white"/>
+</g>
+<mask id="mask205_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="541" y="859" width="101" height="103">
+<path d="M541.623 961.31H641.379V859.729H541.623V961.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask205_13_16077)">
+<path d="M625.698 928.263L624.41 928.93V929.022C624.5 928.976 624.568 928.953 624.613 928.953C624.726 928.884 624.862 928.861 624.93 928.861C625.088 928.861 625.156 928.976 625.156 929.206V932.52C625.156 932.75 625.088 932.911 624.975 932.981C624.862 933.05 624.772 933.073 624.455 933.073V933.188H626.444V933.073C625.879 933.073 625.766 933.004 625.766 932.658V928.263H625.698ZM629.28 928.263L627.992 928.93V929.022C628.083 928.976 628.15 928.953 628.196 928.953C628.309 928.884 628.444 928.861 628.512 928.861C628.67 928.861 628.738 928.976 628.738 929.206V932.52C628.738 932.75 628.67 932.911 628.557 932.981C628.444 933.05 628.354 933.073 628.037 933.073V933.188H630.026V933.073C629.461 933.073 629.348 933.004 629.348 932.658V928.263H629.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask206_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="476" width="112" height="114">
+<path d="M303 589.037H414.004V476H303V589.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask206_13_16077)">
+<mask id="mask207_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask207_13_16077)">
+<path d="M399.723 532.52L394.2 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask208_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask208_13_16077)">
+<path d="M399.723 532.52L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask209_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask209_13_16077)">
+<path d="M399.723 532.52L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask210_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask210_13_16077)">
+<path d="M399.723 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask211_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask211_13_16077)">
+<path d="M394.2 511.532L379.112 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask212_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask212_13_16077)">
+<path d="M394.2 511.532L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask213_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask213_13_16077)">
+<path d="M394.2 511.532L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask214_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask214_13_16077)">
+<path d="M379.112 496.168L358.501 490.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask215_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask215_13_16077)">
+<path d="M337.89 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask216_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask216_13_16077)">
+<path d="M337.89 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask217_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask217_13_16077)">
+<path d="M337.891 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask218_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask218_13_16077)">
+<path d="M322.802 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask219_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask219_13_16077)">
+<path d="M322.802 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask220_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask220_13_16077)">
+<path d="M322.802 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask221_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask221_13_16077)">
+<path d="M317.28 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask222_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask222_13_16077)">
+<path d="M337.891 568.872L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask223_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask223_13_16077)">
+<path d="M337.891 568.872H379.112" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask224_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask224_13_16077)">
+<path d="M337.891 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask225_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask225_13_16077)">
+<path d="M358.501 574.495L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask226_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask226_13_16077)">
+<path d="M358.501 574.495L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask227_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask227_13_16077)">
+<path d="M379.112 568.872L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask228_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask228_13_16077)">
+<path d="M399.723 532.52L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask229_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask229_13_16077)">
+<path d="M399.723 532.52L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask230_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask230_13_16077)">
+<path d="M399.723 532.52L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask231_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask231_13_16077)">
+<path d="M399.723 532.52L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask232_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask232_13_16077)">
+<path d="M399.723 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask233_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask233_13_16077)">
+<path d="M399.723 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask234_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask234_13_16077)">
+<path d="M399.723 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask235_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask235_13_16077)">
+<path d="M394.2 511.532H322.802" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask236_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask236_13_16077)">
+<path d="M394.2 511.532L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask237_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask237_13_16077)">
+<path d="M394.2 511.532L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask238_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask238_13_16077)">
+<path d="M394.2 511.532L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask239_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask239_13_16077)">
+<path d="M394.2 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask240_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask240_13_16077)">
+<path d="M394.2 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask241_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask241_13_16077)">
+<path d="M394.2 511.532V553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask242_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask242_13_16077)">
+<path d="M379.112 496.168H337.89" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask243_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask243_13_16077)">
+<path d="M379.112 496.168L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask244_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask244_13_16077)">
+<path d="M379.112 496.168L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask245_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask245_13_16077)">
+<path d="M379.112 496.168L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask246_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask246_13_16077)">
+<path d="M379.112 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask247_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask247_13_16077)">
+<path d="M379.112 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask248_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask248_13_16077)">
+<path d="M379.112 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask249_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask249_13_16077)">
+<path d="M379.112 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask250_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask250_13_16077)">
+<path d="M358.501 490.544L337.89 496.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask251_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask251_13_16077)">
+<path d="M358.501 490.544L322.802 511.532" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask252_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask252_13_16077)">
+<path d="M358.501 490.544L317.28 532.52" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask253_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask253_13_16077)">
+<path d="M358.501 490.544L322.802 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask254_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask254_13_16077)">
+<path d="M358.501 490.544L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask255_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask255_13_16077)">
+<path d="M358.501 490.544V574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask256_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask256_13_16077)">
+<path d="M358.501 490.544L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask257_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask257_13_16077)">
+<path d="M358.501 490.544L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask258_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask258_13_16077)">
+<path d="M337.89 496.168L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask259_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask259_13_16077)">
+<path d="M337.89 496.168L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask260_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask260_13_16077)">
+<path d="M337.89 496.168L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask261_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask261_13_16077)">
+<path d="M337.89 496.168L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask262_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask262_13_16077)">
+<path d="M322.802 511.532L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask263_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask263_13_16077)">
+<path d="M322.802 511.532L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask264_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask264_13_16077)">
+<path d="M322.802 511.532L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask265_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask265_13_16077)">
+<path d="M317.28 532.52L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask266_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask266_13_16077)">
+<path d="M317.28 532.52L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask267_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask267_13_16077)">
+<path d="M317.28 532.52L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask268_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask268_13_16077)">
+<path d="M317.28 532.52L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask269_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask269_13_16077)">
+<path d="M322.802 553.508L337.891 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask270_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask270_13_16077)">
+<path d="M322.802 553.508L358.501 574.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask271_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask271_13_16077)">
+<path d="M322.802 553.508L379.112 568.872" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask272_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask272_13_16077)">
+<path d="M322.802 553.508L394.2 553.508" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask273_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask273_13_16077)">
+<mask id="mask274_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="527" width="11" height="11">
+<path d="M394.766 537.568H404.68V527.472H394.766V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask274_13_16077)">
+<path d="M399.723 537.045C400.901 537.045 402.032 536.568 402.865 535.72C403.699 534.871 404.167 533.72 404.167 532.52C404.167 531.32 403.699 530.168 402.865 529.32C402.032 528.471 400.901 527.994 399.723 527.994C398.544 527.994 397.414 528.471 396.58 529.32C395.747 530.168 395.279 531.32 395.279 532.52C395.279 533.72 395.747 534.871 396.58 535.72C397.414 536.568 398.544 537.045 399.723 537.045Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask275_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask275_13_16077)">
+<mask id="mask276_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="506" width="11" height="11">
+<path d="M389.243 516.58H399.157V506.484H389.243V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask276_13_16077)">
+<path d="M394.2 516.057C395.379 516.057 396.509 515.58 397.343 514.732C398.176 513.883 398.644 512.732 398.644 511.532C398.644 510.332 398.176 509.181 397.343 508.332C396.509 507.483 395.379 507.007 394.2 507.007C393.022 507.007 391.891 507.483 391.058 508.332C390.224 509.181 389.756 510.332 389.756 511.532C389.756 512.732 390.224 513.883 391.058 514.732C391.891 515.58 393.022 516.057 394.2 516.057Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask277_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask277_13_16077)">
+<mask id="mask278_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="491" width="11" height="11">
+<path d="M374.155 501.215H384.069V491.12H374.155V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask278_13_16077)">
+<path d="M379.112 500.693C380.291 500.693 381.421 500.216 382.254 499.367C383.088 498.519 383.556 497.368 383.556 496.168C383.556 494.967 383.088 493.816 382.254 492.968C381.421 492.119 380.291 491.642 379.112 491.642C377.933 491.642 376.803 492.119 375.97 492.968C375.136 493.816 374.668 494.967 374.668 496.168C374.668 497.368 375.136 498.519 375.97 499.367C376.803 500.216 377.933 500.693 379.112 500.693Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask279_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask279_13_16077)">
+<mask id="mask280_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="485" width="11" height="11">
+<path d="M353.544 495.592H363.458V485.496H353.544V495.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask280_13_16077)">
+<path d="M358.501 495.069C359.68 495.069 360.81 494.592 361.644 493.744C362.477 492.895 362.945 491.744 362.945 490.544C362.945 489.344 362.477 488.193 361.644 487.344C360.81 486.495 359.68 486.019 358.501 486.019C357.323 486.019 356.192 486.495 355.359 487.344C354.526 488.193 354.057 489.344 354.057 490.544C354.057 491.744 354.526 492.895 355.359 493.744C356.192 494.592 357.323 495.069 358.501 495.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask281_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask281_13_16077)">
+<mask id="mask282_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="491" width="11" height="11">
+<path d="M332.933 501.215H342.848V491.12H332.933V501.215Z" fill="white"/>
+</mask>
+<g mask="url(#mask282_13_16077)">
+<path d="M337.891 500.693C339.069 500.693 340.2 500.216 341.033 499.367C341.866 498.519 342.334 497.368 342.334 496.168C342.334 494.967 341.866 493.816 341.033 492.968C340.2 492.119 339.069 491.642 337.891 491.642C336.712 491.642 335.581 492.119 334.748 492.968C333.915 493.816 333.447 494.967 333.447 496.168C333.447 497.368 333.915 498.519 334.748 499.367C335.581 500.216 336.712 500.693 337.891 500.693Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask283_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask283_13_16077)">
+<mask id="mask284_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="506" width="11" height="11">
+<path d="M317.845 516.58H327.76V506.484H317.845V516.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask284_13_16077)">
+<path d="M322.802 516.057C323.981 516.057 325.111 515.58 325.945 514.732C326.778 513.883 327.246 512.732 327.246 511.532C327.246 510.332 326.778 509.181 325.945 508.332C325.111 507.483 323.981 507.007 322.802 507.007C321.624 507.007 320.493 507.483 319.66 508.332C318.827 509.181 318.358 510.332 318.358 511.532C318.358 512.732 318.827 513.883 319.66 514.732C320.493 515.58 321.624 516.057 322.802 516.057Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask285_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask285_13_16077)">
+<mask id="mask286_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="527" width="11" height="11">
+<path d="M312.323 537.568H322.237V527.472H312.323V537.568Z" fill="white"/>
+</mask>
+<g mask="url(#mask286_13_16077)">
+<path d="M317.28 537.045C318.458 537.045 319.589 536.568 320.422 535.72C321.255 534.871 321.724 533.72 321.724 532.52C321.724 531.32 321.255 530.168 320.422 529.32C319.589 528.471 318.458 527.994 317.28 527.994C316.101 527.994 314.971 528.471 314.137 529.32C313.304 530.168 312.836 531.32 312.836 532.52C312.836 533.72 313.304 534.871 314.137 535.72C314.971 536.568 316.101 537.045 317.28 537.045Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask287_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask287_13_16077)">
+<mask id="mask288_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="317" y="548" width="11" height="11">
+<path d="M317.845 558.555H327.76V548.46H317.845V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask288_13_16077)">
+<path d="M322.802 558.033C323.981 558.033 325.111 557.556 325.945 556.708C326.778 555.859 327.246 554.708 327.246 553.508C327.246 552.308 326.778 551.156 325.945 550.308C325.111 549.459 323.981 548.982 322.802 548.982C321.624 548.982 320.493 549.459 319.66 550.308C318.827 551.156 318.358 552.308 318.358 553.508C318.358 554.708 318.827 555.859 319.66 556.708C320.493 557.556 321.624 558.033 322.802 558.033Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask289_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask289_13_16077)">
+<mask id="mask290_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="332" y="563" width="11" height="11">
+<path d="M332.933 573.92H342.848V563.824H332.933V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask290_13_16077)">
+<path d="M337.891 573.397C339.069 573.397 340.2 572.92 341.033 572.072C341.866 571.223 342.334 570.072 342.334 568.872C342.334 567.672 341.866 566.521 341.033 565.672C340.2 564.823 339.069 564.347 337.891 564.347C336.712 564.347 335.581 564.823 334.748 565.672C333.915 566.521 333.447 567.672 333.447 568.872C333.447 570.072 333.915 571.223 334.748 572.072C335.581 572.92 336.712 573.397 337.891 573.397Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask291_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask291_13_16077)">
+<mask id="mask292_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="353" y="569" width="11" height="11">
+<path d="M353.544 579.543H363.458V569.448H353.544V579.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask292_13_16077)">
+<path d="M358.501 579.021C359.68 579.021 360.81 578.544 361.644 577.695C362.477 576.847 362.945 575.696 362.945 574.496C362.945 573.295 362.477 572.144 361.644 571.296C360.81 570.447 359.68 569.97 358.501 569.97C357.323 569.97 356.192 570.447 355.359 571.296C354.526 572.144 354.057 573.295 354.057 574.496C354.057 575.696 354.526 576.847 355.359 577.695C356.192 578.544 357.323 579.021 358.501 579.021Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask293_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask293_13_16077)">
+<mask id="mask294_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="374" y="563" width="11" height="11">
+<path d="M374.155 573.92H384.069V563.824H374.155V573.92Z" fill="white"/>
+</mask>
+<g mask="url(#mask294_13_16077)">
+<path d="M379.112 573.397C380.291 573.397 381.421 572.92 382.254 572.072C383.088 571.223 383.556 570.072 383.556 568.872C383.556 567.672 383.088 566.521 382.254 565.672C381.421 564.823 380.291 564.347 379.112 564.347C377.933 564.347 376.803 564.823 375.97 565.672C375.136 566.521 374.668 567.672 374.668 568.872C374.668 570.072 375.136 571.223 375.97 572.072C376.803 572.92 377.933 573.397 379.112 573.397Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask295_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask295_13_16077)">
+<mask id="mask296_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="389" y="548" width="11" height="11">
+<path d="M389.243 558.555H399.157V548.46H389.243V558.555Z" fill="white"/>
+</mask>
+<g mask="url(#mask296_13_16077)">
+<path d="M394.2 558.033C395.379 558.033 396.509 557.556 397.343 556.708C398.176 555.859 398.644 554.708 398.644 553.508C398.644 552.308 398.176 551.156 397.343 550.308C396.509 549.459 395.379 548.982 394.2 548.982C393.022 548.982 391.891 549.459 391.058 550.308C390.224 551.156 389.756 552.308 389.756 553.508C389.756 554.708 390.224 555.859 391.058 556.708C391.891 557.556 393.022 558.033 394.2 558.033Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask297_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask297_13_16077)">
+<path d="M399.767 529.274C399.36 529.274 399.066 529.389 398.795 529.642C398.388 530.057 398.117 530.885 398.117 531.737C398.117 532.542 398.343 533.394 398.682 533.808C398.953 534.13 399.315 534.291 399.721 534.291C400.083 534.291 400.399 534.176 400.648 533.923C401.077 533.532 401.349 532.68 401.349 531.783C401.349 530.287 400.693 529.274 399.767 529.274ZM399.744 529.458C400.332 529.458 400.648 530.287 400.648 531.806C400.648 533.325 400.354 534.107 399.721 534.107C399.111 534.107 398.795 533.325 398.795 531.806C398.795 530.264 399.111 529.458 399.744 529.458Z" fill="white"/>
+</g>
+<mask id="mask298_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask298_13_16077)">
+<path d="M394.489 508.291L393.201 508.959V509.051C393.292 509.005 393.359 508.982 393.405 508.982C393.518 508.913 393.653 508.89 393.721 508.89C393.879 508.89 393.947 509.005 393.947 509.235V512.549C393.947 512.779 393.879 512.94 393.766 513.009C393.653 513.078 393.563 513.101 393.246 513.101V513.216H395.235V513.101C394.67 513.101 394.557 513.032 394.557 512.687V508.291H394.489Z" fill="white"/>
+</g>
+<mask id="mask299_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask299_13_16077)">
+<path d="M380.737 496.859L380.624 496.813C380.376 497.228 380.285 497.297 379.946 497.297H378.251L379.449 496.008C380.082 495.34 380.353 494.788 380.353 494.213C380.353 493.476 379.788 492.924 379.042 492.924C378.635 492.924 378.274 493.085 378.003 493.361C377.777 493.614 377.664 493.844 377.551 494.374L377.686 494.397C377.98 493.683 378.251 493.453 378.726 493.453C379.336 493.453 379.743 493.868 379.743 494.489C379.743 495.064 379.426 495.732 378.816 496.376L377.551 497.757V497.849H380.33L380.737 496.859Z" fill="white"/>
+</g>
+<mask id="mask300_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask300_13_16077)">
+<path d="M357.821 489.811C358.227 489.811 358.386 489.834 358.566 489.903C359.018 490.065 359.29 490.479 359.29 490.985C359.29 491.583 358.883 492.067 358.363 492.067C358.16 492.067 358.024 492.021 357.753 491.837C357.527 491.698 357.414 491.652 357.301 491.652C357.12 491.652 357.03 491.768 357.03 491.906C357.03 492.159 357.323 492.32 357.821 492.32C358.386 492.32 358.951 492.136 359.29 491.837C359.629 491.537 359.809 491.123 359.809 490.64C359.809 490.249 359.696 489.926 359.493 489.696C359.335 489.535 359.199 489.443 358.883 489.305C359.38 488.96 359.561 488.684 359.561 488.292C359.561 487.694 359.109 487.303 358.453 487.303C358.092 487.303 357.775 487.418 357.527 487.648C357.301 487.855 357.188 488.039 357.03 488.477L357.143 488.5C357.436 487.97 357.753 487.74 358.205 487.74C358.679 487.74 358.996 488.062 358.996 488.523C358.996 488.776 358.883 489.029 358.702 489.213C358.499 489.443 358.295 489.558 357.821 489.719V489.811Z" fill="white"/>
+</g>
+<mask id="mask301_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask301_13_16077)">
+<path d="M339.492 496.169H338.746V492.924H338.43L336.192 496.169V496.629H338.204V497.849H338.746V496.629H339.492V496.169ZM338.204 496.169H336.463L338.204 493.66V496.169Z" fill="white"/>
+</g>
+<mask id="mask302_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask302_13_16077)">
+<path d="M322.299 508.959H323.722C323.835 508.959 323.858 508.959 323.881 508.89L324.152 508.245L324.084 508.199C323.971 508.36 323.903 508.383 323.745 508.383H322.253L321.485 510.109C321.462 510.132 321.462 510.132 321.462 510.156C321.462 510.179 321.508 510.202 321.553 510.202C321.779 510.202 322.073 510.271 322.366 510.363C323.18 510.616 323.564 511.076 323.564 511.812C323.564 512.503 323.135 513.055 322.57 513.055C322.434 513.055 322.299 512.986 322.095 512.848C321.869 512.664 321.688 512.595 321.553 512.595C321.349 512.595 321.236 512.687 321.236 512.871C321.236 513.147 321.575 513.308 322.118 513.308C322.705 513.308 323.225 513.124 323.587 512.756C323.926 512.411 324.061 511.997 324.061 511.444C324.061 510.915 323.926 510.593 323.564 510.225C323.27 509.902 322.841 509.741 322.005 509.58L322.299 508.959Z" fill="white"/>
+</g>
+<mask id="mask303_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask303_13_16077)">
+<path d="M318.677 529.205C317.863 529.274 317.457 529.412 316.937 529.803C316.146 530.356 315.739 531.184 315.739 532.174C315.739 532.795 315.92 533.44 316.236 533.808C316.507 534.13 316.892 534.291 317.344 534.291C318.225 534.291 318.835 533.601 318.835 532.611C318.835 531.668 318.315 531.069 317.502 531.069C317.185 531.069 317.027 531.138 316.575 531.414C316.779 530.31 317.57 529.504 318.7 529.32L318.677 529.205ZM317.231 531.414C317.841 531.414 318.202 531.944 318.202 532.841C318.202 533.647 317.909 534.107 317.411 534.107C316.779 534.107 316.394 533.417 316.394 532.289C316.394 531.898 316.462 531.714 316.598 531.599C316.756 531.483 316.982 531.414 317.231 531.414Z" fill="white"/>
+</g>
+<mask id="mask304_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask304_13_16077)">
+<path d="M324.22 550.355H321.575L321.146 551.436L321.282 551.482C321.575 550.999 321.711 550.907 322.118 550.907H323.655L322.253 555.257H322.705L324.22 550.47V550.355Z" fill="white"/>
+</g>
+<mask id="mask305_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask305_13_16077)">
+<path d="M338.181 567.839C338.882 567.471 339.13 567.149 339.13 566.666C339.13 566.067 338.633 565.63 337.91 565.63C337.119 565.63 336.554 566.113 336.554 566.781C336.554 567.241 336.689 567.471 337.435 568.139C336.667 568.737 336.509 568.967 336.509 569.45C336.509 570.164 337.074 570.647 337.887 570.647C338.746 570.647 339.288 570.187 339.288 569.427C339.288 568.852 339.04 568.507 338.181 567.839ZM338.045 568.599C338.565 568.99 338.746 569.243 338.746 569.657C338.746 570.118 338.43 570.463 337.955 570.463C337.413 570.463 337.051 570.026 337.051 569.404C337.051 568.921 337.209 568.622 337.616 568.277L338.045 568.599ZM337.978 567.724C337.345 567.287 337.074 566.965 337.074 566.551C337.074 566.136 337.39 565.837 337.842 565.837C338.339 565.837 338.656 566.159 338.656 566.643C338.656 567.057 338.452 567.402 338.045 567.678C338 567.701 338 567.701 337.978 567.724Z" fill="white"/>
+</g>
+<mask id="mask306_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask306_13_16077)">
+<path d="M357.143 576.337C357.934 576.245 358.34 576.107 358.815 575.739C359.561 575.187 360.013 574.289 360.013 573.299C360.013 572.103 359.335 571.251 358.408 571.251C357.572 571.251 356.939 571.988 356.939 572.977C356.939 573.852 357.436 574.45 358.227 574.45C358.612 574.45 358.905 574.335 359.29 574.036C358.996 575.21 358.205 575.992 357.12 576.199L357.143 576.337ZM359.312 573.576C359.312 573.737 359.267 573.806 359.199 573.875C358.996 574.036 358.725 574.128 358.476 574.128C357.934 574.128 357.595 573.576 357.595 572.724C357.595 572.31 357.708 571.873 357.843 571.665C357.979 571.527 358.16 571.458 358.363 571.458C358.973 571.458 359.312 572.08 359.312 573.299V573.576Z" fill="white"/>
+</g>
+<mask id="mask307_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask307_13_16077)">
+<path d="M377.613 565.63L376.324 566.297V566.39C376.415 566.343 376.483 566.32 376.528 566.32C376.641 566.251 376.776 566.228 376.844 566.228C377.002 566.228 377.07 566.343 377.07 566.574V569.888C377.07 570.118 377.002 570.279 376.889 570.348C376.776 570.417 376.686 570.44 376.37 570.44V570.555H378.358V570.44C377.793 570.44 377.68 570.371 377.68 570.026V565.63H377.613ZM380.941 565.63C380.534 565.63 380.24 565.745 379.969 565.998C379.562 566.413 379.291 567.241 379.291 568.093C379.291 568.898 379.517 569.75 379.856 570.164C380.127 570.486 380.489 570.647 380.895 570.647C381.257 570.647 381.573 570.532 381.822 570.279C382.251 569.888 382.523 569.036 382.523 568.139C382.523 566.643 381.867 565.63 380.941 565.63ZM380.918 565.814C381.506 565.814 381.822 566.643 381.822 568.162C381.822 569.68 381.528 570.463 380.895 570.463C380.285 570.463 379.969 569.68 379.969 568.162C379.969 566.62 380.285 565.814 380.918 565.814Z" fill="white"/>
+</g>
+<mask id="mask308_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="481" width="101" height="103">
+<path d="M308.623 583.31H408.379V481.729H308.623V583.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask308_13_16077)">
+<path d="M392.698 550.263L391.41 550.93V551.022C391.5 550.976 391.568 550.953 391.613 550.953C391.726 550.884 391.862 550.861 391.93 550.861C392.088 550.861 392.156 550.976 392.156 551.206V554.52C392.156 554.75 392.088 554.911 391.975 554.981C391.862 555.05 391.772 555.073 391.455 555.073V555.188H393.444V555.073C392.879 555.073 392.766 555.004 392.766 554.658V550.263H392.698ZM396.28 550.263L394.992 550.93V551.022C395.083 550.976 395.15 550.953 395.196 550.953C395.309 550.884 395.444 550.861 395.512 550.861C395.67 550.861 395.738 550.976 395.738 551.206V554.52C395.738 554.75 395.67 554.911 395.557 554.981C395.444 555.05 395.354 555.073 395.037 555.073V555.188H397.026V555.073C396.461 555.073 396.348 555.004 396.348 554.658V550.263H396.28Z" fill="white"/>
+</g>
+</g>
+<mask id="mask309_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="353" width="112" height="114">
+<path d="M303 466.037H414.004V353H303V466.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask309_13_16077)">
+<mask id="mask310_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask310_13_16077)">
+<path d="M325.821 393.354L343.54 378.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask311_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask311_13_16077)">
+<path d="M325.821 393.354L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask312_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask312_13_16077)">
+<path d="M325.821 393.354L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask313_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask313_13_16077)">
+<path d="M325.821 393.354L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask314_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask314_13_16077)">
+<path d="M343.54 378.382L317.28 375.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask315_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask315_13_16077)">
+<path d="M343.54 378.382L326.523 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask316_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask316_13_16077)">
+<path d="M343.54 378.382L377.366 389.755" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask317_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask317_13_16077)">
+<path d="M317.28 375.666L326.524 367.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask318_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask318_13_16077)">
+<path d="M377.366 389.755L381.612 412.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask319_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask319_13_16077)">
+<path d="M377.366 389.754L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask320_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask320_13_16077)">
+<path d="M377.366 389.755L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask321_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask321_13_16077)">
+<path d="M381.612 412.102L397.614 391.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask322_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask322_13_16077)">
+<path d="M381.612 412.102L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask323_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask323_13_16077)">
+<path d="M381.612 412.102L354.356 435.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask324_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask324_13_16077)">
+<path d="M397.614 391.444L399.723 403.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask325_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask325_13_16077)">
+<path d="M354.356 435.307L332.308 427.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask326_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask326_13_16077)">
+<path d="M354.356 435.307L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask327_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask327_13_16077)">
+<path d="M354.356 435.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask328_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask328_13_16077)">
+<path d="M332.308 427.895L330.975 447.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask329_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask329_13_16077)">
+<path d="M332.308 427.895L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask330_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask330_13_16077)">
+<path d="M330.975 447.307L342.769 451.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask331_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask331_13_16077)">
+<mask id="mask332_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="388" width="11" height="11">
+<path d="M320.864 398.402H330.778V388.307H320.864V398.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask332_13_16077)">
+<path d="M325.821 397.88C326.999 397.88 328.13 397.403 328.963 396.554C329.797 395.706 330.265 394.555 330.265 393.354C330.265 392.154 329.797 391.003 328.963 390.155C328.13 389.306 326.999 388.829 325.821 388.829C324.642 388.829 323.512 389.306 322.678 390.155C321.845 391.003 321.377 392.154 321.377 393.354C321.377 394.555 321.845 395.706 322.678 396.554C323.512 397.403 324.642 397.88 325.821 397.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask333_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask333_13_16077)">
+<mask id="mask334_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="373" width="11" height="11">
+<path d="M338.583 383.429H348.497V373.334H338.583V383.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask334_13_16077)">
+<path d="M343.54 382.907C344.719 382.907 345.849 382.43 346.683 381.581C347.516 380.733 347.984 379.582 347.984 378.382C347.984 377.181 347.516 376.03 346.683 375.182C345.849 374.333 344.719 373.856 343.54 373.856C342.362 373.856 341.231 374.333 340.398 375.182C339.565 376.03 339.096 377.181 339.096 378.382C339.096 379.582 339.565 380.733 340.398 381.581C341.231 382.43 342.362 382.907 343.54 382.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask335_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask335_13_16077)">
+<mask id="mask336_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="370" width="11" height="11">
+<path d="M312.323 380.714H322.237V370.618H312.323V380.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask336_13_16077)">
+<path d="M317.28 380.191C318.458 380.191 319.589 379.714 320.422 378.866C321.255 378.017 321.724 376.866 321.724 375.666C321.724 374.466 321.255 373.315 320.422 372.466C319.589 371.617 318.458 371.141 317.28 371.141C316.101 371.141 314.971 371.617 314.137 372.466C313.304 373.315 312.836 374.466 312.836 375.666C312.836 376.866 313.304 378.017 314.137 378.866C314.971 379.714 316.101 380.191 317.28 380.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask337_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask337_13_16077)">
+<mask id="mask338_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="321" y="362" width="11" height="11">
+<path d="M321.566 372.592H331.481V362.496H321.566V372.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask338_13_16077)">
+<path d="M326.524 372.069C327.702 372.069 328.833 371.592 329.666 370.744C330.499 369.895 330.967 368.744 330.967 367.544C330.967 366.344 330.499 365.193 329.666 364.344C328.833 363.495 327.702 363.019 326.524 363.019C325.345 363.019 324.214 363.495 323.381 364.344C322.548 365.193 322.08 366.344 322.08 367.544C322.08 368.744 322.548 369.895 323.381 370.744C324.214 371.592 325.345 372.069 326.524 372.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask339_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask339_13_16077)">
+<mask id="mask340_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="372" y="384" width="11" height="11">
+<path d="M372.409 394.802H382.323V384.707H372.409V394.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask340_13_16077)">
+<path d="M377.366 394.28C378.544 394.28 379.675 393.803 380.508 392.954C381.342 392.106 381.81 390.955 381.81 389.755C381.81 388.554 381.342 387.403 380.508 386.555C379.675 385.706 378.544 385.229 377.366 385.229C376.187 385.229 375.057 385.706 374.223 386.555C373.39 387.403 372.922 388.554 372.922 389.755C372.922 390.955 373.39 392.106 374.223 392.954C375.057 393.803 376.187 394.28 377.366 394.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask341_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask341_13_16077)">
+<mask id="mask342_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="376" y="407" width="11" height="11">
+<path d="M376.655 417.15H386.569V407.054H376.655V417.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask342_13_16077)">
+<path d="M381.612 416.628C382.791 416.628 383.921 416.151 384.755 415.302C385.588 414.453 386.056 413.302 386.056 412.102C386.056 410.902 385.588 409.751 384.755 408.902C383.921 408.054 382.791 407.577 381.612 407.577C380.434 407.577 379.303 408.054 378.47 408.902C377.637 409.751 377.168 410.902 377.168 412.102C377.168 413.302 377.637 414.453 378.47 415.302C379.303 416.151 380.434 416.628 381.612 416.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask343_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask343_13_16077)">
+<mask id="mask344_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="386" width="11" height="11">
+<path d="M392.657 396.492H402.571V386.396H392.657V396.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask344_13_16077)">
+<path d="M397.614 395.969C398.792 395.969 399.923 395.492 400.756 394.644C401.59 393.795 402.058 392.644 402.058 391.444C402.058 390.244 401.59 389.093 400.756 388.244C399.923 387.395 398.792 386.919 397.614 386.919C396.435 386.919 395.305 387.395 394.471 388.244C393.638 389.093 393.17 390.244 393.17 391.444C393.17 392.644 393.638 393.795 394.471 394.644C395.305 395.492 396.435 395.969 397.614 395.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask345_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask345_13_16077)">
+<mask id="mask346_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="398" width="11" height="11">
+<path d="M394.766 408.201H404.68V398.105H394.766V408.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask346_13_16077)">
+<path d="M399.723 407.679C400.901 407.679 402.032 407.202 402.865 406.353C403.699 405.504 404.167 404.353 404.167 403.153C404.167 401.953 403.699 400.802 402.865 399.953C402.032 399.105 400.901 398.628 399.723 398.628C398.544 398.628 397.414 399.105 396.58 399.953C395.747 400.802 395.279 401.953 395.279 403.153C395.279 404.353 395.747 405.504 396.58 406.353C397.414 407.202 398.544 407.679 399.723 407.679Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask347_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask347_13_16077)">
+<mask id="mask348_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="349" y="430" width="11" height="11">
+<path d="M349.399 440.354H359.313V430.259H349.399V440.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask348_13_16077)">
+<path d="M354.356 439.832C355.535 439.832 356.665 439.355 357.499 438.506C358.332 437.658 358.8 436.507 358.8 435.307C358.8 434.106 358.332 432.955 357.499 432.107C356.665 431.258 355.535 430.781 354.356 430.781C353.178 430.781 352.047 431.258 351.214 432.107C350.38 432.955 349.912 434.106 349.912 435.307C349.912 436.507 350.38 437.658 351.214 438.506C352.047 439.355 353.178 439.832 354.356 439.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask349_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask349_13_16077)">
+<mask id="mask350_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="327" y="422" width="11" height="11">
+<path d="M327.351 432.943H337.265V422.847H327.351V432.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask350_13_16077)">
+<path d="M332.308 432.42C333.486 432.42 334.617 431.943 335.45 431.095C336.283 430.246 336.752 429.095 336.752 427.895C336.752 426.695 336.283 425.544 335.45 424.695C334.617 423.846 333.486 423.37 332.308 423.37C331.129 423.37 329.999 423.846 329.165 424.695C328.332 425.544 327.864 426.695 327.864 427.895C327.864 429.095 328.332 430.246 329.165 431.095C329.999 431.943 331.129 432.42 332.308 432.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask351_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask351_13_16077)">
+<mask id="mask352_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="326" y="442" width="10" height="11">
+<path d="M326.018 452.355H335.932V442.259H326.018V452.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask352_13_16077)">
+<path d="M330.975 451.832C332.154 451.832 333.284 451.355 334.117 450.507C334.951 449.658 335.419 448.507 335.419 447.307C335.419 446.107 334.951 444.955 334.117 444.107C333.284 443.258 332.154 442.781 330.975 442.781C329.796 442.781 328.666 443.258 327.833 444.107C326.999 444.955 326.531 446.107 326.531 447.307C326.531 448.507 326.999 449.658 327.833 450.507C328.666 451.355 329.796 451.832 330.975 451.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask353_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask353_13_16077)">
+<mask id="mask354_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="337" y="446" width="11" height="11">
+<path d="M337.811 456.543H347.726V446.448H337.811V456.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask354_13_16077)">
+<path d="M342.769 456.021C343.947 456.021 345.078 455.544 345.911 454.695C346.744 453.847 347.213 452.696 347.213 451.496C347.213 450.295 346.744 449.144 345.911 448.296C345.078 447.447 343.947 446.97 342.769 446.97C341.59 446.97 340.459 447.447 339.626 448.296C338.793 449.144 338.325 450.295 338.325 451.496C338.325 452.696 338.793 453.847 339.626 454.695C340.459 455.544 341.59 456.021 342.769 456.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask355_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask355_13_16077)">
+<path d="M325.86 390.113C325.453 390.113 325.159 390.228 324.888 390.481C324.481 390.895 324.21 391.724 324.21 392.575C324.21 393.381 324.436 394.232 324.775 394.646C325.046 394.969 325.408 395.13 325.815 395.13C326.177 395.13 326.493 395.015 326.742 394.762C327.171 394.37 327.442 393.519 327.442 392.621C327.442 391.125 326.787 390.113 325.86 390.113ZM325.838 390.297C326.425 390.297 326.742 391.125 326.742 392.644C326.742 394.163 326.448 394.946 325.815 394.946C325.205 394.946 324.888 394.163 324.888 392.644C324.888 391.102 325.205 390.297 325.838 390.297Z" fill="white"/>
+</g>
+<mask id="mask356_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask356_13_16077)">
+<path d="M343.833 375.137L342.545 375.804V375.896C342.635 375.85 342.703 375.827 342.748 375.827C342.861 375.758 342.997 375.735 343.065 375.735C343.223 375.735 343.291 375.85 343.291 376.08V379.394C343.291 379.624 343.223 379.785 343.11 379.854C342.997 379.923 342.906 379.946 342.59 379.946V380.062H344.579V379.946C344.014 379.946 343.901 379.877 343.901 379.532V375.137H343.833Z" fill="white"/>
+</g>
+<mask id="mask357_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask357_13_16077)">
+<path d="M318.905 376.356L318.792 376.31C318.543 376.725 318.453 376.794 318.114 376.794H316.419L317.617 375.505C318.249 374.837 318.521 374.285 318.521 373.71C318.521 372.973 317.956 372.421 317.21 372.421C316.803 372.421 316.441 372.582 316.17 372.858C315.944 373.111 315.831 373.342 315.718 373.871L315.854 373.894C316.148 373.18 316.419 372.95 316.893 372.95C317.504 372.95 317.91 373.365 317.91 373.986C317.91 374.561 317.594 375.229 316.984 375.873L315.718 377.254V377.346H318.498L318.905 376.356Z" fill="white"/>
+</g>
+<mask id="mask358_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask358_13_16077)">
+<path d="M325.843 366.811C326.25 366.811 326.408 366.834 326.589 366.903C327.041 367.065 327.312 367.479 327.312 367.985C327.312 368.583 326.905 369.067 326.386 369.067C326.182 369.067 326.047 369.021 325.775 368.837C325.549 368.699 325.436 368.652 325.323 368.652C325.143 368.652 325.052 368.768 325.052 368.906C325.052 369.159 325.346 369.32 325.843 369.32C326.408 369.32 326.973 369.136 327.312 368.837C327.651 368.537 327.832 368.123 327.832 367.64C327.832 367.249 327.719 366.926 327.516 366.696C327.357 366.535 327.222 366.443 326.905 366.305C327.403 365.96 327.583 365.684 327.583 365.292C327.583 364.694 327.131 364.303 326.476 364.303C326.114 364.303 325.798 364.418 325.549 364.648C325.323 364.855 325.21 365.039 325.052 365.477L325.165 365.5C325.459 364.97 325.775 364.74 326.227 364.74C326.702 364.74 327.018 365.062 327.018 365.523C327.018 365.776 326.905 366.029 326.725 366.213C326.521 366.443 326.318 366.558 325.843 366.719V366.811Z" fill="white"/>
+</g>
+<mask id="mask359_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask359_13_16077)">
+<path d="M378.965 389.756H378.219V386.511H377.903L375.665 389.756V390.216H377.677V391.436H378.219V390.216H378.965V389.756ZM377.677 389.756H375.937L377.677 387.248V389.756Z" fill="white"/>
+</g>
+<mask id="mask360_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask360_13_16077)">
+<path d="M381.112 409.525H382.536C382.649 409.525 382.671 409.525 382.694 409.456L382.965 408.811L382.897 408.765C382.784 408.927 382.717 408.95 382.558 408.95H381.067L380.298 410.676C380.276 410.699 380.276 410.699 380.276 410.722C380.276 410.745 380.321 410.768 380.366 410.768C380.592 410.768 380.886 410.837 381.18 410.929C381.993 411.182 382.378 411.642 382.378 412.379C382.378 413.069 381.948 413.621 381.383 413.621C381.248 413.621 381.112 413.552 380.909 413.414C380.683 413.23 380.502 413.161 380.366 413.161C380.163 413.161 380.05 413.253 380.05 413.437C380.05 413.713 380.389 413.874 380.931 413.874C381.519 413.874 382.039 413.69 382.4 413.322C382.739 412.977 382.875 412.563 382.875 412.01C382.875 411.481 382.739 411.159 382.378 410.791C382.084 410.468 381.654 410.307 380.818 410.146L381.112 409.525Z" fill="white"/>
+</g>
+<mask id="mask361_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.311H408.379V358.729H308.623V460.311Z" fill="white"/>
+</mask>
+<g mask="url(#mask361_13_16077)">
+<path d="M399.011 388.134C398.198 388.203 397.791 388.341 397.271 388.732C396.48 389.284 396.073 390.113 396.073 391.102C396.073 391.724 396.254 392.368 396.57 392.736C396.842 393.059 397.226 393.22 397.678 393.22C398.559 393.22 399.17 392.529 399.17 391.54C399.17 390.596 398.65 389.998 397.836 389.998C397.52 389.998 397.361 390.067 396.909 390.343C397.113 389.238 397.904 388.433 399.034 388.249L399.011 388.134ZM397.565 390.343C398.175 390.343 398.537 390.872 398.537 391.77C398.537 392.575 398.243 393.036 397.746 393.036C397.113 393.036 396.729 392.345 396.729 391.217C396.729 390.826 396.796 390.642 396.932 390.527C397.09 390.412 397.316 390.343 397.565 390.343Z" fill="white"/>
+</g>
+<mask id="mask362_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask362_13_16077)">
+<path d="M401.141 400.003H398.497L398.068 401.085L398.203 401.131C398.497 400.647 398.633 400.555 399.04 400.555H400.576L399.175 404.905H399.627L401.141 400.118V400.003Z" fill="white"/>
+</g>
+<mask id="mask363_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask363_13_16077)">
+<path d="M354.647 434.27C355.348 433.902 355.596 433.58 355.596 433.097C355.596 432.498 355.099 432.061 354.376 432.061C353.585 432.061 353.02 432.544 353.02 433.212C353.02 433.672 353.155 433.902 353.901 434.57C353.133 435.168 352.975 435.398 352.975 435.881C352.975 436.595 353.54 437.078 354.353 437.078C355.212 437.078 355.755 436.618 355.755 435.858C355.755 435.283 355.506 434.938 354.647 434.27ZM354.512 435.03C355.031 435.421 355.212 435.674 355.212 436.088C355.212 436.549 354.896 436.894 354.421 436.894C353.879 436.894 353.517 436.457 353.517 435.835C353.517 435.352 353.675 435.053 354.082 434.708L354.512 435.03ZM354.444 434.155C353.811 433.718 353.54 433.396 353.54 432.982C353.54 432.567 353.856 432.268 354.308 432.268C354.805 432.268 355.122 432.59 355.122 433.074C355.122 433.488 354.918 433.833 354.512 434.109C354.466 434.132 354.466 434.132 354.444 434.155Z" fill="white"/>
+</g>
+<mask id="mask364_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask364_13_16077)">
+<path d="M330.945 429.737C331.736 429.645 332.143 429.507 332.618 429.138C333.363 428.586 333.815 427.688 333.815 426.699C333.815 425.502 333.137 424.651 332.211 424.651C331.375 424.651 330.742 425.387 330.742 426.377C330.742 427.251 331.239 427.85 332.03 427.85C332.414 427.85 332.708 427.734 333.092 427.435C332.798 428.609 332.007 429.391 330.923 429.599L330.945 429.737ZM333.115 426.975C333.115 427.136 333.07 427.205 333.002 427.274C332.798 427.435 332.527 427.527 332.279 427.527C331.736 427.527 331.397 426.975 331.397 426.124C331.397 425.709 331.51 425.272 331.646 425.065C331.781 424.927 331.962 424.858 332.166 424.858C332.776 424.858 333.115 425.479 333.115 426.699V426.975Z" fill="white"/>
+</g>
+<mask id="mask365_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask365_13_16077)">
+<path d="M329.476 444.063L328.188 444.73V444.822C328.278 444.776 328.346 444.753 328.391 444.753C328.504 444.684 328.64 444.661 328.708 444.661C328.866 444.661 328.934 444.776 328.934 445.006V448.32C328.934 448.55 328.866 448.711 328.753 448.781C328.64 448.85 328.55 448.873 328.233 448.873V448.988H330.222V448.873C329.657 448.873 329.544 448.804 329.544 448.458V444.063H329.476ZM332.804 444.063C332.397 444.063 332.103 444.178 331.832 444.431C331.425 444.845 331.154 445.674 331.154 446.525C331.154 447.331 331.38 448.182 331.719 448.596C331.99 448.919 332.352 449.08 332.759 449.08C333.12 449.08 333.437 448.965 333.685 448.711C334.115 448.32 334.386 447.469 334.386 446.571C334.386 445.075 333.731 444.063 332.804 444.063ZM332.781 444.247C333.369 444.247 333.685 445.075 333.685 446.594C333.685 448.113 333.392 448.896 332.759 448.896C332.149 448.896 331.832 448.113 331.832 446.594C331.832 445.052 332.149 444.247 332.781 444.247Z" fill="white"/>
+</g>
+<mask id="mask366_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="358" width="101" height="103">
+<path d="M308.623 460.31H408.379V358.729H308.623V460.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask366_13_16077)">
+<path d="M341.268 448.251L339.98 448.919V449.011C340.07 448.965 340.138 448.942 340.183 448.942C340.296 448.873 340.432 448.85 340.499 448.85C340.658 448.85 340.725 448.965 340.725 449.195V452.509C340.725 452.739 340.658 452.9 340.545 452.969C340.432 453.038 340.341 453.061 340.025 453.061V453.176H342.014V453.061C341.449 453.061 341.336 452.992 341.336 452.647V448.251H341.268ZM344.85 448.251L343.562 448.919V449.011C343.652 448.965 343.72 448.942 343.765 448.942C343.878 448.873 344.014 448.85 344.082 448.85C344.24 448.85 344.308 448.965 344.308 449.195V452.509C344.308 452.739 344.24 452.9 344.127 452.969C344.014 453.038 343.923 453.061 343.607 453.061V453.176H345.596V453.061C345.031 453.061 344.918 452.992 344.918 452.647V448.251H344.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask367_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="760" y="857" width="112" height="114">
+<path d="M760 970.037H871.004V857H760V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask367_13_16077)">
+<mask id="mask368_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask368_13_16077)">
+<path d="M782.821 897.354L800.54 882.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask369_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask369_13_16077)">
+<path d="M782.821 897.354L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask370_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask370_13_16077)">
+<path d="M782.821 897.354L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask371_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask371_13_16077)">
+<path d="M782.821 897.354L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask372_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask372_13_16077)">
+<path d="M800.54 882.382L774.28 879.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask373_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask373_13_16077)">
+<path d="M800.54 882.382L783.523 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask374_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask374_13_16077)">
+<path d="M800.54 882.382L834.366 893.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask375_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask375_13_16077)">
+<path d="M774.28 879.666L783.524 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask376_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask376_13_16077)">
+<path d="M834.366 893.754L838.612 916.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask377_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask377_13_16077)">
+<path d="M834.366 893.754L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask378_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask378_13_16077)">
+<path d="M834.366 893.754L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask379_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask379_13_16077)">
+<path d="M838.612 916.102L854.614 895.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask380_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask380_13_16077)">
+<path d="M838.612 916.102L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask381_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask381_13_16077)">
+<path d="M838.612 916.102L811.356 939.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask382_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask382_13_16077)">
+<path d="M854.614 895.444L856.723 907.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask383_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask383_13_16077)">
+<path d="M811.356 939.307L789.308 931.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask384_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask384_13_16077)">
+<path d="M811.356 939.306L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask385_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask385_13_16077)">
+<path d="M811.356 939.306L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask386_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask386_13_16077)">
+<path d="M789.308 931.895L787.975 951.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask387_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask387_13_16077)">
+<path d="M789.308 931.895L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask388_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask388_13_16077)">
+<path d="M787.975 951.307L799.769 955.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask389_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask389_13_16077)">
+<mask id="mask390_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="777" y="892" width="11" height="11">
+<path d="M777.864 902.402H787.778V892.307H777.864V902.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask390_13_16077)">
+<path d="M782.821 901.88C783.999 901.88 785.13 901.403 785.963 900.554C786.797 899.706 787.265 898.555 787.265 897.354C787.265 896.154 786.797 895.003 785.963 894.155C785.13 893.306 783.999 892.829 782.821 892.829C781.642 892.829 780.512 893.306 779.678 894.155C778.845 895.003 778.377 896.154 778.377 897.354C778.377 898.555 778.845 899.706 779.678 900.554C780.512 901.403 781.642 901.88 782.821 901.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask391_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask391_13_16077)">
+<mask id="mask392_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="795" y="877" width="11" height="11">
+<path d="M795.583 887.429H805.497V877.334H795.583V887.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask392_13_16077)">
+<path d="M800.54 886.907C801.719 886.907 802.849 886.43 803.683 885.581C804.516 884.733 804.984 883.582 804.984 882.382C804.984 881.181 804.516 880.03 803.683 879.182C802.849 878.333 801.719 877.856 800.54 877.856C799.362 877.856 798.231 878.333 797.398 879.182C796.565 880.03 796.096 881.181 796.096 882.382C796.096 883.582 796.565 884.733 797.398 885.581C798.231 886.43 799.362 886.907 800.54 886.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask393_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask393_13_16077)">
+<mask id="mask394_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="769" y="874" width="11" height="11">
+<path d="M769.323 884.714H779.237V874.618H769.323V884.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask394_13_16077)">
+<path d="M774.28 884.191C775.458 884.191 776.589 883.714 777.422 882.866C778.256 882.017 778.724 880.866 778.724 879.666C778.724 878.466 778.256 877.315 777.422 876.466C776.589 875.617 775.458 875.141 774.28 875.141C773.101 875.141 771.971 875.617 771.137 876.466C770.304 877.315 769.836 878.466 769.836 879.666C769.836 880.866 770.304 882.017 771.137 882.866C771.971 883.714 773.101 884.191 774.28 884.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask395_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask395_13_16077)">
+<mask id="mask396_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="778" y="866" width="11" height="11">
+<path d="M778.566 876.592H788.481V866.496H778.566V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask396_13_16077)">
+<path d="M783.524 876.069C784.702 876.069 785.833 875.592 786.666 874.744C787.499 873.895 787.968 872.744 787.968 871.544C787.968 870.344 787.499 869.193 786.666 868.344C785.833 867.495 784.702 867.019 783.524 867.019C782.345 867.019 781.215 867.495 780.381 868.344C779.548 869.193 779.08 870.344 779.08 871.544C779.08 872.744 779.548 873.895 780.381 874.744C781.215 875.592 782.345 876.069 783.524 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask397_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask397_13_16077)">
+<mask id="mask398_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="829" y="888" width="11" height="11">
+<path d="M829.409 898.802H839.323V888.707H829.409V898.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask398_13_16077)">
+<path d="M834.366 898.28C835.544 898.28 836.675 897.803 837.508 896.954C838.342 896.106 838.81 894.955 838.81 893.754C838.81 892.554 838.342 891.403 837.508 890.555C836.675 889.706 835.544 889.229 834.366 889.229C833.187 889.229 832.057 889.706 831.223 890.555C830.39 891.403 829.922 892.554 829.922 893.754C829.922 894.955 830.39 896.106 831.223 896.954C832.057 897.803 833.187 898.28 834.366 898.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask399_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask399_13_16077)">
+<mask id="mask400_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="833" y="911" width="11" height="11">
+<path d="M833.655 921.15H843.57V911.054H833.655V921.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask400_13_16077)">
+<path d="M838.612 920.628C839.791 920.628 840.921 920.151 841.755 919.302C842.588 918.453 843.056 917.302 843.056 916.102C843.056 914.902 842.588 913.751 841.755 912.902C840.921 912.054 839.791 911.577 838.612 911.577C837.434 911.577 836.303 912.054 835.47 912.902C834.637 913.751 834.168 914.902 834.168 916.102C834.168 917.302 834.637 918.453 835.47 919.302C836.303 920.151 837.434 920.628 838.612 920.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask401_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask401_13_16077)">
+<mask id="mask402_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="849" y="890" width="11" height="11">
+<path d="M849.657 900.492H859.571V890.396H849.657V900.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask402_13_16077)">
+<path d="M854.614 899.969C855.792 899.969 856.923 899.492 857.756 898.644C858.59 897.795 859.058 896.644 859.058 895.444C859.058 894.244 858.59 893.093 857.756 892.244C856.923 891.395 855.792 890.919 854.614 890.919C853.435 890.919 852.305 891.395 851.471 892.244C850.638 893.093 850.17 894.244 850.17 895.444C850.17 896.644 850.638 897.795 851.471 898.644C852.305 899.492 853.435 899.969 854.614 899.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask403_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask403_13_16077)">
+<mask id="mask404_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="851" y="902" width="11" height="11">
+<path d="M851.766 912.201H861.68V902.105H851.766V912.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask404_13_16077)">
+<path d="M856.723 911.678C857.901 911.678 859.032 911.202 859.865 910.353C860.699 909.504 861.167 908.353 861.167 907.153C861.167 905.953 860.699 904.802 859.865 903.953C859.032 903.105 857.901 902.628 856.723 902.628C855.544 902.628 854.414 903.105 853.58 903.953C852.747 904.802 852.279 905.953 852.279 907.153C852.279 908.353 852.747 909.504 853.58 910.353C854.414 911.202 855.544 911.678 856.723 911.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask405_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask405_13_16077)">
+<mask id="mask406_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="806" y="934" width="11" height="11">
+<path d="M806.399 944.354H816.313V934.259H806.399V944.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask406_13_16077)">
+<path d="M811.356 943.832C812.535 943.832 813.665 943.355 814.499 942.506C815.332 941.658 815.8 940.507 815.8 939.307C815.8 938.106 815.332 936.955 814.499 936.107C813.665 935.258 812.535 934.781 811.356 934.781C810.178 934.781 809.047 935.258 808.214 936.107C807.38 936.955 806.912 938.106 806.912 939.307C806.912 940.507 807.38 941.658 808.214 942.506C809.047 943.355 810.178 943.832 811.356 943.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask407_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask407_13_16077)">
+<mask id="mask408_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="784" y="926" width="11" height="11">
+<path d="M784.351 936.943H794.265V926.847H784.351V936.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask408_13_16077)">
+<path d="M789.308 936.42C790.486 936.42 791.617 935.943 792.45 935.095C793.283 934.246 793.752 933.095 793.752 931.895C793.752 930.695 793.283 929.544 792.45 928.695C791.617 927.846 790.486 927.37 789.308 927.37C788.129 927.37 786.999 927.846 786.165 928.695C785.332 929.544 784.864 930.695 784.864 931.895C784.864 933.095 785.332 934.246 786.165 935.095C786.999 935.943 788.129 936.42 789.308 936.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask409_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask409_13_16077)">
+<mask id="mask410_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="783" y="946" width="10" height="11">
+<path d="M783.018 956.355H792.932V946.259H783.018V956.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask410_13_16077)">
+<path d="M787.975 955.832C789.154 955.832 790.284 955.355 791.117 954.507C791.951 953.658 792.419 952.507 792.419 951.307C792.419 950.107 791.951 948.955 791.117 948.107C790.284 947.258 789.154 946.781 787.975 946.781C786.796 946.781 785.666 947.258 784.833 948.107C783.999 948.955 783.531 950.107 783.531 951.307C783.531 952.507 783.999 953.658 784.833 954.507C785.666 955.355 786.796 955.832 787.975 955.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask411_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask411_13_16077)">
+<mask id="mask412_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="794" y="950" width="11" height="11">
+<path d="M794.811 960.543H804.726V950.448H794.811V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask412_13_16077)">
+<path d="M799.769 960.021C800.947 960.021 802.078 959.544 802.911 958.695C803.744 957.847 804.213 956.696 804.213 955.496C804.213 954.295 803.744 953.144 802.911 952.296C802.078 951.447 800.947 950.97 799.769 950.97C798.59 950.97 797.46 951.447 796.626 952.296C795.793 953.144 795.325 954.295 795.325 955.496C795.325 956.696 795.793 957.847 796.626 958.695C797.46 959.544 798.59 960.021 799.769 960.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask413_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask413_13_16077)">
+<path d="M782.86 894.113C782.453 894.113 782.16 894.228 781.888 894.481C781.481 894.895 781.21 895.724 781.21 896.575C781.21 897.381 781.436 898.232 781.775 898.646C782.047 898.969 782.408 899.13 782.815 899.13C783.177 899.13 783.493 899.015 783.742 898.762C784.171 898.37 784.442 897.519 784.442 896.621C784.442 895.125 783.787 894.113 782.86 894.113ZM782.838 894.297C783.425 894.297 783.742 895.125 783.742 896.644C783.742 898.163 783.448 898.946 782.815 898.946C782.205 898.946 781.888 898.163 781.888 896.644C781.888 895.102 782.205 894.297 782.838 894.297Z" fill="white"/>
+</g>
+<mask id="mask414_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask414_13_16077)">
+<path d="M800.833 879.137L799.545 879.804V879.896C799.635 879.85 799.703 879.827 799.748 879.827C799.861 879.758 799.997 879.735 800.065 879.735C800.223 879.735 800.291 879.85 800.291 880.08V883.394C800.291 883.624 800.223 883.785 800.11 883.854C799.997 883.923 799.906 883.946 799.59 883.946V884.061H801.579V883.946C801.014 883.946 800.901 883.877 800.901 883.532V879.137H800.833Z" fill="white"/>
+</g>
+<mask id="mask415_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask415_13_16077)">
+<path d="M775.905 880.356L775.792 880.31C775.543 880.724 775.453 880.794 775.114 880.794H773.419L774.617 879.505C775.249 878.837 775.521 878.285 775.521 877.71C775.521 876.973 774.956 876.421 774.21 876.421C773.803 876.421 773.441 876.582 773.17 876.858C772.944 877.111 772.831 877.341 772.718 877.871L772.854 877.894C773.148 877.18 773.419 876.95 773.893 876.95C774.504 876.95 774.91 877.364 774.91 877.986C774.91 878.561 774.594 879.229 773.984 879.873L772.718 881.254V881.346H775.498L775.905 880.356Z" fill="white"/>
+</g>
+<mask id="mask416_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask416_13_16077)">
+<path d="M782.843 870.811C783.25 870.811 783.408 870.834 783.589 870.903C784.041 871.065 784.312 871.479 784.312 871.985C784.312 872.583 783.905 873.067 783.386 873.067C783.182 873.067 783.047 873.021 782.775 872.837C782.549 872.698 782.436 872.652 782.323 872.652C782.143 872.652 782.052 872.768 782.052 872.906C782.052 873.159 782.346 873.32 782.843 873.32C783.408 873.32 783.973 873.136 784.312 872.837C784.651 872.537 784.832 872.123 784.832 871.64C784.832 871.249 784.719 870.926 784.516 870.696C784.357 870.535 784.222 870.443 783.905 870.305C784.403 869.96 784.583 869.684 784.583 869.292C784.583 868.694 784.131 868.303 783.476 868.303C783.114 868.303 782.798 868.418 782.549 868.648C782.323 868.855 782.21 869.039 782.052 869.477L782.165 869.5C782.459 868.97 782.775 868.74 783.227 868.74C783.702 868.74 784.018 869.062 784.018 869.523C784.018 869.776 783.905 870.029 783.725 870.213C783.521 870.443 783.318 870.558 782.843 870.719V870.811Z" fill="white"/>
+</g>
+<mask id="mask417_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask417_13_16077)">
+<path d="M835.965 893.756H835.219V890.511H834.903L832.665 893.756V894.216H834.677V895.436H835.219V894.216H835.965V893.756ZM834.677 893.756H832.937L834.677 891.248V893.756Z" fill="white"/>
+</g>
+<mask id="mask418_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask418_13_16077)">
+<path d="M838.112 913.525H839.536C839.649 913.525 839.671 913.525 839.694 913.456L839.965 912.811L839.897 912.765C839.784 912.926 839.717 912.949 839.558 912.949H838.067L837.298 914.676C837.276 914.699 837.276 914.699 837.276 914.722C837.276 914.745 837.321 914.768 837.366 914.768C837.592 914.768 837.886 914.837 838.18 914.929C838.993 915.182 839.378 915.642 839.378 916.379C839.378 917.069 838.948 917.621 838.383 917.621C838.248 917.621 838.112 917.552 837.909 917.414C837.683 917.23 837.502 917.161 837.366 917.161C837.163 917.161 837.05 917.253 837.05 917.437C837.05 917.713 837.389 917.874 837.931 917.874C838.519 917.874 839.039 917.69 839.4 917.322C839.739 916.977 839.875 916.563 839.875 916.01C839.875 915.481 839.739 915.159 839.378 914.791C839.084 914.468 838.654 914.307 837.818 914.146L838.112 913.525Z" fill="white"/>
+</g>
+<mask id="mask419_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask419_13_16077)">
+<path d="M856.011 892.134C855.198 892.203 854.791 892.341 854.271 892.732C853.48 893.284 853.073 894.113 853.073 895.102C853.073 895.724 853.254 896.368 853.571 896.736C853.842 897.058 854.226 897.22 854.678 897.22C855.559 897.22 856.17 896.529 856.17 895.54C856.17 894.596 855.65 893.998 854.836 893.998C854.52 893.998 854.362 894.067 853.91 894.343C854.113 893.238 854.904 892.433 856.034 892.249L856.011 892.134ZM854.565 894.343C855.175 894.343 855.537 894.872 855.537 895.77C855.537 896.575 855.243 897.035 854.746 897.035C854.113 897.035 853.729 896.345 853.729 895.217C853.729 894.826 853.797 894.642 853.932 894.527C854.09 894.412 854.316 894.343 854.565 894.343Z" fill="white"/>
+</g>
+<mask id="mask420_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask420_13_16077)">
+<path d="M858.141 904.003H855.497L855.068 905.085L855.203 905.131C855.497 904.647 855.633 904.555 856.04 904.555H857.576L856.175 908.905H856.627L858.141 904.118V904.003Z" fill="white"/>
+</g>
+<mask id="mask421_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask421_13_16077)">
+<path d="M811.647 938.27C812.348 937.902 812.596 937.58 812.596 937.097C812.596 936.498 812.099 936.061 811.376 936.061C810.585 936.061 810.02 936.544 810.02 937.212C810.02 937.672 810.156 937.902 810.901 938.57C810.133 939.168 809.975 939.398 809.975 939.881C809.975 940.595 810.54 941.078 811.353 941.078C812.212 941.078 812.755 940.618 812.755 939.858C812.755 939.283 812.506 938.938 811.647 938.27ZM811.512 939.03C812.031 939.421 812.212 939.674 812.212 940.088C812.212 940.549 811.896 940.894 811.421 940.894C810.879 940.894 810.517 940.457 810.517 939.835C810.517 939.352 810.675 939.053 811.082 938.708L811.512 939.03ZM811.444 938.155C810.811 937.718 810.54 937.396 810.54 936.982C810.54 936.567 810.856 936.268 811.308 936.268C811.805 936.268 812.122 936.59 812.122 937.074C812.122 937.488 811.918 937.833 811.512 938.109C811.466 938.132 811.466 938.132 811.444 938.155Z" fill="white"/>
+</g>
+<mask id="mask422_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask422_13_16077)">
+<path d="M787.945 933.737C788.736 933.645 789.143 933.507 789.618 933.138C790.363 932.586 790.815 931.688 790.815 930.699C790.815 929.502 790.137 928.651 789.211 928.651C788.375 928.651 787.742 929.387 787.742 930.377C787.742 931.251 788.239 931.85 789.03 931.85C789.414 931.85 789.708 931.734 790.092 931.435C789.798 932.609 789.007 933.391 787.923 933.599L787.945 933.737ZM790.115 930.975C790.115 931.136 790.07 931.205 790.002 931.274C789.798 931.435 789.527 931.527 789.279 931.527C788.736 931.527 788.397 930.975 788.397 930.124C788.397 929.709 788.51 929.272 788.646 929.065C788.781 928.927 788.962 928.858 789.166 928.858C789.776 928.858 790.115 929.479 790.115 930.699V930.975Z" fill="white"/>
+</g>
+<mask id="mask423_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask423_13_16077)">
+<path d="M786.476 948.063L785.188 948.73V948.822C785.278 948.776 785.346 948.753 785.391 948.753C785.504 948.684 785.64 948.661 785.708 948.661C785.866 948.661 785.934 948.776 785.934 949.006V952.32C785.934 952.55 785.866 952.711 785.753 952.78C785.64 952.85 785.55 952.873 785.233 952.873V952.988H787.222V952.873C786.657 952.873 786.544 952.804 786.544 952.458V948.063H786.476ZM789.804 948.063C789.397 948.063 789.103 948.178 788.832 948.431C788.425 948.845 788.154 949.674 788.154 950.525C788.154 951.331 788.38 952.182 788.719 952.596C788.99 952.919 789.352 953.08 789.759 953.08C790.12 953.08 790.437 952.965 790.685 952.711C791.115 952.32 791.386 951.469 791.386 950.571C791.386 949.075 790.731 948.063 789.804 948.063ZM789.781 948.247C790.369 948.247 790.685 949.075 790.685 950.594C790.685 952.113 790.392 952.896 789.759 952.896C789.149 952.896 788.832 952.113 788.832 950.594C788.832 949.052 789.149 948.247 789.781 948.247Z" fill="white"/>
+</g>
+<mask id="mask424_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="765" y="862" width="101" height="103">
+<path d="M765.623 964.31H865.379V862.729H765.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask424_13_16077)">
+<path d="M798.268 952.251L796.98 952.919V953.011C797.07 952.965 797.138 952.942 797.183 952.942C797.296 952.873 797.432 952.85 797.499 952.85C797.658 952.85 797.725 952.965 797.725 953.195V956.509C797.725 956.739 797.658 956.9 797.545 956.969C797.432 957.038 797.341 957.061 797.025 957.061V957.176H799.014V957.061C798.449 957.061 798.336 956.992 798.336 956.647V952.251H798.268ZM801.85 952.251L800.562 952.919V953.011C800.652 952.965 800.72 952.942 800.765 952.942C800.878 952.873 801.014 952.85 801.082 952.85C801.24 952.85 801.308 952.965 801.308 953.195V956.509C801.308 956.739 801.24 956.9 801.127 956.969C801.014 957.038 800.923 957.061 800.607 957.061V957.176H802.596V957.061C802.031 957.061 801.918 956.992 801.918 956.647V952.251H801.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask425_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1212" y="775" width="112" height="114">
+<path d="M1212 888.037H1323V775H1212V888.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask425_13_16077)">
+<mask id="mask426_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask426_13_16077)">
+<path d="M1234.82 815.354L1252.54 800.382" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask427_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask427_13_16077)">
+<path d="M1234.82 815.354L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask428_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask428_13_16077)">
+<path d="M1234.82 815.354L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask429_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask429_13_16077)">
+<path d="M1234.82 815.354L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask430_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask430_13_16077)">
+<path d="M1252.54 800.382L1226.28 797.666" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask431_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask431_13_16077)">
+<path d="M1252.54 800.382L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask432_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask432_13_16077)">
+<path d="M1252.54 800.382L1286.37 811.754" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask433_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask433_13_16077)">
+<path d="M1226.28 797.666L1235.52 789.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask434_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask434_13_16077)">
+<path d="M1286.37 811.754L1290.61 834.102" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask435_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask435_13_16077)">
+<path d="M1286.37 811.754L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask436_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask436_13_16077)">
+<path d="M1286.37 811.754L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask437_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask437_13_16077)">
+<path d="M1290.61 834.102L1306.61 813.444" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask438_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask438_13_16077)">
+<path d="M1290.61 834.102L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask439_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask439_13_16077)">
+<path d="M1290.61 834.102L1263.36 857.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask440_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask440_13_16077)">
+<path d="M1306.61 813.444L1308.72 825.153" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask441_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask441_13_16077)">
+<path d="M1263.36 857.307L1241.31 849.895" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask442_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask442_13_16077)">
+<path d="M1263.36 857.306L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask443_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask443_13_16077)">
+<path d="M1263.36 857.306L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask444_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask444_13_16077)">
+<path d="M1241.31 849.895L1239.98 869.307" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask445_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask445_13_16077)">
+<path d="M1241.31 849.895L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask446_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask446_13_16077)">
+<path d="M1239.98 869.307L1251.77 873.495" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask447_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask447_13_16077)">
+<mask id="mask448_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1229" y="810" width="11" height="11">
+<path d="M1229.86 820.402H1239.78V810.307H1229.86V820.402Z" fill="white"/>
+</mask>
+<g mask="url(#mask448_13_16077)">
+<path d="M1234.82 819.88C1236 819.88 1237.13 819.403 1237.96 818.554C1238.8 817.706 1239.26 816.555 1239.26 815.354C1239.26 814.154 1238.8 813.003 1237.96 812.155C1237.13 811.306 1236 810.829 1234.82 810.829C1233.64 810.829 1232.51 811.306 1231.68 812.155C1230.85 813.003 1230.38 814.154 1230.38 815.354C1230.38 816.555 1230.85 817.706 1231.68 818.554C1232.51 819.403 1233.64 819.88 1234.82 819.88Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask449_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask449_13_16077)">
+<mask id="mask450_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1247" y="795" width="11" height="11">
+<path d="M1247.58 805.429H1257.5V795.334H1247.58V805.429Z" fill="white"/>
+</mask>
+<g mask="url(#mask450_13_16077)">
+<path d="M1252.54 804.907C1253.72 804.907 1254.85 804.43 1255.68 803.581C1256.52 802.733 1256.98 801.582 1256.98 800.382C1256.98 799.181 1256.52 798.03 1255.68 797.182C1254.85 796.333 1253.72 795.856 1252.54 795.856C1251.36 795.856 1250.23 796.333 1249.4 797.182C1248.56 798.03 1248.1 799.181 1248.1 800.382C1248.1 801.582 1248.56 802.733 1249.4 803.581C1250.23 804.43 1251.36 804.907 1252.54 804.907Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask451_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask451_13_16077)">
+<mask id="mask452_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1221" y="792" width="11" height="11">
+<path d="M1221.32 802.714H1231.24V792.618H1221.32V802.714Z" fill="white"/>
+</mask>
+<g mask="url(#mask452_13_16077)">
+<path d="M1226.28 802.191C1227.46 802.191 1228.59 801.714 1229.42 800.866C1230.26 800.017 1230.72 798.866 1230.72 797.666C1230.72 796.466 1230.26 795.315 1229.42 794.466C1228.59 793.617 1227.46 793.141 1226.28 793.141C1225.1 793.141 1223.97 793.617 1223.14 794.466C1222.3 795.315 1221.84 796.466 1221.84 797.666C1221.84 798.866 1222.3 800.017 1223.14 800.866C1223.97 801.714 1225.1 802.191 1226.28 802.191Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask453_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask453_13_16077)">
+<mask id="mask454_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1230" y="784" width="11" height="11">
+<path d="M1230.57 794.592H1240.48V784.496H1230.57V794.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask454_13_16077)">
+<path d="M1235.52 794.069C1236.7 794.069 1237.83 793.592 1238.67 792.744C1239.5 791.895 1239.97 790.744 1239.97 789.544C1239.97 788.344 1239.5 787.193 1238.67 786.344C1237.83 785.495 1236.7 785.019 1235.52 785.019C1234.34 785.019 1233.21 785.495 1232.38 786.344C1231.55 787.193 1231.08 788.344 1231.08 789.544C1231.08 790.744 1231.55 791.895 1232.38 792.744C1233.21 793.592 1234.34 794.069 1235.52 794.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask455_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask455_13_16077)">
+<mask id="mask456_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1281" y="806" width="11" height="11">
+<path d="M1281.41 816.802H1291.32V806.707H1281.41V816.802Z" fill="white"/>
+</mask>
+<g mask="url(#mask456_13_16077)">
+<path d="M1286.37 816.28C1287.54 816.28 1288.67 815.803 1289.51 814.954C1290.34 814.106 1290.81 812.955 1290.81 811.754C1290.81 810.554 1290.34 809.403 1289.51 808.555C1288.67 807.706 1287.54 807.229 1286.37 807.229C1285.19 807.229 1284.06 807.706 1283.22 808.555C1282.39 809.403 1281.92 810.554 1281.92 811.754C1281.92 812.955 1282.39 814.106 1283.22 814.954C1284.06 815.803 1285.19 816.28 1286.37 816.28Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask457_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask457_13_16077)">
+<mask id="mask458_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1285" y="829" width="11" height="11">
+<path d="M1285.66 839.15H1295.57V829.054H1285.66V839.15Z" fill="white"/>
+</mask>
+<g mask="url(#mask458_13_16077)">
+<path d="M1290.61 838.628C1291.79 838.628 1292.92 838.151 1293.75 837.302C1294.59 836.453 1295.06 835.302 1295.06 834.102C1295.06 832.902 1294.59 831.751 1293.75 830.902C1292.92 830.054 1291.79 829.577 1290.61 829.577C1289.43 829.577 1288.3 830.054 1287.47 830.902C1286.64 831.751 1286.17 832.902 1286.17 834.102C1286.17 835.302 1286.64 836.453 1287.47 837.302C1288.3 838.151 1289.43 838.628 1290.61 838.628Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask459_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask459_13_16077)">
+<mask id="mask460_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1301" y="808" width="11" height="11">
+<path d="M1301.66 818.492H1311.57V808.396H1301.66V818.492Z" fill="white"/>
+</mask>
+<g mask="url(#mask460_13_16077)">
+<path d="M1306.61 817.969C1307.79 817.969 1308.92 817.492 1309.76 816.644C1310.59 815.795 1311.06 814.644 1311.06 813.444C1311.06 812.244 1310.59 811.093 1309.76 810.244C1308.92 809.395 1307.79 808.919 1306.61 808.919C1305.44 808.919 1304.3 809.395 1303.47 810.244C1302.64 811.093 1302.17 812.244 1302.17 813.444C1302.17 814.644 1302.64 815.795 1303.47 816.644C1304.3 817.492 1305.44 817.969 1306.61 817.969Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask461_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask461_13_16077)">
+<mask id="mask462_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1303" y="820" width="11" height="11">
+<path d="M1303.77 830.201H1313.68V820.105H1303.77V830.201Z" fill="white"/>
+</mask>
+<g mask="url(#mask462_13_16077)">
+<path d="M1308.72 829.678C1309.9 829.678 1311.03 829.202 1311.87 828.353C1312.7 827.504 1313.17 826.353 1313.17 825.153C1313.17 823.953 1312.7 822.802 1311.87 821.953C1311.03 821.105 1309.9 820.628 1308.72 820.628C1307.54 820.628 1306.41 821.105 1305.58 821.953C1304.75 822.802 1304.28 823.953 1304.28 825.153C1304.28 826.353 1304.75 827.504 1305.58 828.353C1306.41 829.202 1307.54 829.678 1308.72 829.678Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask463_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask463_13_16077)">
+<mask id="mask464_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1258" y="852" width="11" height="11">
+<path d="M1258.4 862.354H1268.31V852.259H1258.4V862.354Z" fill="white"/>
+</mask>
+<g mask="url(#mask464_13_16077)">
+<path d="M1263.36 861.832C1264.53 861.832 1265.67 861.355 1266.5 860.506C1267.33 859.658 1267.8 858.507 1267.8 857.307C1267.8 856.106 1267.33 854.955 1266.5 854.107C1265.67 853.258 1264.53 852.781 1263.36 852.781C1262.18 852.781 1261.05 853.258 1260.21 854.107C1259.38 854.955 1258.91 856.106 1258.91 857.307C1258.91 858.507 1259.38 859.658 1260.21 860.506C1261.05 861.355 1262.18 861.832 1263.36 861.832Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask465_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask465_13_16077)">
+<mask id="mask466_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1236" y="844" width="11" height="11">
+<path d="M1236.35 854.943H1246.26V844.847H1236.35V854.943Z" fill="white"/>
+</mask>
+<g mask="url(#mask466_13_16077)">
+<path d="M1241.31 854.42C1242.49 854.42 1243.62 853.943 1244.45 853.095C1245.28 852.246 1245.75 851.095 1245.75 849.895C1245.75 848.695 1245.28 847.544 1244.45 846.695C1243.62 845.846 1242.49 845.37 1241.31 845.37C1240.13 845.37 1239 845.846 1238.17 846.695C1237.33 847.544 1236.86 848.695 1236.86 849.895C1236.86 851.095 1237.33 852.246 1238.17 853.095C1239 853.943 1240.13 854.42 1241.31 854.42Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask467_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask467_13_16077)">
+<mask id="mask468_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1235" y="864" width="10" height="11">
+<path d="M1235.02 874.355H1244.93V864.259H1235.02V874.355Z" fill="white"/>
+</mask>
+<g mask="url(#mask468_13_16077)">
+<path d="M1239.98 873.832C1241.15 873.832 1242.28 873.355 1243.12 872.507C1243.95 871.658 1244.42 870.507 1244.42 869.307C1244.42 868.107 1243.95 866.955 1243.12 866.107C1242.28 865.258 1241.15 864.781 1239.98 864.781C1238.8 864.781 1237.67 865.258 1236.83 866.107C1236 866.955 1235.53 868.107 1235.53 869.307C1235.53 870.507 1236 871.658 1236.83 872.507C1237.67 873.355 1238.8 873.832 1239.98 873.832Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask469_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask469_13_16077)">
+<mask id="mask470_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1246" y="868" width="11" height="11">
+<path d="M1246.81 878.543H1256.73V868.448H1246.81V878.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask470_13_16077)">
+<path d="M1251.77 878.021C1252.95 878.021 1254.08 877.544 1254.91 876.695C1255.74 875.847 1256.21 874.696 1256.21 873.496C1256.21 872.295 1255.74 871.144 1254.91 870.296C1254.08 869.447 1252.95 868.97 1251.77 868.97C1250.59 868.97 1249.46 869.447 1248.63 870.296C1247.79 871.144 1247.32 872.295 1247.32 873.496C1247.32 874.696 1247.79 875.847 1248.63 876.695C1249.46 877.544 1250.59 878.021 1251.77 878.021Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask471_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask471_13_16077)">
+<path d="M1234.86 812.113C1234.45 812.113 1234.16 812.228 1233.89 812.481C1233.48 812.895 1233.21 813.724 1233.21 814.575C1233.21 815.381 1233.44 816.232 1233.78 816.646C1234.05 816.969 1234.41 817.13 1234.81 817.13C1235.18 817.13 1235.49 817.015 1235.74 816.762C1236.17 816.37 1236.44 815.519 1236.44 814.621C1236.44 813.125 1235.79 812.113 1234.86 812.113ZM1234.84 812.297C1235.43 812.297 1235.74 813.125 1235.74 814.644C1235.74 816.163 1235.45 816.946 1234.81 816.946C1234.2 816.946 1233.89 816.163 1233.89 814.644C1233.89 813.102 1234.2 812.297 1234.84 812.297Z" fill="white"/>
+</g>
+<mask id="mask472_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask472_13_16077)">
+<path d="M1252.83 797.137L1251.54 797.804V797.896C1251.64 797.85 1251.7 797.827 1251.75 797.827C1251.86 797.758 1252 797.735 1252.06 797.735C1252.22 797.735 1252.29 797.85 1252.29 798.08V801.394C1252.29 801.624 1252.22 801.785 1252.11 801.854C1252 801.923 1251.91 801.946 1251.59 801.946V802.061H1253.58V801.946C1253.01 801.946 1252.9 801.877 1252.9 801.532V797.137H1252.83Z" fill="white"/>
+</g>
+<mask id="mask473_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask473_13_16077)">
+<path d="M1227.9 798.356L1227.79 798.31C1227.54 798.724 1227.45 798.794 1227.11 798.794H1225.42L1226.62 797.505C1227.25 796.837 1227.52 796.285 1227.52 795.71C1227.52 794.973 1226.96 794.421 1226.21 794.421C1225.8 794.421 1225.44 794.582 1225.17 794.858C1224.94 795.111 1224.83 795.341 1224.72 795.871L1224.85 795.894C1225.15 795.18 1225.42 794.95 1225.89 794.95C1226.5 794.95 1226.91 795.364 1226.91 795.986C1226.91 796.561 1226.59 797.229 1225.98 797.873L1224.72 799.254V799.346H1227.5L1227.9 798.356Z" fill="white"/>
+</g>
+<mask id="mask474_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask474_13_16077)">
+<path d="M1234.84 788.811C1235.25 788.811 1235.41 788.834 1235.59 788.903C1236.04 789.065 1236.31 789.479 1236.31 789.985C1236.31 790.583 1235.91 791.067 1235.39 791.067C1235.18 791.067 1235.05 791.021 1234.78 790.837C1234.55 790.698 1234.44 790.652 1234.32 790.652C1234.14 790.652 1234.05 790.768 1234.05 790.906C1234.05 791.159 1234.35 791.32 1234.84 791.32C1235.41 791.32 1235.97 791.136 1236.31 790.837C1236.65 790.537 1236.83 790.123 1236.83 789.64C1236.83 789.249 1236.72 788.926 1236.52 788.696C1236.36 788.535 1236.22 788.443 1235.91 788.305C1236.4 787.96 1236.58 787.684 1236.58 787.292C1236.58 786.694 1236.13 786.303 1235.48 786.303C1235.11 786.303 1234.8 786.418 1234.55 786.648C1234.32 786.855 1234.21 787.039 1234.05 787.477L1234.17 787.5C1234.46 786.97 1234.78 786.74 1235.23 786.74C1235.7 786.74 1236.02 787.062 1236.02 787.523C1236.02 787.776 1235.91 788.029 1235.72 788.213C1235.52 788.443 1235.32 788.558 1234.84 788.719V788.811Z" fill="white"/>
+</g>
+<mask id="mask475_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask475_13_16077)">
+<path d="M1287.96 811.756H1287.22V808.511H1286.9L1284.67 811.756V812.216H1286.68V813.436H1287.22V812.216H1287.96V811.756ZM1286.68 811.756H1284.94L1286.68 809.248V811.756Z" fill="white"/>
+</g>
+<mask id="mask476_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask476_13_16077)">
+<path d="M1290.11 831.525H1291.54C1291.65 831.525 1291.67 831.525 1291.69 831.456L1291.97 830.811L1291.9 830.765C1291.78 830.926 1291.72 830.949 1291.56 830.949H1290.07L1289.3 832.676C1289.28 832.699 1289.28 832.699 1289.28 832.722C1289.28 832.745 1289.32 832.768 1289.37 832.768C1289.59 832.768 1289.89 832.837 1290.18 832.929C1290.99 833.182 1291.38 833.642 1291.38 834.379C1291.38 835.069 1290.95 835.621 1290.38 835.621C1290.25 835.621 1290.11 835.552 1289.91 835.414C1289.68 835.23 1289.5 835.161 1289.37 835.161C1289.16 835.161 1289.05 835.253 1289.05 835.437C1289.05 835.713 1289.39 835.874 1289.93 835.874C1290.52 835.874 1291.04 835.69 1291.4 835.322C1291.74 834.977 1291.87 834.563 1291.87 834.01C1291.87 833.481 1291.74 833.159 1291.38 832.791C1291.08 832.468 1290.65 832.307 1289.82 832.146L1290.11 831.525Z" fill="white"/>
+</g>
+<mask id="mask477_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask477_13_16077)">
+<path d="M1308.01 810.134C1307.2 810.203 1306.79 810.341 1306.27 810.732C1305.48 811.284 1305.07 812.113 1305.07 813.102C1305.07 813.724 1305.25 814.368 1305.57 814.736C1305.84 815.058 1306.23 815.22 1306.68 815.22C1307.56 815.22 1308.17 814.529 1308.17 813.54C1308.17 812.596 1307.65 811.998 1306.84 811.998C1306.52 811.998 1306.36 812.067 1305.91 812.343C1306.11 811.238 1306.9 810.433 1308.03 810.249L1308.01 810.134ZM1306.56 812.343C1307.18 812.343 1307.54 812.872 1307.54 813.77C1307.54 814.575 1307.24 815.035 1306.75 815.035C1306.11 815.035 1305.73 814.345 1305.73 813.217C1305.73 812.826 1305.8 812.642 1305.93 812.527C1306.09 812.412 1306.32 812.343 1306.56 812.343Z" fill="white"/>
+</g>
+<mask id="mask478_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask478_13_16077)">
+<path d="M1310.14 822.003H1307.5L1307.07 823.085L1307.2 823.131C1307.5 822.647 1307.63 822.555 1308.04 822.555H1309.58L1308.18 826.905H1308.63L1310.14 822.118V822.003Z" fill="white"/>
+</g>
+<mask id="mask479_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask479_13_16077)">
+<path d="M1263.65 856.27C1264.35 855.902 1264.6 855.58 1264.6 855.097C1264.6 854.498 1264.1 854.061 1263.38 854.061C1262.58 854.061 1262.02 854.544 1262.02 855.212C1262.02 855.672 1262.16 855.902 1262.9 856.57C1262.13 857.168 1261.97 857.398 1261.97 857.881C1261.97 858.595 1262.54 859.078 1263.35 859.078C1264.21 859.078 1264.75 858.618 1264.75 857.858C1264.75 857.283 1264.51 856.938 1263.65 856.27ZM1263.51 857.03C1264.03 857.421 1264.21 857.674 1264.21 858.088C1264.21 858.549 1263.9 858.894 1263.42 858.894C1262.88 858.894 1262.52 858.457 1262.52 857.835C1262.52 857.352 1262.68 857.053 1263.08 856.708L1263.51 857.03ZM1263.44 856.155C1262.81 855.718 1262.54 855.396 1262.54 854.982C1262.54 854.567 1262.86 854.268 1263.31 854.268C1263.81 854.268 1264.12 854.59 1264.12 855.074C1264.12 855.488 1263.92 855.833 1263.51 856.109C1263.47 856.132 1263.47 856.132 1263.44 856.155Z" fill="white"/>
+</g>
+<mask id="mask480_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask480_13_16077)">
+<path d="M1239.95 851.737C1240.74 851.645 1241.14 851.507 1241.62 851.138C1242.36 850.586 1242.82 849.688 1242.82 848.699C1242.82 847.502 1242.14 846.651 1241.21 846.651C1240.37 846.651 1239.74 847.387 1239.74 848.377C1239.74 849.251 1240.24 849.85 1241.03 849.85C1241.41 849.85 1241.71 849.734 1242.09 849.435C1241.8 850.609 1241.01 851.391 1239.92 851.599L1239.95 851.737ZM1242.11 848.975C1242.11 849.136 1242.07 849.205 1242 849.274C1241.8 849.435 1241.53 849.527 1241.28 849.527C1240.74 849.527 1240.4 848.975 1240.4 848.124C1240.4 847.709 1240.51 847.272 1240.65 847.065C1240.78 846.927 1240.96 846.858 1241.17 846.858C1241.78 846.858 1242.11 847.479 1242.11 848.699V848.975Z" fill="white"/>
+</g>
+<mask id="mask481_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask481_13_16077)">
+<path d="M1238.48 866.063L1237.19 866.73V866.822C1237.28 866.776 1237.35 866.753 1237.39 866.753C1237.5 866.684 1237.64 866.661 1237.71 866.661C1237.87 866.661 1237.93 866.776 1237.93 867.006V870.32C1237.93 870.55 1237.87 870.711 1237.75 870.78C1237.64 870.85 1237.55 870.873 1237.23 870.873V870.988H1239.22V870.873C1238.66 870.873 1238.54 870.804 1238.54 870.458V866.063H1238.48ZM1241.8 866.063C1241.4 866.063 1241.1 866.178 1240.83 866.431C1240.43 866.845 1240.15 867.674 1240.15 868.525C1240.15 869.331 1240.38 870.182 1240.72 870.596C1240.99 870.919 1241.35 871.08 1241.76 871.08C1242.12 871.08 1242.44 870.965 1242.69 870.711C1243.11 870.32 1243.39 869.469 1243.39 868.571C1243.39 867.075 1242.73 866.063 1241.8 866.063ZM1241.78 866.247C1242.37 866.247 1242.69 867.075 1242.69 868.594C1242.69 870.113 1242.39 870.896 1241.76 870.896C1241.15 870.896 1240.83 870.113 1240.83 868.594C1240.83 867.052 1241.15 866.247 1241.78 866.247Z" fill="white"/>
+</g>
+<mask id="mask482_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="1217" y="780" width="101" height="103">
+<path d="M1217.62 882.31H1317.38V780.729H1217.62V882.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask482_13_16077)">
+<path d="M1250.27 870.251L1248.98 870.919V871.011C1249.07 870.965 1249.14 870.942 1249.18 870.942C1249.3 870.873 1249.43 870.85 1249.5 870.85C1249.66 870.85 1249.73 870.965 1249.73 871.195V874.509C1249.73 874.739 1249.66 874.9 1249.54 874.969C1249.43 875.038 1249.34 875.061 1249.02 875.061V875.176H1251.01V875.061C1250.45 875.061 1250.34 874.992 1250.34 874.647V870.251H1250.27ZM1253.85 870.251L1252.56 870.919V871.011C1252.65 870.965 1252.72 870.942 1252.77 870.942C1252.88 870.873 1253.01 870.85 1253.08 870.85C1253.24 870.85 1253.31 870.965 1253.31 871.195V874.509C1253.31 874.739 1253.24 874.9 1253.13 874.969C1253.01 875.038 1252.92 875.061 1252.61 875.061V875.176H1254.6V875.061C1254.03 875.061 1253.92 874.992 1253.92 874.647V870.251H1253.85Z" fill="white"/>
+</g>
+</g>
+<mask id="mask483_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="303" y="599" width="112" height="114">
+<path d="M303 712.037H414.004V599H303V712.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask483_13_16077)">
+<mask id="mask484_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask484_13_16077)">
+<path d="M373.994 647.467L399.723 613.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask485_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask485_13_16077)">
+<path d="M373.994 647.467L346.753 682.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask486_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask486_13_16077)">
+<path d="M373.994 647.467L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask487_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask487_13_16077)">
+<path d="M373.994 647.467L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask488_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask488_13_16077)">
+<path d="M373.994 647.467L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask489_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask489_13_16077)">
+<path d="M346.753 682.876L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask490_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask490_13_16077)">
+<path d="M346.753 682.876L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask491_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask491_13_16077)">
+<path d="M346.753 682.876L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask492_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask492_13_16077)">
+<path d="M343.325 666.493L334.824 615.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask493_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask493_13_16077)">
+<path d="M343.325 666.493L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask494_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask494_13_16077)">
+<path d="M343.325 666.493L376.747 697.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask495_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask495_13_16077)">
+<path d="M343.325 666.493L324.53 693.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask496_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask496_13_16077)">
+<path d="M343.325 666.493L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask497_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask497_13_16077)">
+<path d="M343.325 666.493L317.28 674.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask498_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask498_13_16077)">
+<path d="M334.824 615.141L353.445 633.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask499_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask499_13_16077)">
+<path d="M353.445 633.168L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask500_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask500_13_16077)">
+<path d="M353.445 633.168L361.001 669.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask501_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask501_13_16077)">
+<path d="M376.747 697.496L397.74 678.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask502_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask502_13_16077)">
+<path d="M324.53 693.105L340.084 651.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask503_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask503_13_16077)">
+<mask id="mask504_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="369" y="642" width="10" height="11">
+<path d="M369.037 652.515H378.951V642.419H369.037V652.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask504_13_16077)">
+<path d="M373.994 651.992C375.172 651.992 376.303 651.515 377.136 650.667C377.97 649.818 378.438 648.667 378.438 647.467C378.438 646.267 377.97 645.116 377.136 644.267C376.303 643.418 375.172 642.942 373.994 642.942C372.815 642.942 371.685 643.418 370.851 644.267C370.018 645.116 369.55 646.267 369.55 647.467C369.55 648.667 370.018 649.818 370.851 650.667C371.685 651.515 372.815 651.992 373.994 651.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask505_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask505_13_16077)">
+<mask id="mask506_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="394" y="608" width="11" height="11">
+<path d="M394.766 618.592H404.68V608.496H394.766V618.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask506_13_16077)">
+<path d="M399.723 618.069C400.901 618.069 402.032 617.593 402.865 616.744C403.699 615.895 404.167 614.744 404.167 613.544C404.167 612.344 403.699 611.193 402.865 610.344C402.032 609.496 400.901 609.019 399.723 609.019C398.544 609.019 397.414 609.496 396.58 610.344C395.747 611.193 395.279 612.344 395.279 613.544C395.279 614.744 395.747 615.895 396.58 616.744C397.414 617.593 398.544 618.069 399.723 618.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask507_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask507_13_16077)">
+<mask id="mask508_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="341" y="677" width="11" height="11">
+<path d="M341.796 687.924H351.71V677.829H341.796V687.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask508_13_16077)">
+<path d="M346.753 687.402C347.931 687.402 349.062 686.925 349.895 686.076C350.728 685.228 351.197 684.077 351.197 682.876C351.197 681.676 350.728 680.525 349.895 679.677C349.062 678.828 347.931 678.351 346.753 678.351C345.574 678.351 344.444 678.828 343.61 679.677C342.777 680.525 342.309 681.676 342.309 682.876C342.309 684.077 342.777 685.228 343.61 686.076C344.444 686.925 345.574 687.402 346.753 687.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask509_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask509_13_16077)">
+<mask id="mask510_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="338" y="661" width="11" height="11">
+<path d="M338.368 671.541H348.282V661.445H338.368V671.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask510_13_16077)">
+<path d="M343.325 671.018C344.503 671.018 345.634 670.541 346.467 669.693C347.3 668.844 347.769 667.693 347.769 666.493C347.769 665.293 347.3 664.142 346.467 663.293C345.634 662.444 344.503 661.968 343.325 661.968C342.146 661.968 341.016 662.444 340.182 663.293C339.349 664.142 338.881 665.293 338.881 666.493C338.881 667.693 339.349 668.844 340.182 669.693C341.016 670.541 342.146 671.018 343.325 671.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask511_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask511_13_16077)">
+<mask id="mask512_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="610" width="11" height="11">
+<path d="M329.867 620.189H339.781V610.094H329.867V620.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask512_13_16077)">
+<path d="M334.824 619.667C336.003 619.667 337.133 619.19 337.967 618.341C338.8 617.493 339.268 616.342 339.268 615.141C339.268 613.941 338.8 612.79 337.967 611.941C337.133 611.093 336.003 610.616 334.824 610.616C333.646 610.616 332.515 611.093 331.682 611.941C330.848 612.79 330.38 613.941 330.38 615.141C330.38 616.342 330.848 617.493 331.682 618.341C332.515 619.19 333.646 619.667 334.824 619.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask513_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask513_13_16077)">
+<mask id="mask514_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="348" y="628" width="11" height="11">
+<path d="M348.488 638.216H358.402V628.12H348.488V638.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask514_13_16077)">
+<path d="M353.445 637.693C354.623 637.693 355.754 637.216 356.587 636.368C357.421 635.519 357.889 634.368 357.889 633.168C357.889 631.968 357.421 630.817 356.587 629.968C355.754 629.119 354.623 628.643 353.445 628.643C352.266 628.643 351.136 629.119 350.303 629.968C349.469 630.817 349.001 631.968 349.001 633.168C349.001 634.368 349.469 635.519 350.303 636.368C351.136 637.216 352.266 637.693 353.445 637.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask515_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask515_13_16077)">
+<mask id="mask516_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="371" y="692" width="11" height="11">
+<path d="M371.79 702.543H381.704V692.448H371.79V702.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask516_13_16077)">
+<path d="M376.747 702.021C377.925 702.021 379.056 701.544 379.889 700.696C380.723 699.847 381.191 698.696 381.191 697.496C381.191 696.295 380.723 695.144 379.889 694.296C379.056 693.447 377.925 692.97 376.747 692.97C375.568 692.97 374.438 693.447 373.604 694.296C372.771 695.144 372.303 696.295 372.303 697.496C372.303 698.696 372.771 699.847 373.604 700.696C374.438 701.544 375.568 702.021 376.747 702.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask517_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask517_13_16077)">
+<mask id="mask518_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="319" y="688" width="11" height="11">
+<path d="M319.573 698.153H329.487V688.057H319.573V698.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask518_13_16077)">
+<path d="M324.53 697.63C325.708 697.63 326.839 697.153 327.672 696.305C328.506 695.456 328.974 694.305 328.974 693.105C328.974 691.905 328.506 690.754 327.672 689.905C326.839 689.056 325.708 688.58 324.53 688.58C323.351 688.58 322.221 689.056 321.388 689.905C320.554 690.754 320.086 691.905 320.086 693.105C320.086 694.305 320.554 695.456 321.388 696.305C322.221 697.153 323.351 697.63 324.53 697.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask519_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask519_13_16077)">
+<mask id="mask520_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="335" y="646" width="11" height="11">
+<path d="M335.127 656.971H345.041V646.876H335.127V656.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask520_13_16077)">
+<path d="M340.084 656.449C341.263 656.449 342.393 655.972 343.226 655.123C344.06 654.275 344.528 653.124 344.528 651.924C344.528 650.723 344.06 649.572 343.226 648.724C342.393 647.875 341.263 647.398 340.084 647.398C338.905 647.398 337.775 647.875 336.942 648.724C336.108 649.572 335.64 650.723 335.64 651.924C335.64 653.124 336.108 654.275 336.942 655.123C337.775 655.972 338.905 656.449 340.084 656.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask521_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask521_13_16077)">
+<mask id="mask522_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="392" y="673" width="11" height="11">
+<path d="M392.783 683.164H402.697V673.068H392.783V683.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask522_13_16077)">
+<path d="M397.74 682.641C398.918 682.641 400.049 682.164 400.882 681.316C401.715 680.467 402.184 679.316 402.184 678.116C402.184 676.916 401.715 675.765 400.882 674.916C400.049 674.067 398.918 673.591 397.74 673.591C396.561 673.591 395.431 674.067 394.597 674.916C393.764 675.765 393.296 676.916 393.296 678.116C393.296 679.316 393.764 680.467 394.597 681.316C395.431 682.164 396.561 682.641 397.74 682.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask523_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask523_13_16077)">
+<mask id="mask524_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="356" y="664" width="10" height="11">
+<path d="M356.043 674.696H365.958V664.601H356.043V674.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask524_13_16077)">
+<path d="M361.001 674.174C362.179 674.174 363.31 673.697 364.143 672.848C364.976 672 365.445 670.849 365.445 669.649C365.445 668.448 364.976 667.297 364.143 666.449C363.31 665.6 362.179 665.123 361.001 665.123C359.822 665.123 358.692 665.6 357.858 666.449C357.025 667.297 356.557 668.448 356.557 669.649C356.557 670.849 357.025 672 357.858 672.848C358.692 673.697 359.822 674.174 361.001 674.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask525_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask525_13_16077)">
+<mask id="mask526_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="669" width="11" height="11">
+<path d="M312.323 679.902H322.237V669.806H312.323V679.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask526_13_16077)">
+<path d="M317.28 679.38C318.458 679.38 319.589 678.903 320.422 678.054C321.256 677.206 321.724 676.054 321.724 674.854C321.724 673.654 321.256 672.503 320.422 671.654C319.589 670.806 318.458 670.329 317.28 670.329C316.101 670.329 314.971 670.806 314.137 671.654C313.304 672.503 312.836 673.654 312.836 674.854C312.836 676.054 313.304 677.206 314.137 678.054C314.971 678.903 316.101 679.38 317.28 679.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask527_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask527_13_16077)">
+<path d="M374.032 644.225C373.626 644.225 373.332 644.34 373.061 644.593C372.654 645.008 372.383 645.836 372.383 646.688C372.383 647.493 372.609 648.345 372.948 648.759C373.219 649.081 373.58 649.242 373.987 649.242C374.349 649.242 374.665 649.127 374.914 648.874C375.343 648.483 375.614 647.631 375.614 646.734C375.614 645.238 374.959 644.225 374.032 644.225ZM374.01 644.409C374.597 644.409 374.914 645.238 374.914 646.757C374.914 648.276 374.62 649.058 373.987 649.058C373.377 649.058 373.061 648.276 373.061 646.757C373.061 645.215 373.377 644.409 374.01 644.409Z" fill="white"/>
+</g>
+<mask id="mask528_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask528_13_16077)">
+<path d="M400.011 610.303L398.723 610.97V611.062C398.814 611.016 398.881 610.993 398.927 610.993C399.04 610.924 399.175 610.901 399.243 610.901C399.401 610.901 399.469 611.016 399.469 611.246V614.56C399.469 614.791 399.401 614.952 399.288 615.021C399.175 615.09 399.085 615.113 398.768 615.113V615.228H400.757V615.113C400.192 615.113 400.079 615.044 400.079 614.698V610.303H400.011Z" fill="white"/>
+</g>
+<mask id="mask529_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask529_13_16077)">
+<path d="M348.376 683.567L348.263 683.521C348.014 683.935 347.924 684.004 347.585 684.004H345.89L347.087 682.716C347.72 682.048 347.991 681.496 347.991 680.921C347.991 680.184 347.426 679.632 346.681 679.632C346.274 679.632 345.912 679.793 345.641 680.069C345.415 680.322 345.302 680.552 345.189 681.082L345.325 681.105C345.618 680.391 345.89 680.161 346.364 680.161C346.974 680.161 347.381 680.575 347.381 681.197C347.381 681.772 347.065 682.439 346.455 683.084L345.189 684.465V684.557H347.969L348.376 683.567Z" fill="white"/>
+</g>
+<mask id="mask530_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask530_13_16077)">
+<path d="M342.641 665.76C343.048 665.76 343.206 665.783 343.387 665.852C343.839 666.013 344.11 666.428 344.11 666.934C344.11 667.532 343.703 668.016 343.183 668.016C342.98 668.016 342.844 667.97 342.573 667.785C342.347 667.647 342.234 667.601 342.121 667.601C341.94 667.601 341.85 667.716 341.85 667.855C341.85 668.108 342.144 668.269 342.641 668.269C343.206 668.269 343.771 668.085 344.11 667.785C344.449 667.486 344.63 667.072 344.63 666.589C344.63 666.198 344.517 665.875 344.313 665.645C344.155 665.484 344.019 665.392 343.703 665.254C344.2 664.909 344.381 664.633 344.381 664.241C344.381 663.643 343.929 663.252 343.274 663.252C342.912 663.252 342.596 663.367 342.347 663.597C342.121 663.804 342.008 663.988 341.85 664.425L341.963 664.448C342.257 663.919 342.573 663.689 343.025 663.689C343.5 663.689 343.816 664.011 343.816 664.471C343.816 664.725 343.703 664.978 343.522 665.162C343.319 665.392 343.115 665.507 342.641 665.668V665.76Z" fill="white"/>
+</g>
+<mask id="mask531_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask531_13_16077)">
+<path d="M336.426 615.142H335.68V611.897H335.364L333.126 615.142V615.602H335.138V616.822H335.68V615.602H336.426V615.142ZM335.138 615.142H333.397L335.138 612.633V615.142Z" fill="white"/>
+</g>
+<mask id="mask532_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask532_13_16077)">
+<path d="M352.946 630.59H354.37C354.483 630.59 354.506 630.59 354.528 630.52L354.8 629.876L354.732 629.83C354.619 629.991 354.551 630.014 354.393 630.014H352.901L352.133 631.74C352.11 631.763 352.11 631.763 352.11 631.786C352.11 631.809 352.155 631.832 352.201 631.832C352.427 631.832 352.72 631.901 353.014 631.993C353.828 632.247 354.212 632.707 354.212 633.443C354.212 634.134 353.783 634.686 353.218 634.686C353.082 634.686 352.946 634.617 352.743 634.479C352.517 634.295 352.336 634.226 352.201 634.226C351.997 634.226 351.884 634.318 351.884 634.502C351.884 634.778 352.223 634.939 352.766 634.939C353.353 634.939 353.873 634.755 354.235 634.387C354.574 634.042 354.709 633.627 354.709 633.075C354.709 632.546 354.574 632.224 354.212 631.855C353.918 631.533 353.489 631.372 352.653 631.211L352.946 630.59Z" fill="white"/>
+</g>
+<mask id="mask533_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask533_13_16077)">
+<path d="M378.146 694.182C377.332 694.251 376.925 694.389 376.405 694.781C375.614 695.333 375.208 696.161 375.208 697.151C375.208 697.772 375.388 698.417 375.705 698.785C375.976 699.107 376.36 699.268 376.812 699.268C377.694 699.268 378.304 698.578 378.304 697.588C378.304 696.645 377.784 696.046 376.97 696.046C376.654 696.046 376.496 696.115 376.044 696.392C376.247 695.287 377.038 694.481 378.168 694.297L378.146 694.182ZM376.699 696.392C377.309 696.392 377.671 696.921 377.671 697.818C377.671 698.624 377.377 699.084 376.88 699.084C376.247 699.084 375.863 698.394 375.863 697.266C375.863 696.875 375.931 696.691 376.066 696.576C376.225 696.461 376.451 696.392 376.699 696.392Z" fill="white"/>
+</g>
+<mask id="mask534_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask534_13_16077)">
+<path d="M325.951 689.953H323.306L322.877 691.035L323.012 691.081C323.306 690.598 323.442 690.506 323.849 690.506H325.386L323.984 694.855H324.436L325.951 690.068V689.953Z" fill="white"/>
+</g>
+<mask id="mask535_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask535_13_16077)">
+<path d="M340.375 650.888C341.076 650.519 341.324 650.197 341.324 649.714C341.324 649.116 340.827 648.678 340.104 648.678C339.313 648.678 338.748 649.162 338.748 649.829C338.748 650.289 338.883 650.519 339.629 651.187C338.861 651.785 338.703 652.015 338.703 652.499C338.703 653.212 339.268 653.695 340.081 653.695C340.94 653.695 341.482 653.235 341.482 652.476C341.482 651.9 341.234 651.555 340.375 650.888ZM340.239 651.647C340.759 652.038 340.94 652.291 340.94 652.706C340.94 653.166 340.624 653.511 340.149 653.511C339.607 653.511 339.245 653.074 339.245 652.453C339.245 651.969 339.403 651.67 339.81 651.325L340.239 651.647ZM340.172 650.773C339.539 650.335 339.268 650.013 339.268 649.599C339.268 649.185 339.584 648.885 340.036 648.885C340.533 648.885 340.85 649.208 340.85 649.691C340.85 650.105 340.646 650.45 340.239 650.727C340.194 650.75 340.194 650.75 340.172 650.773Z" fill="white"/>
+</g>
+<mask id="mask536_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask536_13_16077)">
+<path d="M396.378 679.96C397.169 679.868 397.576 679.73 398.051 679.361C398.797 678.809 399.249 677.911 399.249 676.922C399.249 675.725 398.571 674.874 397.644 674.874C396.808 674.874 396.175 675.61 396.175 676.6C396.175 677.474 396.672 678.073 397.463 678.073C397.847 678.073 398.141 677.957 398.525 677.658C398.232 678.832 397.441 679.614 396.356 679.822L396.378 679.96ZM398.548 677.198C398.548 677.359 398.503 677.428 398.435 677.497C398.232 677.658 397.96 677.75 397.712 677.75C397.169 677.75 396.83 677.198 396.83 676.347C396.83 675.932 396.943 675.495 397.079 675.288C397.215 675.15 397.395 675.081 397.599 675.081C398.209 675.081 398.548 675.702 398.548 676.922V677.198Z" fill="white"/>
+</g>
+<mask id="mask537_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask537_13_16077)">
+<path d="M359.501 666.405L358.212 667.072V667.164C358.303 667.118 358.371 667.095 358.416 667.095C358.529 667.026 358.664 667.003 358.732 667.003C358.89 667.003 358.958 667.118 358.958 667.348V670.662C358.958 670.892 358.89 671.053 358.777 671.122C358.664 671.191 358.574 671.214 358.258 671.214V671.33H360.246V671.214C359.681 671.214 359.568 671.145 359.568 670.8V666.405H359.501ZM362.828 666.405C362.422 666.405 362.128 666.52 361.857 666.773C361.45 667.187 361.179 668.016 361.179 668.867C361.179 669.673 361.405 670.524 361.744 670.938C362.015 671.261 362.376 671.422 362.783 671.422C363.145 671.422 363.461 671.307 363.71 671.053C364.139 670.662 364.41 669.811 364.41 668.913C364.41 667.417 363.755 666.405 362.828 666.405ZM362.806 666.589C363.393 666.589 363.71 667.417 363.71 668.936C363.71 670.455 363.416 671.237 362.783 671.237C362.173 671.237 361.857 670.455 361.857 668.936C361.857 667.394 362.173 666.589 362.806 666.589Z" fill="white"/>
+</g>
+<mask id="mask538_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="308" y="604" width="101" height="103">
+<path d="M308.623 706.31H408.379V604.729H308.623V706.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask538_13_16077)">
+<path d="M315.78 671.612L314.492 672.279V672.371C314.583 672.325 314.65 672.302 314.696 672.302C314.809 672.233 314.944 672.21 315.012 672.21C315.17 672.21 315.238 672.325 315.238 672.555V675.869C315.238 676.099 315.17 676.26 315.057 676.329C314.944 676.398 314.854 676.421 314.537 676.421V676.536H316.526V676.421C315.961 676.421 315.848 676.352 315.848 676.007V671.612H315.78ZM319.357 671.612L318.069 672.279V672.371C318.159 672.325 318.227 672.302 318.272 672.302C318.385 672.233 318.521 672.21 318.589 672.21C318.747 672.21 318.815 672.325 318.815 672.555V675.869C318.815 676.099 318.747 676.26 318.634 676.329C318.521 676.398 318.43 676.421 318.114 676.421V676.536H320.103V676.421C319.538 676.421 319.425 676.352 319.425 676.007V671.612H319.357Z" fill="white"/>
+</g>
+</g>
+<mask id="mask539_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="320" y="857" width="112" height="114">
+<path d="M320 970.037H431.004V857H320V970.037Z" fill="white"/>
+</mask>
+<g mask="url(#mask539_13_16077)">
+<mask id="mask540_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask540_13_16077)">
+<path d="M390.994 905.467L416.723 871.544" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask541_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask541_13_16077)">
+<path d="M390.994 905.467L363.753 940.876" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask542_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask542_13_16077)">
+<path d="M390.994 905.467L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask543_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask543_13_16077)">
+<path d="M390.994 905.467L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask544_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask544_13_16077)">
+<path d="M390.994 905.467L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask545_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask545_13_16077)">
+<path d="M363.753 940.876L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask546_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask546_13_16077)">
+<path d="M363.753 940.876L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask547_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask547_13_16077)">
+<path d="M363.753 940.876L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask548_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask548_13_16077)">
+<path d="M360.325 924.493L351.824 873.141" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask549_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask549_13_16077)">
+<path d="M360.325 924.493L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask550_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask550_13_16077)">
+<path d="M360.325 924.493L393.747 955.496" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask551_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask551_13_16077)">
+<path d="M360.325 924.493L341.53 951.105" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask552_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask552_13_16077)">
+<path d="M360.325 924.493L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask553_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask553_13_16077)">
+<path d="M360.325 924.493L334.28 932.854" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask554_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask554_13_16077)">
+<path d="M351.824 873.141L370.445 891.168" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask555_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask555_13_16077)">
+<path d="M370.445 891.168L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask556_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask556_13_16077)">
+<path d="M370.445 891.168L378.001 927.648" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask557_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask557_13_16077)">
+<path d="M393.747 955.496L414.74 936.116" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask558_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask558_13_16077)">
+<path d="M341.53 951.105L357.084 909.924" stroke="black" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+<mask id="mask559_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask559_13_16077)">
+<mask id="mask560_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="386" y="900" width="10" height="11">
+<path d="M386.037 910.515H395.951V900.419H386.037V910.515Z" fill="white"/>
+</mask>
+<g mask="url(#mask560_13_16077)">
+<path d="M390.994 909.992C392.172 909.992 393.303 909.515 394.136 908.667C394.97 907.818 395.438 906.667 395.438 905.467C395.438 904.267 394.97 903.116 394.136 902.267C393.303 901.418 392.172 900.942 390.994 900.942C389.815 900.942 388.685 901.418 387.851 902.267C387.018 903.116 386.55 904.267 386.55 905.467C386.55 906.667 387.018 907.818 387.851 908.667C388.685 909.515 389.815 909.992 390.994 909.992Z" fill="#F8BA12" stroke="#F8BA12" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask561_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask561_13_16077)">
+<mask id="mask562_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="411" y="866" width="11" height="11">
+<path d="M411.766 876.592H421.68V866.496H411.766V876.592Z" fill="white"/>
+</mask>
+<g mask="url(#mask562_13_16077)">
+<path d="M416.723 876.069C417.901 876.069 419.032 875.593 419.865 874.744C420.699 873.895 421.167 872.744 421.167 871.544C421.167 870.344 420.699 869.193 419.865 868.344C419.032 867.496 417.901 867.019 416.723 867.019C415.544 867.019 414.414 867.496 413.58 868.344C412.747 869.193 412.279 870.344 412.279 871.544C412.279 872.744 412.747 873.895 413.58 874.744C414.414 875.593 415.544 876.069 416.723 876.069Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask563_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask563_13_16077)">
+<mask id="mask564_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="358" y="935" width="11" height="11">
+<path d="M358.796 945.924H368.71V935.829H358.796V945.924Z" fill="white"/>
+</mask>
+<g mask="url(#mask564_13_16077)">
+<path d="M363.753 945.402C364.931 945.402 366.062 944.925 366.895 944.076C367.728 943.228 368.197 942.077 368.197 940.876C368.197 939.676 367.728 938.525 366.895 937.677C366.062 936.828 364.931 936.351 363.753 936.351C362.574 936.351 361.444 936.828 360.61 937.677C359.777 938.525 359.309 939.676 359.309 940.876C359.309 942.077 359.777 943.228 360.61 944.076C361.444 944.925 362.574 945.402 363.753 945.402Z" fill="#F6A90C" stroke="#F6A90C" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask565_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask565_13_16077)">
+<mask id="mask566_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="355" y="919" width="11" height="11">
+<path d="M355.368 929.541H365.282V919.445H355.368V929.541Z" fill="white"/>
+</mask>
+<g mask="url(#mask566_13_16077)">
+<path d="M360.325 929.018C361.503 929.018 362.634 928.541 363.467 927.693C364.3 926.844 364.769 925.693 364.769 924.493C364.769 923.293 364.3 922.142 363.467 921.293C362.634 920.444 361.503 919.968 360.325 919.968C359.146 919.968 358.016 920.444 357.182 921.293C356.349 922.142 355.881 923.293 355.881 924.493C355.881 925.693 356.349 926.844 357.182 927.693C358.016 928.541 359.146 929.018 360.325 929.018Z" fill="#F7B00E" stroke="#F7B00E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask567_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask567_13_16077)">
+<mask id="mask568_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="346" y="868" width="11" height="11">
+<path d="M346.867 878.189H356.781V868.094H346.867V878.189Z" fill="white"/>
+</mask>
+<g mask="url(#mask568_13_16077)">
+<path d="M351.824 877.667C353.003 877.667 354.133 877.19 354.967 876.341C355.8 875.493 356.268 874.342 356.268 873.141C356.268 871.941 355.8 870.79 354.967 869.941C354.133 869.093 353.003 868.616 351.824 868.616C350.646 868.616 349.515 869.093 348.682 869.941C347.848 870.79 347.38 871.941 347.38 873.141C347.38 874.342 347.848 875.493 348.682 876.341C349.515 877.19 350.646 877.667 351.824 877.667Z" fill="#2E727E" stroke="#2E727E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask569_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask569_13_16077)">
+<mask id="mask570_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="365" y="886" width="11" height="11">
+<path d="M365.488 896.216H375.402V886.12H365.488V896.216Z" fill="white"/>
+</mask>
+<g mask="url(#mask570_13_16077)">
+<path d="M370.445 895.693C371.623 895.693 372.754 895.216 373.587 894.368C374.421 893.519 374.889 892.368 374.889 891.168C374.889 889.968 374.421 888.817 373.587 887.968C372.754 887.119 371.623 886.643 370.445 886.643C369.266 886.643 368.136 887.119 367.303 887.968C366.469 888.817 366.001 889.968 366.001 891.168C366.001 892.368 366.469 893.519 367.303 894.368C368.136 895.216 369.266 895.693 370.445 895.693Z" fill="#296D7E" stroke="#296D7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask571_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask571_13_16077)">
+<mask id="mask572_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="388" y="950" width="11" height="11">
+<path d="M388.79 960.543H398.704V950.448H388.79V960.543Z" fill="white"/>
+</mask>
+<g mask="url(#mask572_13_16077)">
+<path d="M393.747 960.021C394.925 960.021 396.056 959.544 396.889 958.696C397.723 957.847 398.191 956.696 398.191 955.496C398.191 954.295 397.723 953.144 396.889 952.296C396.056 951.447 394.925 950.97 393.747 950.97C392.568 950.97 391.438 951.447 390.604 952.296C389.771 953.144 389.303 954.295 389.303 955.496C389.303 956.696 389.771 957.847 390.604 958.696C391.438 959.544 392.568 960.021 393.747 960.021Z" fill="#2D717E" stroke="#2D717E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask573_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask573_13_16077)">
+<mask id="mask574_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="336" y="946" width="11" height="11">
+<path d="M336.573 956.153H346.487V946.057H336.573V956.153Z" fill="white"/>
+</mask>
+<g mask="url(#mask574_13_16077)">
+<path d="M341.53 955.63C342.708 955.63 343.839 955.153 344.672 954.305C345.506 953.456 345.974 952.305 345.974 951.105C345.974 949.905 345.506 948.754 344.672 947.905C343.839 947.056 342.708 946.58 341.53 946.58C340.351 946.58 339.221 947.056 338.388 947.905C337.554 948.754 337.086 949.905 337.086 951.105C337.086 952.305 337.554 953.456 338.388 954.305C339.221 955.153 340.351 955.63 341.53 955.63Z" fill="#276B7E" stroke="#276B7E" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask575_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask575_13_16077)">
+<mask id="mask576_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="352" y="904" width="11" height="11">
+<path d="M352.127 914.971H362.041V904.876H352.127V914.971Z" fill="white"/>
+</mask>
+<g mask="url(#mask576_13_16077)">
+<path d="M357.084 914.449C358.263 914.449 359.393 913.972 360.226 913.123C361.06 912.275 361.528 911.124 361.528 909.924C361.528 908.723 361.06 907.572 360.226 906.724C359.393 905.875 358.263 905.398 357.084 905.398C355.905 905.398 354.775 905.875 353.942 906.724C353.108 907.572 352.64 908.723 352.64 909.924C352.64 911.124 353.108 912.275 353.942 913.123C354.775 913.972 355.905 914.449 357.084 914.449Z" fill="#7B0154" stroke="#7B0154" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask577_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask577_13_16077)">
+<mask id="mask578_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="409" y="931" width="11" height="11">
+<path d="M409.783 941.164H419.697V931.068H409.783V941.164Z" fill="white"/>
+</mask>
+<g mask="url(#mask578_13_16077)">
+<path d="M414.74 940.641C415.918 940.641 417.049 940.164 417.882 939.316C418.715 938.467 419.184 937.316 419.184 936.116C419.184 934.916 418.715 933.765 417.882 932.916C417.049 932.067 415.918 931.591 414.74 931.591C413.561 931.591 412.431 932.067 411.597 932.916C410.764 933.765 410.296 934.916 410.296 936.116C410.296 937.316 410.764 938.467 411.597 939.316C412.431 940.164 413.561 940.641 414.74 940.641Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask579_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask579_13_16077)">
+<mask id="mask580_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="373" y="922" width="10" height="11">
+<path d="M373.043 932.696H382.958V922.601H373.043V932.696Z" fill="white"/>
+</mask>
+<g mask="url(#mask580_13_16077)">
+<path d="M378.001 932.174C379.179 932.174 380.31 931.697 381.143 930.848C381.976 930 382.445 928.849 382.445 927.649C382.445 926.448 381.976 925.297 381.143 924.449C380.31 923.6 379.179 923.123 378.001 923.123C376.822 923.123 375.692 923.6 374.858 924.449C374.025 925.297 373.557 926.448 373.557 927.649C373.557 928.849 374.025 930 374.858 930.848C375.692 931.697 376.822 932.174 378.001 932.174Z" fill="#710353" stroke="#710353" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask581_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask581_13_16077)">
+<mask id="mask582_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="329" y="927" width="11" height="11">
+<path d="M329.323 937.902H339.237V927.806H329.323V937.902Z" fill="white"/>
+</mask>
+<g mask="url(#mask582_13_16077)">
+<path d="M334.28 937.38C335.458 937.38 336.589 936.903 337.422 936.054C338.256 935.206 338.724 934.054 338.724 932.854C338.724 931.654 338.256 930.503 337.422 929.654C336.589 928.806 335.458 928.329 334.28 928.329C333.101 928.329 331.971 928.806 331.137 929.654C330.304 930.503 329.836 931.654 329.836 932.854C329.836 934.054 330.304 935.206 331.137 936.054C331.971 936.903 333.101 937.38 334.28 937.38Z" fill="#680652" stroke="#680652" stroke-width="0.354773" stroke-miterlimit="10" stroke-linejoin="round"/>
+</g>
+</g>
+<mask id="mask583_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask583_13_16077)">
+<path d="M391.032 902.225C390.626 902.225 390.332 902.34 390.061 902.593C389.654 903.008 389.383 903.836 389.383 904.688C389.383 905.493 389.609 906.345 389.948 906.759C390.219 907.081 390.58 907.242 390.987 907.242C391.349 907.242 391.665 907.127 391.914 906.874C392.343 906.483 392.614 905.631 392.614 904.734C392.614 903.238 391.959 902.225 391.032 902.225ZM391.01 902.409C391.597 902.409 391.914 903.238 391.914 904.757C391.914 906.276 391.62 907.058 390.987 907.058C390.377 907.058 390.061 906.276 390.061 904.757C390.061 903.215 390.377 902.409 391.01 902.409Z" fill="white"/>
+</g>
+<mask id="mask584_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask584_13_16077)">
+<path d="M417.011 868.303L415.723 868.97V869.062C415.814 869.016 415.881 868.993 415.927 868.993C416.04 868.924 416.175 868.901 416.243 868.901C416.401 868.901 416.469 869.016 416.469 869.246V872.56C416.469 872.791 416.401 872.952 416.288 873.021C416.175 873.09 416.085 873.113 415.768 873.113V873.228H417.757V873.113C417.192 873.113 417.079 873.044 417.079 872.698V868.303H417.011Z" fill="white"/>
+</g>
+<mask id="mask585_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask585_13_16077)">
+<path d="M365.376 941.567L365.263 941.521C365.014 941.935 364.924 942.004 364.585 942.004H362.89L364.087 940.716C364.72 940.048 364.991 939.496 364.991 938.921C364.991 938.184 364.426 937.632 363.681 937.632C363.274 937.632 362.912 937.793 362.641 938.069C362.415 938.322 362.302 938.552 362.189 939.082L362.325 939.105C362.618 938.391 362.89 938.161 363.364 938.161C363.974 938.161 364.381 938.575 364.381 939.197C364.381 939.772 364.065 940.439 363.455 941.084L362.189 942.465V942.557H364.969L365.376 941.567Z" fill="white"/>
+</g>
+<mask id="mask586_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask586_13_16077)">
+<path d="M359.641 923.76C360.048 923.76 360.206 923.783 360.387 923.852C360.839 924.013 361.11 924.428 361.11 924.934C361.11 925.532 360.703 926.016 360.183 926.016C359.98 926.016 359.844 925.97 359.573 925.785C359.347 925.647 359.234 925.601 359.121 925.601C358.94 925.601 358.85 925.716 358.85 925.855C358.85 926.108 359.144 926.269 359.641 926.269C360.206 926.269 360.771 926.085 361.11 925.785C361.449 925.486 361.63 925.072 361.63 924.589C361.63 924.198 361.517 923.875 361.313 923.645C361.155 923.484 361.019 923.392 360.703 923.254C361.2 922.909 361.381 922.633 361.381 922.241C361.381 921.643 360.929 921.252 360.274 921.252C359.912 921.252 359.596 921.367 359.347 921.597C359.121 921.804 359.008 921.988 358.85 922.425L358.963 922.448C359.257 921.919 359.573 921.689 360.025 921.689C360.5 921.689 360.816 922.011 360.816 922.471C360.816 922.725 360.703 922.978 360.522 923.162C360.319 923.392 360.115 923.507 359.641 923.668V923.76Z" fill="white"/>
+</g>
+<mask id="mask587_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask587_13_16077)">
+<path d="M353.426 873.142H352.68V869.897H352.364L350.126 873.142V873.602H352.138V874.822H352.68V873.602H353.426V873.142ZM352.138 873.142H350.397L352.138 870.633V873.142Z" fill="white"/>
+</g>
+<mask id="mask588_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask588_13_16077)">
+<path d="M369.946 888.59H371.37C371.483 888.59 371.506 888.59 371.528 888.52L371.8 887.876L371.732 887.83C371.619 887.991 371.551 888.014 371.393 888.014H369.901L369.133 889.74C369.11 889.763 369.11 889.763 369.11 889.786C369.11 889.809 369.155 889.832 369.201 889.832C369.427 889.832 369.72 889.901 370.014 889.993C370.828 890.247 371.212 890.707 371.212 891.443C371.212 892.134 370.783 892.686 370.218 892.686C370.082 892.686 369.946 892.617 369.743 892.479C369.517 892.295 369.336 892.226 369.201 892.226C368.997 892.226 368.884 892.318 368.884 892.502C368.884 892.778 369.223 892.939 369.766 892.939C370.353 892.939 370.873 892.755 371.235 892.387C371.574 892.042 371.709 891.627 371.709 891.075C371.709 890.546 371.574 890.224 371.212 889.855C370.918 889.533 370.489 889.372 369.653 889.211L369.946 888.59Z" fill="white"/>
+</g>
+<mask id="mask589_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask589_13_16077)">
+<path d="M395.146 952.182C394.332 952.251 393.925 952.389 393.405 952.781C392.614 953.333 392.208 954.161 392.208 955.151C392.208 955.772 392.388 956.417 392.705 956.785C392.976 957.107 393.36 957.268 393.812 957.268C394.694 957.268 395.304 956.578 395.304 955.588C395.304 954.645 394.784 954.046 393.97 954.046C393.654 954.046 393.496 954.115 393.044 954.392C393.247 953.287 394.038 952.481 395.168 952.297L395.146 952.182ZM393.699 954.392C394.309 954.392 394.671 954.921 394.671 955.818C394.671 956.624 394.377 957.084 393.88 957.084C393.247 957.084 392.863 956.394 392.863 955.266C392.863 954.875 392.931 954.691 393.066 954.576C393.225 954.461 393.451 954.392 393.699 954.392Z" fill="white"/>
+</g>
+<mask id="mask590_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask590_13_16077)">
+<path d="M342.951 947.953H340.306L339.877 949.035L340.012 949.081C340.306 948.598 340.442 948.506 340.849 948.506H342.386L340.984 952.855H341.436L342.951 948.068V947.953Z" fill="white"/>
+</g>
+<mask id="mask591_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask591_13_16077)">
+<path d="M357.375 908.888C358.076 908.519 358.324 908.197 358.324 907.714C358.324 907.116 357.827 906.678 357.104 906.678C356.313 906.678 355.748 907.162 355.748 907.829C355.748 908.289 355.883 908.519 356.629 909.187C355.861 909.785 355.703 910.015 355.703 910.499C355.703 911.212 356.268 911.695 357.081 911.695C357.94 911.695 358.482 911.235 358.482 910.476C358.482 909.9 358.234 909.555 357.375 908.888ZM357.239 909.647C357.759 910.038 357.94 910.291 357.94 910.706C357.94 911.166 357.624 911.511 357.149 911.511C356.607 911.511 356.245 911.074 356.245 910.453C356.245 909.969 356.403 909.67 356.81 909.325L357.239 909.647ZM357.172 908.773C356.539 908.335 356.268 908.013 356.268 907.599C356.268 907.185 356.584 906.885 357.036 906.885C357.533 906.885 357.85 907.208 357.85 907.691C357.85 908.105 357.646 908.45 357.239 908.727C357.194 908.75 357.194 908.75 357.172 908.773Z" fill="white"/>
+</g>
+<mask id="mask592_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask592_13_16077)">
+<path d="M413.378 937.96C414.169 937.868 414.576 937.73 415.051 937.361C415.797 936.809 416.249 935.911 416.249 934.922C416.249 933.725 415.571 932.874 414.644 932.874C413.808 932.874 413.175 933.61 413.175 934.6C413.175 935.474 413.672 936.073 414.463 936.073C414.847 936.073 415.141 935.957 415.525 935.658C415.232 936.832 414.441 937.614 413.356 937.822L413.378 937.96ZM415.548 935.198C415.548 935.359 415.503 935.428 415.435 935.497C415.232 935.658 414.96 935.75 414.712 935.75C414.169 935.75 413.83 935.198 413.83 934.347C413.83 933.932 413.943 933.495 414.079 933.288C414.215 933.15 414.395 933.081 414.599 933.081C415.209 933.081 415.548 933.702 415.548 934.922V935.198Z" fill="white"/>
+</g>
+<mask id="mask593_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask593_13_16077)">
+<path d="M376.501 924.405L375.212 925.072V925.164C375.303 925.118 375.371 925.095 375.416 925.095C375.529 925.026 375.664 925.003 375.732 925.003C375.89 925.003 375.958 925.118 375.958 925.348V928.662C375.958 928.892 375.89 929.053 375.777 929.122C375.664 929.191 375.574 929.214 375.258 929.214V929.33H377.246V929.214C376.681 929.214 376.568 929.145 376.568 928.8V924.405H376.501ZM379.828 924.405C379.422 924.405 379.128 924.52 378.857 924.773C378.45 925.187 378.179 926.016 378.179 926.867C378.179 927.673 378.405 928.524 378.744 928.938C379.015 929.261 379.376 929.422 379.783 929.422C380.145 929.422 380.461 929.307 380.71 929.053C381.139 928.662 381.41 927.811 381.41 926.913C381.41 925.417 380.755 924.405 379.828 924.405ZM379.806 924.589C380.393 924.589 380.71 925.417 380.71 926.936C380.71 928.455 380.416 929.237 379.783 929.237C379.173 929.237 378.857 928.455 378.857 926.936C378.857 925.394 379.173 924.589 379.806 924.589Z" fill="white"/>
+</g>
+<mask id="mask594_13_16077" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="325" y="862" width="101" height="103">
+<path d="M325.623 964.31H425.379V862.729H325.623V964.31Z" fill="white"/>
+</mask>
+<g mask="url(#mask594_13_16077)">
+<path d="M332.78 929.612L331.492 930.279V930.371C331.583 930.325 331.65 930.302 331.696 930.302C331.809 930.233 331.944 930.21 332.012 930.21C332.17 930.21 332.238 930.325 332.238 930.555V933.869C332.238 934.099 332.17 934.26 332.057 934.329C331.944 934.398 331.854 934.421 331.537 934.421V934.536H333.526V934.421C332.961 934.421 332.848 934.352 332.848 934.007V929.612H332.78ZM336.357 929.612L335.069 930.279V930.371C335.159 930.325 335.227 930.302 335.272 930.302C335.385 930.233 335.521 930.21 335.589 930.21C335.747 930.21 335.815 930.325 335.815 930.555V933.869C335.815 934.099 335.747 934.26 335.634 934.329C335.521 934.398 335.43 934.421 335.114 934.421V934.536H337.103V934.421C336.538 934.421 336.425 934.352 336.425 934.007V929.612H336.357Z" fill="white"/>
+</g>
+</g>
+<path d="M216.565 235H207.284V208.818H216.642C219.275 208.818 221.542 209.342 223.443 210.391C225.343 211.43 226.805 212.926 227.828 214.878C228.859 216.83 229.375 219.165 229.375 221.884C229.375 224.611 228.859 226.955 227.828 228.915C226.805 230.875 225.335 232.379 223.417 233.428C221.508 234.476 219.224 235 216.565 235ZM212.819 230.257H216.335C217.971 230.257 219.348 229.967 220.464 229.388C221.589 228.8 222.433 227.892 222.995 226.665C223.567 225.429 223.852 223.835 223.852 221.884C223.852 219.949 223.567 218.368 222.995 217.141C222.433 215.913 221.593 215.01 220.477 214.43C219.361 213.851 217.984 213.561 216.348 213.561H212.819V230.257ZM232.653 235V215.364H238.099V235H232.653ZM235.389 212.832C234.579 212.832 233.885 212.564 233.305 212.027C232.734 211.482 232.448 210.83 232.448 210.071C232.448 209.321 232.734 208.678 233.305 208.141C233.885 207.595 234.579 207.322 235.389 207.322C236.198 207.322 236.889 207.595 237.46 208.141C238.039 208.678 238.329 209.321 238.329 210.071C238.329 210.83 238.039 211.482 237.46 212.027C236.889 212.564 236.198 212.832 235.389 212.832ZM250.614 235.384C248.602 235.384 246.872 234.957 245.423 234.105C243.983 233.244 242.875 232.051 242.1 230.526C241.332 229 240.949 227.244 240.949 225.259C240.949 223.247 241.337 221.483 242.112 219.966C242.896 218.44 244.009 217.251 245.449 216.399C246.889 215.538 248.602 215.108 250.588 215.108C252.301 215.108 253.801 215.419 255.088 216.041C256.375 216.663 257.394 217.537 258.144 218.662C258.894 219.787 259.307 221.108 259.384 222.625H254.244C254.1 221.645 253.716 220.857 253.094 220.26C252.48 219.655 251.675 219.352 250.678 219.352C249.834 219.352 249.097 219.582 248.466 220.043C247.844 220.494 247.358 221.155 247.009 222.024C246.659 222.893 246.484 223.946 246.484 225.182C246.484 226.435 246.655 227.5 246.996 228.378C247.345 229.256 247.835 229.925 248.466 230.385C249.097 230.845 249.834 231.075 250.678 231.075C251.3 231.075 251.858 230.947 252.352 230.692C252.855 230.436 253.269 230.065 253.592 229.58C253.925 229.085 254.142 228.493 254.244 227.803H259.384C259.298 229.303 258.889 230.624 258.156 231.766C257.432 232.899 256.43 233.786 255.152 234.425C253.874 235.064 252.361 235.384 250.614 235.384ZM272.595 215.364V219.455H260.77V215.364H272.595ZM263.454 210.659H268.9V228.966C268.9 229.469 268.977 229.861 269.131 230.142C269.284 230.415 269.497 230.607 269.77 230.717C270.051 230.828 270.375 230.884 270.741 230.884C270.997 230.884 271.253 230.862 271.508 230.82C271.764 230.768 271.96 230.73 272.096 230.705L272.953 234.757C272.68 234.842 272.297 234.94 271.802 235.051C271.308 235.17 270.707 235.243 270 235.268C268.687 235.32 267.537 235.145 266.548 234.744C265.568 234.344 264.805 233.722 264.26 232.878C263.714 232.034 263.446 230.969 263.454 229.682V210.659ZM275.423 235V215.364H280.869V235H275.423ZM278.158 212.832C277.349 212.832 276.654 212.564 276.075 212.027C275.504 211.482 275.218 210.83 275.218 210.071C275.218 209.321 275.504 208.678 276.075 208.141C276.654 207.595 277.349 207.322 278.158 207.322C278.968 207.322 279.658 207.595 280.229 208.141C280.809 208.678 281.099 209.321 281.099 210.071C281.099 210.83 280.809 211.482 280.229 212.027C279.658 212.564 278.968 212.832 278.158 212.832ZM293.383 235.384C291.398 235.384 289.68 234.962 288.231 234.118C286.791 233.266 285.679 232.081 284.895 230.564C284.111 229.038 283.719 227.27 283.719 225.259C283.719 223.23 284.111 221.457 284.895 219.94C285.679 218.415 286.791 217.23 288.231 216.386C289.68 215.534 291.398 215.108 293.383 215.108C295.369 215.108 297.082 215.534 298.523 216.386C299.971 217.23 301.088 218.415 301.872 219.94C302.656 221.457 303.048 223.23 303.048 225.259C303.048 227.27 302.656 229.038 301.872 230.564C301.088 232.081 299.971 233.266 298.523 234.118C297.082 234.962 295.369 235.384 293.383 235.384ZM293.409 231.165C294.312 231.165 295.067 230.909 295.672 230.398C296.277 229.878 296.733 229.17 297.04 228.276C297.355 227.381 297.513 226.362 297.513 225.22C297.513 224.078 297.355 223.06 297.04 222.165C296.733 221.27 296.277 220.562 295.672 220.043C295.067 219.523 294.312 219.263 293.409 219.263C292.497 219.263 291.73 219.523 291.108 220.043C290.494 220.562 290.03 221.27 289.714 222.165C289.408 223.06 289.254 224.078 289.254 225.22C289.254 226.362 289.408 227.381 289.714 228.276C290.03 229.17 290.494 229.878 291.108 230.398C291.73 230.909 292.497 231.165 293.409 231.165ZM311.315 223.648V235H305.869V215.364H311.06V218.828H311.29C311.724 217.686 312.453 216.783 313.476 216.118C314.499 215.445 315.739 215.108 317.196 215.108C318.56 215.108 319.749 215.406 320.763 216.003C321.777 216.599 322.565 217.452 323.128 218.56C323.69 219.659 323.972 220.972 323.972 222.497V235H318.526V223.469C318.534 222.267 318.227 221.33 317.605 220.656C316.983 219.974 316.126 219.634 315.036 219.634C314.303 219.634 313.655 219.791 313.092 220.107C312.538 220.422 312.104 220.882 311.788 221.487C311.482 222.084 311.324 222.804 311.315 223.648ZM333.143 235.371C331.89 235.371 330.774 235.153 329.794 234.719C328.814 234.276 328.038 233.624 327.467 232.763C326.905 231.893 326.623 230.811 326.623 229.516C326.623 228.425 326.824 227.509 327.224 226.767C327.625 226.026 328.17 225.429 328.861 224.977C329.551 224.526 330.335 224.185 331.213 223.955C332.099 223.724 333.028 223.562 334 223.469C335.142 223.349 336.062 223.239 336.761 223.136C337.46 223.026 337.967 222.864 338.283 222.651C338.598 222.437 338.756 222.122 338.756 221.705V221.628C338.756 220.818 338.5 220.192 337.989 219.749C337.486 219.305 336.77 219.084 335.841 219.084C334.861 219.084 334.081 219.301 333.501 219.736C332.922 220.162 332.538 220.699 332.351 221.347L327.314 220.938C327.569 219.744 328.072 218.713 328.822 217.844C329.572 216.966 330.54 216.293 331.724 215.824C332.917 215.347 334.298 215.108 335.866 215.108C336.957 215.108 338.001 215.236 338.998 215.491C340.004 215.747 340.895 216.143 341.67 216.68C342.454 217.217 343.072 217.908 343.524 218.751C343.976 219.587 344.202 220.588 344.202 221.756V235H339.037V232.277H338.883C338.568 232.891 338.146 233.432 337.618 233.901C337.089 234.361 336.454 234.723 335.713 234.987C334.971 235.243 334.115 235.371 333.143 235.371ZM334.703 231.612C335.504 231.612 336.212 231.455 336.825 231.139C337.439 230.815 337.92 230.381 338.27 229.835C338.619 229.29 338.794 228.672 338.794 227.982V225.898C338.623 226.009 338.389 226.111 338.091 226.205C337.801 226.29 337.473 226.371 337.106 226.447C336.74 226.516 336.373 226.58 336.007 226.639C335.64 226.69 335.308 226.737 335.01 226.78C334.371 226.874 333.812 227.023 333.335 227.227C332.858 227.432 332.487 227.709 332.223 228.058C331.959 228.399 331.827 228.825 331.827 229.337C331.827 230.078 332.095 230.645 332.632 231.037C333.177 231.42 333.868 231.612 334.703 231.612ZM347.707 235V215.364H352.987V218.79H353.191C353.549 217.571 354.15 216.651 354.994 216.028C355.837 215.398 356.809 215.082 357.908 215.082C358.181 215.082 358.475 215.099 358.791 215.134C359.106 215.168 359.383 215.214 359.622 215.274V220.107C359.366 220.03 359.012 219.962 358.56 219.902C358.109 219.842 357.695 219.812 357.32 219.812C356.519 219.812 355.803 219.987 355.173 220.337C354.55 220.678 354.056 221.155 353.69 221.768C353.332 222.382 353.153 223.089 353.153 223.891V235H347.707ZM365.677 242.364C364.987 242.364 364.339 242.308 363.734 242.197C363.137 242.095 362.643 241.963 362.251 241.801L363.478 237.736C364.117 237.932 364.693 238.038 365.204 238.055C365.724 238.072 366.171 237.953 366.546 237.697C366.93 237.442 367.241 237.007 367.48 236.393L367.799 235.562L360.755 215.364H366.482L370.548 229.784H370.752L374.856 215.364H380.622L372.99 237.122C372.623 238.179 372.125 239.099 371.494 239.884C370.872 240.676 370.083 241.286 369.129 241.712C368.174 242.146 367.024 242.364 365.677 242.364ZM390.301 235V215.364H395.491V218.828H395.721C396.13 217.678 396.812 216.77 397.767 216.105C398.721 215.44 399.863 215.108 401.193 215.108C402.539 215.108 403.686 215.445 404.632 216.118C405.578 216.783 406.208 217.686 406.524 218.828H406.728C407.129 217.703 407.853 216.804 408.901 216.131C409.958 215.449 411.207 215.108 412.647 215.108C414.48 215.108 415.967 215.692 417.109 216.859C418.259 218.018 418.835 219.663 418.835 221.794V235H413.401V222.868C413.401 221.777 413.112 220.959 412.532 220.413C411.953 219.868 411.228 219.595 410.359 219.595C409.37 219.595 408.599 219.911 408.045 220.541C407.491 221.163 407.214 221.986 407.214 223.009V235H401.934V222.753C401.934 221.79 401.657 221.023 401.103 220.452C400.558 219.881 399.838 219.595 398.943 219.595C398.338 219.595 397.792 219.749 397.306 220.055C396.829 220.354 396.45 220.776 396.169 221.321C395.887 221.858 395.747 222.489 395.747 223.213V235H390.301ZM428.016 235.371C426.763 235.371 425.647 235.153 424.667 234.719C423.686 234.276 422.911 233.624 422.34 232.763C421.777 231.893 421.496 230.811 421.496 229.516C421.496 228.425 421.696 227.509 422.097 226.767C422.498 226.026 423.043 225.429 423.733 224.977C424.424 224.526 425.208 224.185 426.086 223.955C426.972 223.724 427.901 223.562 428.873 223.469C430.015 223.349 430.935 223.239 431.634 223.136C432.333 223.026 432.84 222.864 433.155 222.651C433.471 222.437 433.628 222.122 433.628 221.705V221.628C433.628 220.818 433.373 220.192 432.861 219.749C432.358 219.305 431.642 219.084 430.713 219.084C429.733 219.084 428.953 219.301 428.374 219.736C427.794 220.162 427.411 220.699 427.223 221.347L422.186 220.938C422.442 219.744 422.945 218.713 423.695 217.844C424.445 216.966 425.412 216.293 426.597 215.824C427.79 215.347 429.171 215.108 430.739 215.108C431.83 215.108 432.874 215.236 433.871 215.491C434.877 215.747 435.767 216.143 436.543 216.68C437.327 217.217 437.945 217.908 438.397 218.751C438.848 219.587 439.074 220.588 439.074 221.756V235H433.909V232.277H433.756C433.441 232.891 433.019 233.432 432.49 233.901C431.962 234.361 431.327 234.723 430.586 234.987C429.844 235.243 428.988 235.371 428.016 235.371ZM429.576 231.612C430.377 231.612 431.084 231.455 431.698 231.139C432.311 230.815 432.793 230.381 433.142 229.835C433.492 229.29 433.667 228.672 433.667 227.982V225.898C433.496 226.009 433.262 226.111 432.963 226.205C432.674 226.29 432.346 226.371 431.979 226.447C431.613 226.516 431.246 226.58 430.88 226.639C430.513 226.69 430.181 226.737 429.882 226.78C429.243 226.874 428.685 227.023 428.208 227.227C427.73 227.432 427.36 227.709 427.096 228.058C426.831 228.399 426.699 228.825 426.699 229.337C426.699 230.078 426.968 230.645 427.505 231.037C428.05 231.42 428.74 231.612 429.576 231.612ZM442.579 242.364V215.364H447.949V218.662H448.192C448.43 218.134 448.775 217.597 449.227 217.051C449.687 216.497 450.284 216.037 451.017 215.67C451.758 215.295 452.679 215.108 453.778 215.108C455.21 215.108 456.531 215.483 457.741 216.233C458.952 216.974 459.919 218.095 460.643 219.595C461.368 221.087 461.73 222.957 461.73 225.207C461.73 227.398 461.376 229.247 460.669 230.756C459.97 232.256 459.015 233.393 457.805 234.169C456.604 234.936 455.257 235.32 453.765 235.32C452.709 235.32 451.809 235.145 451.068 234.795C450.335 234.446 449.734 234.007 449.265 233.479C448.797 232.942 448.439 232.401 448.192 231.855H448.025V242.364H442.579ZM447.91 225.182C447.91 226.349 448.072 227.368 448.396 228.237C448.72 229.107 449.189 229.784 449.802 230.27C450.416 230.747 451.162 230.986 452.04 230.986C452.926 230.986 453.676 230.743 454.29 230.257C454.903 229.763 455.368 229.081 455.683 228.212C456.007 227.334 456.169 226.324 456.169 225.182C456.169 224.048 456.011 223.051 455.696 222.19C455.381 221.33 454.916 220.656 454.302 220.17C453.689 219.685 452.934 219.442 452.04 219.442C451.153 219.442 450.403 219.676 449.79 220.145C449.184 220.614 448.72 221.278 448.396 222.139C448.072 223 447.91 224.014 447.91 225.182ZM464.641 242.364V215.364H470.01V218.662H470.253C470.491 218.134 470.837 217.597 471.288 217.051C471.749 216.497 472.345 216.037 473.078 215.67C473.82 215.295 474.74 215.108 475.84 215.108C477.271 215.108 478.592 215.483 479.803 216.233C481.013 216.974 481.98 218.095 482.705 219.595C483.429 221.087 483.791 222.957 483.791 225.207C483.791 227.398 483.438 229.247 482.73 230.756C482.031 232.256 481.077 233.393 479.866 234.169C478.665 234.936 477.318 235.32 475.827 235.32C474.77 235.32 473.871 235.145 473.129 234.795C472.396 234.446 471.795 234.007 471.327 233.479C470.858 232.942 470.5 232.401 470.253 231.855H470.087V242.364H464.641ZM469.972 225.182C469.972 226.349 470.134 227.368 470.457 228.237C470.781 229.107 471.25 229.784 471.864 230.27C472.477 230.747 473.223 230.986 474.101 230.986C474.987 230.986 475.737 230.743 476.351 230.257C476.965 229.763 477.429 229.081 477.744 228.212C478.068 227.334 478.23 226.324 478.23 225.182C478.23 224.048 478.072 223.051 477.757 222.19C477.442 221.33 476.977 220.656 476.364 220.17C475.75 219.685 474.996 219.442 474.101 219.442C473.215 219.442 472.465 219.676 471.851 220.145C471.246 220.614 470.781 221.278 470.457 222.139C470.134 223 469.972 224.014 469.972 225.182ZM486.702 235V215.364H492.148V235H486.702ZM489.438 212.832C488.628 212.832 487.933 212.564 487.354 212.027C486.783 211.482 486.497 210.83 486.497 210.071C486.497 209.321 486.783 208.678 487.354 208.141C487.933 207.595 488.628 207.322 489.438 207.322C490.247 207.322 490.938 207.595 491.509 208.141C492.088 208.678 492.378 209.321 492.378 210.071C492.378 210.83 492.088 211.482 491.509 212.027C490.938 212.564 490.247 212.832 489.438 212.832ZM501.237 223.648V235H495.79V215.364H500.981V218.828H501.211C501.646 217.686 502.374 216.783 503.397 216.118C504.42 215.445 505.66 215.108 507.117 215.108C508.481 215.108 509.67 215.406 510.684 216.003C511.698 216.599 512.487 217.452 513.049 218.56C513.612 219.659 513.893 220.972 513.893 222.497V235H508.447V223.469C508.455 222.267 508.148 221.33 507.526 220.656C506.904 219.974 506.048 219.634 504.957 219.634C504.224 219.634 503.576 219.791 503.013 220.107C502.46 220.422 502.025 220.882 501.71 221.487C501.403 222.084 501.245 222.804 501.237 223.648ZM526.312 242.773C524.547 242.773 523.035 242.53 521.773 242.044C520.52 241.567 519.523 240.915 518.782 240.088C518.04 239.261 517.559 238.332 517.337 237.301L522.374 236.624C522.528 237.016 522.77 237.382 523.103 237.723C523.435 238.064 523.874 238.337 524.42 238.541C524.974 238.754 525.647 238.861 526.439 238.861C527.624 238.861 528.6 238.571 529.367 237.991C530.143 237.42 530.53 236.462 530.53 235.115V231.523H530.3C530.062 232.068 529.704 232.584 529.226 233.07C528.749 233.555 528.135 233.952 527.385 234.259C526.635 234.565 525.741 234.719 524.701 234.719C523.226 234.719 521.884 234.378 520.674 233.696C519.472 233.006 518.513 231.953 517.797 230.538C517.09 229.115 516.736 227.317 516.736 225.143C516.736 222.919 517.099 221.061 517.823 219.57C518.547 218.078 519.51 216.962 520.712 216.22C521.922 215.479 523.248 215.108 524.688 215.108C525.787 215.108 526.708 215.295 527.449 215.67C528.191 216.037 528.787 216.497 529.239 217.051C529.699 217.597 530.053 218.134 530.3 218.662H530.505V215.364H535.912V235.192C535.912 236.862 535.503 238.26 534.685 239.385C533.867 240.51 532.733 241.354 531.285 241.916C529.844 242.487 528.187 242.773 526.312 242.773ZM526.427 230.628C527.305 230.628 528.046 230.411 528.651 229.976C529.265 229.533 529.733 228.902 530.057 228.084C530.39 227.257 530.556 226.268 530.556 225.118C530.556 223.967 530.394 222.97 530.07 222.126C529.746 221.274 529.278 220.614 528.664 220.145C528.05 219.676 527.305 219.442 526.427 219.442C525.532 219.442 524.778 219.685 524.164 220.17C523.55 220.648 523.086 221.312 522.77 222.165C522.455 223.017 522.297 224.001 522.297 225.118C522.297 226.251 522.455 227.232 522.77 228.058C523.094 228.876 523.559 229.511 524.164 229.963C524.778 230.406 525.532 230.628 526.427 230.628ZM547.138 242.364V215.364H552.508V218.662H552.751C552.989 218.134 553.334 217.597 553.786 217.051C554.246 216.497 554.843 216.037 555.576 215.67C556.317 215.295 557.238 215.108 558.337 215.108C559.769 215.108 561.09 215.483 562.3 216.233C563.51 216.974 564.478 218.095 565.202 219.595C565.927 221.087 566.289 222.957 566.289 225.207C566.289 227.398 565.935 229.247 565.228 230.756C564.529 232.256 563.574 233.393 562.364 234.169C561.162 234.936 559.816 235.32 558.324 235.32C557.268 235.32 556.368 235.145 555.627 234.795C554.894 234.446 554.293 234.007 553.824 233.479C553.356 232.942 552.998 232.401 552.751 231.855H552.584V242.364H547.138ZM552.469 225.182C552.469 226.349 552.631 227.368 552.955 228.237C553.279 229.107 553.748 229.784 554.361 230.27C554.975 230.747 555.721 230.986 556.599 230.986C557.485 230.986 558.235 230.743 558.849 230.257C559.462 229.763 559.927 229.081 560.242 228.212C560.566 227.334 560.728 226.324 560.728 225.182C560.728 224.048 560.57 223.051 560.255 222.19C559.939 221.33 559.475 220.656 558.861 220.17C558.248 219.685 557.493 219.442 556.599 219.442C555.712 219.442 554.962 219.676 554.349 220.145C553.743 220.614 553.279 221.278 552.955 222.139C552.631 223 552.469 224.014 552.469 225.182ZM578.148 235.384C576.129 235.384 574.39 234.974 572.932 234.156C571.484 233.33 570.367 232.162 569.583 230.653C568.799 229.136 568.407 227.342 568.407 225.271C568.407 223.251 568.799 221.479 569.583 219.953C570.367 218.428 571.471 217.239 572.894 216.386C574.326 215.534 576.005 215.108 577.931 215.108C579.227 215.108 580.432 215.317 581.549 215.734C582.674 216.143 583.654 216.761 584.489 217.588C585.333 218.415 585.989 219.455 586.458 220.707C586.927 221.952 587.161 223.409 587.161 225.08V226.575H570.58V223.2H582.035C582.035 222.416 581.864 221.722 581.523 221.116C581.182 220.511 580.709 220.038 580.104 219.697C579.508 219.348 578.813 219.173 578.021 219.173C577.194 219.173 576.461 219.365 575.822 219.749C575.191 220.124 574.697 220.631 574.339 221.27C573.981 221.901 573.798 222.604 573.789 223.379V226.588C573.789 227.56 573.968 228.399 574.326 229.107C574.692 229.814 575.208 230.359 575.873 230.743C576.538 231.126 577.326 231.318 578.238 231.318C578.843 231.318 579.397 231.233 579.9 231.062C580.403 230.892 580.833 230.636 581.191 230.295C581.549 229.955 581.822 229.537 582.009 229.043L587.046 229.375C586.79 230.585 586.266 231.642 585.474 232.545C584.69 233.44 583.675 234.139 582.431 234.642C581.195 235.136 579.768 235.384 578.148 235.384ZM589.995 235V215.364H595.275V218.79H595.48C595.837 217.571 596.438 216.651 597.282 216.028C598.126 215.398 599.097 215.082 600.197 215.082C600.47 215.082 600.764 215.099 601.079 215.134C601.394 215.168 601.671 215.214 601.91 215.274V220.107C601.654 220.03 601.301 219.962 600.849 219.902C600.397 219.842 599.984 219.812 599.609 219.812C598.808 219.812 598.092 219.987 597.461 220.337C596.839 220.678 596.345 221.155 595.978 221.768C595.62 222.382 595.441 223.089 595.441 223.891V235H589.995ZM615.435 215.364V219.455H603.609V215.364H615.435ZM606.294 210.659H611.74V228.966C611.74 229.469 611.817 229.861 611.97 230.142C612.124 230.415 612.337 230.607 612.609 230.717C612.891 230.828 613.214 230.884 613.581 230.884C613.837 230.884 614.092 230.862 614.348 230.82C614.604 230.768 614.8 230.73 614.936 230.705L615.793 234.757C615.52 234.842 615.136 234.94 614.642 235.051C614.148 235.17 613.547 235.243 612.839 235.268C611.527 235.32 610.376 235.145 609.388 234.744C608.408 234.344 607.645 233.722 607.099 232.878C606.554 232.034 606.285 230.969 606.294 229.682V210.659ZM630.855 226.639V215.364H636.301V235H631.072V231.433H630.867C630.424 232.584 629.687 233.509 628.656 234.207C627.633 234.906 626.384 235.256 624.91 235.256C623.597 235.256 622.443 234.957 621.445 234.361C620.448 233.764 619.668 232.916 619.106 231.817C618.552 230.717 618.271 229.401 618.262 227.866V215.364H623.708V226.895C623.717 228.054 624.028 228.97 624.641 229.643C625.255 230.317 626.078 230.653 627.109 230.653C627.765 230.653 628.379 230.504 628.95 230.206C629.521 229.899 629.981 229.447 630.33 228.851C630.688 228.254 630.863 227.517 630.855 226.639ZM639.937 235V215.364H645.217V218.79H645.421C645.779 217.571 646.38 216.651 647.224 216.028C648.067 215.398 649.039 215.082 650.138 215.082C650.411 215.082 650.705 215.099 651.021 215.134C651.336 215.168 651.613 215.214 651.851 215.274V220.107C651.596 220.03 651.242 219.962 650.79 219.902C650.339 219.842 649.925 219.812 649.55 219.812C648.749 219.812 648.033 219.987 647.403 220.337C646.78 220.678 646.286 221.155 645.92 221.768C645.562 222.382 645.383 223.089 645.383 223.891V235H639.937ZM654.049 235V208.818H659.495V218.662H659.662C659.9 218.134 660.245 217.597 660.697 217.051C661.157 216.497 661.754 216.037 662.487 215.67C663.228 215.295 664.149 215.108 665.248 215.108C666.68 215.108 668.001 215.483 669.211 216.233C670.422 216.974 671.389 218.095 672.113 219.595C672.838 221.087 673.2 222.957 673.2 225.207C673.2 227.398 672.846 229.247 672.139 230.756C671.44 232.256 670.486 233.393 669.275 234.169C668.074 234.936 666.727 235.32 665.236 235.32C664.179 235.32 663.28 235.145 662.538 234.795C661.805 234.446 661.204 234.007 660.736 233.479C660.267 232.942 659.909 232.401 659.662 231.855H659.419V235H654.049ZM659.38 225.182C659.38 226.349 659.542 227.368 659.866 228.237C660.19 229.107 660.659 229.784 661.272 230.27C661.886 230.747 662.632 230.986 663.51 230.986C664.396 230.986 665.146 230.743 665.76 230.257C666.373 229.763 666.838 229.081 667.153 228.212C667.477 227.334 667.639 226.324 667.639 225.182C667.639 224.048 667.481 223.051 667.166 222.19C666.851 221.33 666.386 220.656 665.772 220.17C665.159 219.685 664.405 219.442 663.51 219.442C662.623 219.442 661.873 219.676 661.26 220.145C660.655 220.614 660.19 221.278 659.866 222.139C659.542 223 659.38 224.014 659.38 225.182ZM681.713 235.371C680.46 235.371 679.344 235.153 678.364 234.719C677.384 234.276 676.608 233.624 676.037 232.763C675.475 231.893 675.193 230.811 675.193 229.516C675.193 228.425 675.394 227.509 675.794 226.767C676.195 226.026 676.74 225.429 677.431 224.977C678.121 224.526 678.905 224.185 679.783 223.955C680.669 223.724 681.598 223.562 682.57 223.469C683.712 223.349 684.632 223.239 685.331 223.136C686.03 223.026 686.537 222.864 686.853 222.651C687.168 222.437 687.326 222.122 687.326 221.705V221.628C687.326 220.818 687.07 220.192 686.559 219.749C686.056 219.305 685.34 219.084 684.411 219.084C683.431 219.084 682.651 219.301 682.071 219.736C681.492 220.162 681.108 220.699 680.921 221.347L675.884 220.938C676.139 219.744 676.642 218.713 677.392 217.844C678.142 216.966 679.11 216.293 680.294 215.824C681.487 215.347 682.868 215.108 684.436 215.108C685.527 215.108 686.571 215.236 687.568 215.491C688.574 215.747 689.465 216.143 690.24 216.68C691.024 217.217 691.642 217.908 692.094 218.751C692.546 219.587 692.772 220.588 692.772 221.756V235H687.607V232.277H687.453C687.138 232.891 686.716 233.432 686.188 233.901C685.659 234.361 685.024 234.723 684.283 234.987C683.541 235.243 682.685 235.371 681.713 235.371ZM683.273 231.612C684.074 231.612 684.782 231.455 685.395 231.139C686.009 230.815 686.49 230.381 686.84 229.835C687.189 229.29 687.364 228.672 687.364 227.982V225.898C687.193 226.009 686.959 226.111 686.661 226.205C686.371 226.29 686.043 226.371 685.676 226.447C685.31 226.516 684.943 226.58 684.577 226.639C684.21 226.69 683.878 226.737 683.58 226.78C682.941 226.874 682.382 227.023 681.905 227.227C681.428 227.432 681.057 227.709 680.793 228.058C680.529 228.399 680.397 228.825 680.397 229.337C680.397 230.078 680.665 230.645 681.202 231.037C681.747 231.42 682.438 231.612 683.273 231.612ZM706.721 215.364V219.455H694.896V215.364H706.721ZM697.581 210.659H703.027V228.966C703.027 229.469 703.103 229.861 703.257 230.142C703.41 230.415 703.623 230.607 703.896 230.717C704.177 230.828 704.501 230.884 704.868 230.884C705.123 230.884 705.379 230.862 705.635 230.82C705.89 230.768 706.086 230.73 706.223 230.705L707.079 234.757C706.807 234.842 706.423 234.94 705.929 235.051C705.434 235.17 704.834 235.243 704.126 235.268C702.814 235.32 701.663 235.145 700.674 234.744C699.694 234.344 698.932 233.722 698.386 232.878C697.841 232.034 697.572 230.969 697.581 229.682V210.659ZM709.549 235V215.364H714.995V235H709.549ZM712.285 212.832C711.475 212.832 710.78 212.564 710.201 212.027C709.63 211.482 709.344 210.83 709.344 210.071C709.344 209.321 709.63 208.678 710.201 208.141C710.78 207.595 711.475 207.322 712.285 207.322C713.094 207.322 713.785 207.595 714.356 208.141C714.935 208.678 715.225 209.321 715.225 210.071C715.225 210.83 714.935 211.482 714.356 212.027C713.785 212.564 713.094 212.832 712.285 212.832ZM727.51 235.384C725.524 235.384 723.807 234.962 722.358 234.118C720.917 233.266 719.805 232.081 719.021 230.564C718.237 229.038 717.845 227.27 717.845 225.259C717.845 223.23 718.237 221.457 719.021 219.94C719.805 218.415 720.917 217.23 722.358 216.386C723.807 215.534 725.524 215.108 727.51 215.108C729.495 215.108 731.209 215.534 732.649 216.386C734.098 217.23 735.214 218.415 735.998 219.94C736.782 221.457 737.174 223.23 737.174 225.259C737.174 227.27 736.782 229.038 735.998 230.564C735.214 232.081 734.098 233.266 732.649 234.118C731.209 234.962 729.495 235.384 727.51 235.384ZM727.535 231.165C728.439 231.165 729.193 230.909 729.798 230.398C730.403 229.878 730.859 229.17 731.166 228.276C731.481 227.381 731.639 226.362 731.639 225.22C731.639 224.078 731.481 223.06 731.166 222.165C730.859 221.27 730.403 220.562 729.798 220.043C729.193 219.523 728.439 219.263 727.535 219.263C726.623 219.263 725.856 219.523 725.234 220.043C724.62 220.562 724.156 221.27 723.841 222.165C723.534 223.06 723.38 224.078 723.38 225.22C723.38 226.362 723.534 227.381 723.841 228.276C724.156 229.17 724.62 229.878 725.234 230.398C725.856 230.909 726.623 231.165 727.535 231.165ZM745.442 223.648V235H739.996V215.364H745.186V218.828H745.416C745.851 217.686 746.579 216.783 747.602 216.118C748.625 215.445 749.865 215.108 751.322 215.108C752.686 215.108 753.875 215.406 754.889 216.003C755.903 216.599 756.692 217.452 757.254 218.56C757.817 219.659 758.098 220.972 758.098 222.497V235H752.652V223.469C752.66 222.267 752.354 221.33 751.731 220.656C751.109 219.974 750.253 219.634 749.162 219.634C748.429 219.634 747.781 219.791 747.219 220.107C746.665 220.422 746.23 220.882 745.915 221.487C745.608 222.084 745.45 222.804 745.442 223.648ZM778.008 220.963L773.022 221.27C772.937 220.844 772.754 220.46 772.473 220.119C772.191 219.77 771.821 219.493 771.36 219.288C770.909 219.075 770.368 218.969 769.737 218.969C768.893 218.969 768.181 219.148 767.602 219.506C767.022 219.855 766.733 220.324 766.733 220.912C766.733 221.381 766.92 221.777 767.295 222.101C767.67 222.425 768.314 222.685 769.226 222.881L772.779 223.597C774.689 223.989 776.112 224.619 777.049 225.489C777.987 226.358 778.456 227.5 778.456 228.915C778.456 230.202 778.076 231.331 777.318 232.303C776.568 233.274 775.537 234.033 774.224 234.578C772.92 235.115 771.416 235.384 769.711 235.384C767.112 235.384 765.041 234.842 763.498 233.76C761.964 232.669 761.065 231.186 760.801 229.311L766.157 229.03C766.319 229.822 766.711 230.428 767.333 230.845C767.956 231.254 768.753 231.459 769.724 231.459C770.679 231.459 771.446 231.276 772.025 230.909C772.613 230.534 772.912 230.053 772.92 229.464C772.912 228.97 772.703 228.565 772.294 228.25C771.885 227.926 771.254 227.679 770.402 227.509L767.001 226.831C765.083 226.447 763.656 225.783 762.718 224.837C761.789 223.891 761.325 222.685 761.325 221.219C761.325 219.957 761.666 218.871 762.348 217.959C763.038 217.047 764.005 216.344 765.25 215.849C766.503 215.355 767.968 215.108 769.647 215.108C772.128 215.108 774.079 215.632 775.503 216.68C776.934 217.729 777.77 219.156 778.008 220.963ZM261.09 263.364V267.455H249.265V263.364H261.09ZM251.949 258.659H257.395V276.966C257.395 277.469 257.472 277.861 257.625 278.142C257.779 278.415 257.992 278.607 258.265 278.717C258.546 278.828 258.87 278.884 259.236 278.884C259.492 278.884 259.748 278.862 260.003 278.82C260.259 278.768 260.455 278.73 260.591 278.705L261.448 282.757C261.175 282.842 260.792 282.94 260.297 283.051C259.803 283.17 259.202 283.243 258.495 283.268C257.182 283.32 256.032 283.145 255.043 282.744C254.063 282.344 253.3 281.722 252.755 280.878C252.209 280.034 251.941 278.969 251.949 277.682V258.659ZM272.579 283.384C270.593 283.384 268.876 282.962 267.427 282.118C265.986 281.266 264.874 280.081 264.09 278.564C263.306 277.038 262.914 275.27 262.914 273.259C262.914 271.23 263.306 269.457 264.09 267.94C264.874 266.415 265.986 265.23 267.427 264.386C268.876 263.534 270.593 263.108 272.579 263.108C274.564 263.108 276.278 263.534 277.718 264.386C279.167 265.23 280.283 266.415 281.067 267.94C281.851 269.457 282.243 271.23 282.243 273.259C282.243 275.27 281.851 277.038 281.067 278.564C280.283 280.081 279.167 281.266 277.718 282.118C276.278 282.962 274.564 283.384 272.579 283.384ZM272.604 279.165C273.508 279.165 274.262 278.909 274.867 278.398C275.472 277.878 275.928 277.17 276.235 276.276C276.55 275.381 276.708 274.362 276.708 273.22C276.708 272.078 276.55 271.06 276.235 270.165C275.928 269.27 275.472 268.562 274.867 268.043C274.262 267.523 273.508 267.263 272.604 267.263C271.692 267.263 270.925 267.523 270.303 268.043C269.689 268.562 269.225 269.27 268.91 270.165C268.603 271.06 268.449 272.078 268.449 273.22C268.449 274.362 268.603 275.381 268.91 276.276C269.225 277.17 269.689 277.878 270.303 278.398C270.925 278.909 271.692 279.165 272.604 279.165ZM292.677 290.364V263.364H298.046V266.662H298.289C298.528 266.134 298.873 265.597 299.324 265.051C299.785 264.497 300.381 264.037 301.114 263.67C301.856 263.295 302.776 263.108 303.876 263.108C305.307 263.108 306.628 263.483 307.839 264.233C309.049 264.974 310.016 266.095 310.741 267.595C311.465 269.087 311.827 270.957 311.827 273.207C311.827 275.398 311.474 277.247 310.766 278.756C310.067 280.256 309.113 281.393 307.903 282.169C306.701 282.936 305.354 283.32 303.863 283.32C302.806 283.32 301.907 283.145 301.165 282.795C300.432 282.446 299.831 282.007 299.363 281.479C298.894 280.942 298.536 280.401 298.289 279.855H298.123V290.364H292.677ZM298.008 273.182C298.008 274.349 298.17 275.368 298.493 276.237C298.817 277.107 299.286 277.784 299.9 278.27C300.513 278.747 301.259 278.986 302.137 278.986C303.023 278.986 303.773 278.743 304.387 278.257C305.001 277.763 305.465 277.081 305.78 276.212C306.104 275.334 306.266 274.324 306.266 273.182C306.266 272.048 306.108 271.051 305.793 270.19C305.478 269.33 305.013 268.656 304.4 268.17C303.786 267.685 303.032 267.442 302.137 267.442C301.251 267.442 300.501 267.676 299.887 268.145C299.282 268.614 298.817 269.278 298.493 270.139C298.17 271 298.008 272.014 298.008 273.182ZM323.687 283.384C321.667 283.384 319.928 282.974 318.471 282.156C317.022 281.33 315.906 280.162 315.121 278.653C314.337 277.136 313.945 275.342 313.945 273.271C313.945 271.251 314.337 269.479 315.121 267.953C315.906 266.428 317.009 265.239 318.433 264.386C319.864 263.534 321.543 263.108 323.469 263.108C324.765 263.108 325.971 263.317 327.087 263.734C328.212 264.143 329.192 264.761 330.028 265.588C330.871 266.415 331.528 267.455 331.996 268.707C332.465 269.952 332.7 271.409 332.7 273.08V274.575H316.119V271.2H327.573C327.573 270.416 327.403 269.722 327.062 269.116C326.721 268.511 326.248 268.038 325.643 267.697C325.046 267.348 324.352 267.173 323.559 267.173C322.732 267.173 321.999 267.365 321.36 267.749C320.729 268.124 320.235 268.631 319.877 269.27C319.519 269.901 319.336 270.604 319.327 271.379V274.588C319.327 275.56 319.506 276.399 319.864 277.107C320.231 277.814 320.746 278.359 321.411 278.743C322.076 279.126 322.864 279.318 323.776 279.318C324.381 279.318 324.935 279.233 325.438 279.062C325.941 278.892 326.371 278.636 326.729 278.295C327.087 277.955 327.36 277.537 327.548 277.043L332.585 277.375C332.329 278.585 331.805 279.642 331.012 280.545C330.228 281.44 329.214 282.139 327.969 282.642C326.734 283.136 325.306 283.384 323.687 283.384ZM335.534 283V263.364H340.813V266.79H341.018C341.376 265.571 341.977 264.651 342.82 264.028C343.664 263.398 344.636 263.082 345.735 263.082C346.008 263.082 346.302 263.099 346.617 263.134C346.933 263.168 347.21 263.214 347.448 263.274V268.107C347.193 268.03 346.839 267.962 346.387 267.902C345.936 267.842 345.522 267.812 345.147 267.812C344.346 267.812 343.63 267.987 342.999 268.337C342.377 268.678 341.883 269.155 341.516 269.768C341.159 270.382 340.98 271.089 340.98 271.891V283H335.534ZM361.088 263.364V267.455H348.969V263.364H361.088ZM351.743 283V261.945C351.743 260.521 352.02 259.341 352.574 258.403C353.136 257.466 353.903 256.763 354.875 256.294C355.847 255.825 356.95 255.591 358.186 255.591C359.021 255.591 359.784 255.655 360.474 255.783C361.173 255.911 361.693 256.026 362.034 256.128L361.062 260.219C360.849 260.151 360.585 260.087 360.27 260.027C359.963 259.967 359.648 259.938 359.324 259.938C358.523 259.938 357.964 260.125 357.649 260.5C357.334 260.866 357.176 261.382 357.176 262.047V283H351.743ZM371.864 283.384C369.878 283.384 368.161 282.962 366.712 282.118C365.272 281.266 364.16 280.081 363.375 278.564C362.591 277.038 362.199 275.27 362.199 273.259C362.199 271.23 362.591 269.457 363.375 267.94C364.16 266.415 365.272 265.23 366.712 264.386C368.161 263.534 369.878 263.108 371.864 263.108C373.85 263.108 375.563 263.534 377.003 264.386C378.452 265.23 379.569 266.415 380.353 267.94C381.137 269.457 381.529 271.23 381.529 273.259C381.529 275.27 381.137 277.038 380.353 278.564C379.569 280.081 378.452 281.266 377.003 282.118C375.563 282.962 373.85 283.384 371.864 283.384ZM371.89 279.165C372.793 279.165 373.547 278.909 374.152 278.398C374.758 277.878 375.214 277.17 375.52 276.276C375.836 275.381 375.993 274.362 375.993 273.22C375.993 272.078 375.836 271.06 375.52 270.165C375.214 269.27 374.758 268.562 374.152 268.043C373.547 267.523 372.793 267.263 371.89 267.263C370.978 267.263 370.211 267.523 369.589 268.043C368.975 268.562 368.51 269.27 368.195 270.165C367.888 271.06 367.735 272.078 367.735 273.22C367.735 274.362 367.888 275.381 368.195 276.276C368.51 277.17 368.975 277.878 369.589 278.398C370.211 278.909 370.978 279.165 371.89 279.165ZM384.35 283V263.364H389.63V266.79H389.834C390.192 265.571 390.793 264.651 391.637 264.028C392.481 263.398 393.452 263.082 394.552 263.082C394.825 263.082 395.119 263.099 395.434 263.134C395.749 263.168 396.026 263.214 396.265 263.274V268.107C396.009 268.03 395.655 267.962 395.204 267.902C394.752 267.842 394.339 267.812 393.964 267.812C393.163 267.812 392.447 267.987 391.816 268.337C391.194 268.678 390.7 269.155 390.333 269.768C389.975 270.382 389.796 271.089 389.796 271.891V283H384.35ZM398.361 283V263.364H403.551V266.828H403.781C404.19 265.678 404.872 264.77 405.826 264.105C406.781 263.44 407.923 263.108 409.253 263.108C410.599 263.108 411.746 263.445 412.692 264.118C413.638 264.783 414.268 265.686 414.584 266.828H414.788C415.189 265.703 415.913 264.804 416.961 264.131C418.018 263.449 419.267 263.108 420.707 263.108C422.54 263.108 424.027 263.692 425.169 264.859C426.319 266.018 426.895 267.663 426.895 269.794V283H421.461V270.868C421.461 269.777 421.172 268.959 420.592 268.413C420.013 267.868 419.288 267.595 418.419 267.595C417.43 267.595 416.659 267.911 416.105 268.541C415.551 269.163 415.274 269.986 415.274 271.009V283H409.994V270.753C409.994 269.79 409.717 269.023 409.163 268.452C408.618 267.881 407.897 267.595 407.003 267.595C406.397 267.595 405.852 267.749 405.366 268.055C404.889 268.354 404.51 268.776 404.228 269.321C403.947 269.858 403.807 270.489 403.807 271.213V283H398.361ZM436.076 283.371C434.823 283.371 433.707 283.153 432.727 282.719C431.746 282.276 430.971 281.624 430.4 280.763C429.837 279.893 429.556 278.811 429.556 277.516C429.556 276.425 429.756 275.509 430.157 274.767C430.557 274.026 431.103 273.429 431.793 272.977C432.484 272.526 433.268 272.185 434.146 271.955C435.032 271.724 435.961 271.562 436.932 271.469C438.075 271.349 438.995 271.239 439.694 271.136C440.393 271.026 440.9 270.864 441.215 270.651C441.53 270.437 441.688 270.122 441.688 269.705V269.628C441.688 268.818 441.432 268.192 440.921 267.749C440.418 267.305 439.702 267.084 438.773 267.084C437.793 267.084 437.013 267.301 436.434 267.736C435.854 268.162 435.471 268.699 435.283 269.347L430.246 268.938C430.502 267.744 431.005 266.713 431.755 265.844C432.505 264.966 433.472 264.293 434.657 263.824C435.85 263.347 437.231 263.108 438.799 263.108C439.89 263.108 440.934 263.236 441.931 263.491C442.937 263.747 443.827 264.143 444.603 264.68C445.387 265.217 446.005 265.908 446.457 266.751C446.908 267.587 447.134 268.588 447.134 269.756V283H441.969V280.277H441.816C441.501 280.891 441.079 281.432 440.55 281.901C440.022 282.361 439.387 282.723 438.646 282.987C437.904 283.243 437.048 283.371 436.076 283.371ZM437.636 279.612C438.437 279.612 439.144 279.455 439.758 279.139C440.371 278.815 440.853 278.381 441.202 277.835C441.552 277.29 441.727 276.672 441.727 275.982V273.898C441.556 274.009 441.322 274.111 441.023 274.205C440.734 274.29 440.405 274.371 440.039 274.447C439.673 274.516 439.306 274.58 438.94 274.639C438.573 274.69 438.241 274.737 437.942 274.78C437.303 274.874 436.745 275.023 436.268 275.227C435.79 275.432 435.42 275.709 435.155 276.058C434.891 276.399 434.759 276.825 434.759 277.337C434.759 278.078 435.028 278.645 435.565 279.037C436.11 279.42 436.8 279.612 437.636 279.612ZM456.085 271.648V283H450.639V263.364H455.83V266.828H456.06C456.494 265.686 457.223 264.783 458.246 264.118C459.269 263.445 460.509 263.108 461.966 263.108C463.33 263.108 464.519 263.406 465.533 264.003C466.547 264.599 467.335 265.452 467.898 266.56C468.46 267.659 468.742 268.972 468.742 270.497V283H463.296V271.469C463.304 270.267 462.997 269.33 462.375 268.656C461.753 267.974 460.896 267.634 459.806 267.634C459.073 267.634 458.425 267.791 457.862 268.107C457.308 268.422 456.874 268.882 456.558 269.487C456.252 270.084 456.094 270.804 456.085 271.648ZM481.186 283.384C479.175 283.384 477.445 282.957 475.996 282.105C474.555 281.244 473.447 280.051 472.672 278.526C471.905 277 471.521 275.244 471.521 273.259C471.521 271.247 471.909 269.483 472.685 267.966C473.469 266.44 474.581 265.251 476.021 264.399C477.462 263.538 479.175 263.108 481.16 263.108C482.874 263.108 484.374 263.419 485.66 264.041C486.947 264.663 487.966 265.537 488.716 266.662C489.466 267.787 489.879 269.108 489.956 270.625H484.817C484.672 269.645 484.288 268.857 483.666 268.26C483.052 267.655 482.247 267.352 481.25 267.352C480.406 267.352 479.669 267.582 479.038 268.043C478.416 268.494 477.93 269.155 477.581 270.024C477.231 270.893 477.057 271.946 477.057 273.182C477.057 274.435 477.227 275.5 477.568 276.378C477.918 277.256 478.408 277.925 479.038 278.385C479.669 278.845 480.406 279.075 481.25 279.075C481.872 279.075 482.43 278.947 482.925 278.692C483.427 278.436 483.841 278.065 484.165 277.58C484.497 277.085 484.714 276.493 484.817 275.803H489.956C489.871 277.303 489.462 278.624 488.729 279.766C488.004 280.899 487.003 281.786 485.724 282.425C484.446 283.064 482.933 283.384 481.186 283.384ZM501.672 283.384C499.652 283.384 497.913 282.974 496.456 282.156C495.007 281.33 493.89 280.162 493.106 278.653C492.322 277.136 491.93 275.342 491.93 273.271C491.93 271.251 492.322 269.479 493.106 267.953C493.89 266.428 494.994 265.239 496.417 264.386C497.849 263.534 499.528 263.108 501.454 263.108C502.75 263.108 503.956 263.317 505.072 263.734C506.197 264.143 507.177 264.761 508.013 265.588C508.856 266.415 509.513 267.455 509.981 268.707C510.45 269.952 510.684 271.409 510.684 273.08V274.575H494.103V271.2H505.558C505.558 270.416 505.388 269.722 505.047 269.116C504.706 268.511 504.233 268.038 503.628 267.697C503.031 267.348 502.336 267.173 501.544 267.173C500.717 267.173 499.984 267.365 499.345 267.749C498.714 268.124 498.22 268.631 497.862 269.27C497.504 269.901 497.321 270.604 497.312 271.379V274.588C497.312 275.56 497.491 276.399 497.849 277.107C498.216 277.814 498.731 278.359 499.396 278.743C500.061 279.126 500.849 279.318 501.761 279.318C502.366 279.318 502.92 279.233 503.423 279.062C503.926 278.892 504.356 278.636 504.714 278.295C505.072 277.955 505.345 277.537 505.532 277.043L510.569 277.375C510.314 278.585 509.789 279.642 508.997 280.545C508.213 281.44 507.199 282.139 505.954 282.642C504.718 283.136 503.291 283.384 501.672 283.384ZM528.366 283.32C526.875 283.32 525.524 282.936 524.314 282.169C523.112 281.393 522.157 280.256 521.45 278.756C520.751 277.247 520.402 275.398 520.402 273.207C520.402 270.957 520.764 269.087 521.488 267.595C522.213 266.095 523.176 264.974 524.378 264.233C525.588 263.483 526.913 263.108 528.353 263.108C529.453 263.108 530.369 263.295 531.102 263.67C531.843 264.037 532.44 264.497 532.892 265.051C533.352 265.597 533.701 266.134 533.94 266.662H534.106V256.818H539.54V283H534.17V279.855H533.94C533.684 280.401 533.322 280.942 532.853 281.479C532.393 282.007 531.792 282.446 531.051 282.795C530.318 283.145 529.423 283.32 528.366 283.32ZM530.092 278.986C530.97 278.986 531.711 278.747 532.316 278.27C532.93 277.784 533.399 277.107 533.723 276.237C534.055 275.368 534.221 274.349 534.221 273.182C534.221 272.014 534.059 271 533.736 270.139C533.412 269.278 532.943 268.614 532.329 268.145C531.716 267.676 530.97 267.442 530.092 267.442C529.197 267.442 528.443 267.685 527.829 268.17C527.216 268.656 526.751 269.33 526.436 270.19C526.12 271.051 525.963 272.048 525.963 273.182C525.963 274.324 526.12 275.334 526.436 276.212C526.76 277.081 527.224 277.763 527.829 278.257C528.443 278.743 529.197 278.986 530.092 278.986ZM543.297 283V263.364H548.743V283H543.297ZM546.033 260.832C545.223 260.832 544.529 260.564 543.949 260.027C543.378 259.482 543.093 258.83 543.093 258.071C543.093 257.321 543.378 256.678 543.949 256.141C544.529 255.595 545.223 255.322 546.033 255.322C546.843 255.322 547.533 255.595 548.104 256.141C548.683 256.678 548.973 257.321 548.973 258.071C548.973 258.83 548.683 259.482 548.104 260.027C547.533 260.564 546.843 260.832 546.033 260.832ZM568.724 268.963L563.738 269.27C563.653 268.844 563.47 268.46 563.188 268.119C562.907 267.77 562.536 267.493 562.076 267.288C561.624 267.075 561.083 266.969 560.452 266.969C559.609 266.969 558.897 267.148 558.318 267.506C557.738 267.855 557.448 268.324 557.448 268.912C557.448 269.381 557.636 269.777 558.011 270.101C558.386 270.425 559.029 270.685 559.941 270.881L563.495 271.597C565.404 271.989 566.827 272.619 567.765 273.489C568.702 274.358 569.171 275.5 569.171 276.915C569.171 278.202 568.792 279.331 568.033 280.303C567.283 281.274 566.252 282.033 564.94 282.578C563.636 283.115 562.131 283.384 560.427 283.384C557.827 283.384 555.756 282.842 554.214 281.76C552.68 280.669 551.781 279.186 551.516 277.311L556.873 277.03C557.035 277.822 557.427 278.428 558.049 278.845C558.671 279.254 559.468 279.459 560.44 279.459C561.394 279.459 562.161 279.276 562.741 278.909C563.329 278.534 563.627 278.053 563.636 277.464C563.627 276.97 563.418 276.565 563.009 276.25C562.6 275.926 561.97 275.679 561.117 275.509L557.717 274.831C555.799 274.447 554.372 273.783 553.434 272.837C552.505 271.891 552.041 270.685 552.041 269.219C552.041 267.957 552.381 266.871 553.063 265.959C553.754 265.047 554.721 264.344 555.965 263.849C557.218 263.355 558.684 263.108 560.363 263.108C562.843 263.108 564.795 263.632 566.218 264.68C567.65 265.729 568.485 267.156 568.724 268.963ZM582.325 263.364V267.455H570.5V263.364H582.325ZM573.185 258.659H578.631V276.966C578.631 277.469 578.707 277.861 578.861 278.142C579.014 278.415 579.227 278.607 579.5 278.717C579.781 278.828 580.105 278.884 580.471 278.884C580.727 278.884 580.983 278.862 581.239 278.82C581.494 278.768 581.69 278.73 581.827 278.705L582.683 282.757C582.41 282.842 582.027 282.94 581.533 283.051C581.038 283.17 580.437 283.243 579.73 283.268C578.418 283.32 577.267 283.145 576.278 282.744C575.298 282.344 574.535 281.722 573.99 280.878C573.444 280.034 573.176 278.969 573.185 277.682V258.659ZM585.153 283V263.364H590.433V266.79H590.637C590.995 265.571 591.596 264.651 592.44 264.028C593.283 263.398 594.255 263.082 595.354 263.082C595.627 263.082 595.921 263.099 596.237 263.134C596.552 263.168 596.829 263.214 597.068 263.274V268.107C596.812 268.03 596.458 267.962 596.006 267.902C595.555 267.842 595.141 267.812 594.766 267.812C593.965 267.812 593.249 267.987 592.619 268.337C591.997 268.678 591.502 269.155 591.136 269.768C590.778 270.382 590.599 271.089 590.599 271.891V283H585.153ZM599.163 283V263.364H604.609V283H599.163ZM601.899 260.832C601.089 260.832 600.395 260.564 599.815 260.027C599.244 259.482 598.959 258.83 598.959 258.071C598.959 257.321 599.244 256.678 599.815 256.141C600.395 255.595 601.089 255.322 601.899 255.322C602.709 255.322 603.399 255.595 603.97 256.141C604.55 256.678 604.839 257.321 604.839 258.071C604.839 258.83 604.55 259.482 603.97 260.027C603.399 260.564 602.709 260.832 601.899 260.832ZM608.354 283V256.818H613.8V266.662H613.966C614.205 266.134 614.55 265.597 615.002 265.051C615.462 264.497 616.059 264.037 616.792 263.67C617.533 263.295 618.454 263.108 619.553 263.108C620.985 263.108 622.306 263.483 623.516 264.233C624.726 264.974 625.694 266.095 626.418 267.595C627.142 269.087 627.505 270.957 627.505 273.207C627.505 275.398 627.151 277.247 626.444 278.756C625.745 280.256 624.79 281.393 623.58 282.169C622.378 282.936 621.032 283.32 619.54 283.32C618.483 283.32 617.584 283.145 616.843 282.795C616.11 282.446 615.509 282.007 615.04 281.479C614.571 280.942 614.213 280.401 613.966 279.855H613.723V283H608.354ZM613.685 273.182C613.685 274.349 613.847 275.368 614.171 276.237C614.495 277.107 614.963 277.784 615.577 278.27C616.191 278.747 616.936 278.986 617.814 278.986C618.701 278.986 619.451 278.743 620.064 278.257C620.678 277.763 621.142 277.081 621.458 276.212C621.782 275.334 621.944 274.324 621.944 273.182C621.944 272.048 621.786 271.051 621.471 270.19C621.155 269.33 620.691 268.656 620.077 268.17C619.463 267.685 618.709 267.442 617.814 267.442C616.928 267.442 616.178 267.676 615.564 268.145C614.959 268.614 614.495 269.278 614.171 270.139C613.847 271 613.685 272.014 613.685 273.182ZM643.011 274.639V263.364H648.457V283H643.228V279.433H643.024C642.58 280.584 641.843 281.509 640.812 282.207C639.789 282.906 638.541 283.256 637.066 283.256C635.754 283.256 634.599 282.957 633.602 282.361C632.605 281.764 631.825 280.916 631.262 279.817C630.708 278.717 630.427 277.401 630.419 275.866V263.364H635.865V274.895C635.873 276.054 636.184 276.97 636.798 277.643C637.411 278.317 638.234 278.653 639.265 278.653C639.921 278.653 640.535 278.504 641.106 278.206C641.677 277.899 642.137 277.447 642.487 276.851C642.845 276.254 643.019 275.517 643.011 274.639ZM662.538 263.364V267.455H650.712V263.364H662.538ZM653.397 258.659H658.843V276.966C658.843 277.469 658.92 277.861 659.073 278.142C659.227 278.415 659.44 278.607 659.712 278.717C659.994 278.828 660.317 278.884 660.684 278.884C660.94 278.884 661.195 278.862 661.451 278.82C661.707 278.768 661.903 278.73 662.039 278.705L662.896 282.757C662.623 282.842 662.239 282.94 661.745 283.051C661.251 283.17 660.65 283.243 659.942 283.268C658.63 283.32 657.479 283.145 656.491 282.744C655.511 282.344 654.748 281.722 654.202 280.878C653.657 280.034 653.389 278.969 653.397 277.682V258.659ZM665.365 283V263.364H670.811V283H665.365ZM668.101 260.832C667.291 260.832 666.597 260.564 666.017 260.027C665.446 259.482 665.161 258.83 665.161 258.071C665.161 257.321 665.446 256.678 666.017 256.141C666.597 255.595 667.291 255.322 668.101 255.322C668.911 255.322 669.601 255.595 670.172 256.141C670.752 256.678 671.041 257.321 671.041 258.071C671.041 258.83 670.752 259.482 670.172 260.027C669.601 260.564 668.911 260.832 668.101 260.832ZM683.326 283.384C681.34 283.384 679.623 282.962 678.174 282.118C676.734 281.266 675.621 280.081 674.837 278.564C674.053 277.038 673.661 275.27 673.661 273.259C673.661 271.23 674.053 269.457 674.837 267.94C675.621 266.415 676.734 265.23 678.174 264.386C679.623 263.534 681.34 263.108 683.326 263.108C685.312 263.108 687.025 263.534 688.465 264.386C689.914 265.23 691.031 266.415 691.815 267.94C692.599 269.457 692.991 271.23 692.991 273.259C692.991 275.27 692.599 277.038 691.815 278.564C691.031 280.081 689.914 281.266 688.465 282.118C687.025 282.962 685.312 283.384 683.326 283.384ZM683.352 279.165C684.255 279.165 685.009 278.909 685.614 278.398C686.219 277.878 686.675 277.17 686.982 276.276C687.298 275.381 687.455 274.362 687.455 273.22C687.455 272.078 687.298 271.06 686.982 270.165C686.675 269.27 686.219 268.562 685.614 268.043C685.009 267.523 684.255 267.263 683.352 267.263C682.44 267.263 681.673 267.523 681.05 268.043C680.437 268.562 679.972 269.27 679.657 270.165C679.35 271.06 679.197 272.078 679.197 273.22C679.197 274.362 679.35 275.381 679.657 276.276C679.972 277.17 680.437 277.878 681.05 278.398C681.673 278.909 682.44 279.165 683.352 279.165ZM701.258 271.648V283H695.812V263.364H701.002V266.828H701.232C701.667 265.686 702.396 264.783 703.419 264.118C704.441 263.445 705.681 263.108 707.139 263.108C708.502 263.108 709.691 263.406 710.705 264.003C711.72 264.599 712.508 265.452 713.07 266.56C713.633 267.659 713.914 268.972 713.914 270.497V283H708.468V271.469C708.477 270.267 708.17 269.33 707.548 268.656C706.926 267.974 706.069 267.634 704.978 267.634C704.245 267.634 703.597 267.791 703.035 268.107C702.481 268.422 702.046 268.882 701.731 269.487C701.424 270.084 701.267 270.804 701.258 271.648ZM733.825 268.963L728.839 269.27C728.754 268.844 728.57 268.46 728.289 268.119C728.008 267.77 727.637 267.493 727.177 267.288C726.725 267.075 726.184 266.969 725.553 266.969C724.71 266.969 723.998 267.148 723.418 267.506C722.839 267.855 722.549 268.324 722.549 268.912C722.549 269.381 722.737 269.777 723.112 270.101C723.487 270.425 724.13 270.685 725.042 270.881L728.596 271.597C730.505 271.989 731.928 272.619 732.866 273.489C733.803 274.358 734.272 275.5 734.272 276.915C734.272 278.202 733.893 279.331 733.134 280.303C732.384 281.274 731.353 282.033 730.041 282.578C728.737 283.115 727.232 283.384 725.528 283.384C722.928 283.384 720.857 282.842 719.315 281.76C717.781 280.669 716.881 279.186 716.617 277.311L721.974 277.03C722.136 277.822 722.528 278.428 723.15 278.845C723.772 279.254 724.569 279.459 725.541 279.459C726.495 279.459 727.262 279.276 727.842 278.909C728.43 278.534 728.728 278.053 728.737 277.464C728.728 276.97 728.519 276.565 728.11 276.25C727.701 275.926 727.07 275.679 726.218 275.509L722.817 274.831C720.9 274.447 719.472 273.783 718.535 272.837C717.606 271.891 717.141 270.685 717.141 269.219C717.141 267.957 717.482 266.871 718.164 265.959C718.854 265.047 719.822 264.344 721.066 263.849C722.319 263.355 723.785 263.108 725.464 263.108C727.944 263.108 729.896 263.632 731.319 264.68C732.751 265.729 733.586 267.156 733.825 268.963Z" fill="black"/>
+<path d="M282.981 821V794.818H293.311C295.297 794.818 296.988 795.197 298.386 795.956C299.784 796.706 300.849 797.75 301.582 799.088C302.324 800.418 302.694 801.952 302.694 803.69C302.694 805.429 302.319 806.963 301.569 808.293C300.819 809.622 299.733 810.658 298.309 811.399C296.895 812.141 295.182 812.511 293.17 812.511H286.586V808.075H292.275C293.341 808.075 294.219 807.892 294.909 807.526C295.608 807.151 296.128 806.635 296.469 805.979C296.818 805.314 296.993 804.551 296.993 803.69C296.993 802.821 296.818 802.062 296.469 801.415C296.128 800.759 295.608 800.251 294.909 799.893C294.21 799.527 293.324 799.344 292.25 799.344H288.517V821H282.981ZM314.1 821.384C312.08 821.384 310.342 820.974 308.884 820.156C307.435 819.33 306.319 818.162 305.535 816.653C304.751 815.136 304.359 813.342 304.359 811.271C304.359 809.251 304.751 807.479 305.535 805.953C306.319 804.428 307.423 803.239 308.846 802.386C310.278 801.534 311.957 801.108 313.883 801.108C315.178 801.108 316.384 801.317 317.501 801.734C318.626 802.143 319.606 802.761 320.441 803.588C321.285 804.415 321.941 805.455 322.41 806.707C322.879 807.952 323.113 809.409 323.113 811.08V812.575H306.532V809.2H317.986C317.986 808.416 317.816 807.722 317.475 807.116C317.134 806.511 316.661 806.038 316.056 805.697C315.46 805.348 314.765 805.173 313.972 805.173C313.146 805.173 312.413 805.365 311.773 805.749C311.143 806.124 310.648 806.631 310.29 807.27C309.933 807.901 309.749 808.604 309.741 809.379V812.588C309.741 813.56 309.92 814.399 310.278 815.107C310.644 815.814 311.16 816.359 311.825 816.743C312.489 817.126 313.278 817.318 314.19 817.318C314.795 817.318 315.349 817.233 315.852 817.062C316.354 816.892 316.785 816.636 317.143 816.295C317.501 815.955 317.773 815.537 317.961 815.043L322.998 815.375C322.742 816.585 322.218 817.642 321.425 818.545C320.641 819.44 319.627 820.139 318.383 820.642C317.147 821.136 315.719 821.384 314.1 821.384ZM325.947 821V801.364H331.227V804.79H331.431C331.789 803.571 332.39 802.651 333.234 802.028C334.078 801.398 335.049 801.082 336.149 801.082C336.421 801.082 336.715 801.099 337.031 801.134C337.346 801.168 337.623 801.214 337.862 801.274V806.107C337.606 806.03 337.252 805.962 336.801 805.902C336.349 805.842 335.936 805.812 335.561 805.812C334.759 805.812 334.043 805.987 333.413 806.337C332.791 806.678 332.296 807.155 331.93 807.768C331.572 808.382 331.393 809.089 331.393 809.891V821H325.947ZM351.501 801.364V805.455H339.382V801.364H351.501ZM342.156 821V799.945C342.156 798.521 342.433 797.341 342.987 796.403C343.55 795.466 344.317 794.763 345.288 794.294C346.26 793.825 347.364 793.591 348.599 793.591C349.435 793.591 350.197 793.655 350.888 793.783C351.587 793.911 352.107 794.026 352.447 794.128L351.476 798.219C351.263 798.151 350.999 798.087 350.683 798.027C350.376 797.967 350.061 797.938 349.737 797.938C348.936 797.938 348.378 798.125 348.062 798.5C347.747 798.866 347.589 799.382 347.589 800.047V821H342.156ZM362.277 821.384C360.292 821.384 358.574 820.962 357.125 820.118C355.685 819.266 354.573 818.081 353.789 816.564C353.005 815.038 352.613 813.27 352.613 811.259C352.613 809.23 353.005 807.457 353.789 805.94C354.573 804.415 355.685 803.23 357.125 802.386C358.574 801.534 360.292 801.108 362.277 801.108C364.263 801.108 365.976 801.534 367.417 802.386C368.866 803.23 369.982 804.415 370.766 805.94C371.55 807.457 371.942 809.23 371.942 811.259C371.942 813.27 371.55 815.038 370.766 816.564C369.982 818.081 368.866 819.266 367.417 820.118C365.976 820.962 364.263 821.384 362.277 821.384ZM362.303 817.165C363.206 817.165 363.961 816.909 364.566 816.398C365.171 815.878 365.627 815.17 365.934 814.276C366.249 813.381 366.407 812.362 366.407 811.22C366.407 810.078 366.249 809.06 365.934 808.165C365.627 807.27 365.171 806.562 364.566 806.043C363.961 805.523 363.206 805.263 362.303 805.263C361.391 805.263 360.624 805.523 360.002 806.043C359.388 806.562 358.924 807.27 358.608 808.165C358.302 809.06 358.148 810.078 358.148 811.22C358.148 812.362 358.302 813.381 358.608 814.276C358.924 815.17 359.388 815.878 360.002 816.398C360.624 816.909 361.391 817.165 362.303 817.165ZM374.763 821V801.364H380.043V804.79H380.248C380.606 803.571 381.207 802.651 382.05 802.028C382.894 801.398 383.866 801.082 384.965 801.082C385.238 801.082 385.532 801.099 385.847 801.134C386.163 801.168 386.44 801.214 386.678 801.274V806.107C386.423 806.03 386.069 805.962 385.617 805.902C385.165 805.842 384.752 805.812 384.377 805.812C383.576 805.812 382.86 805.987 382.229 806.337C381.607 806.678 381.113 807.155 380.746 807.768C380.388 808.382 380.209 809.089 380.209 809.891V821H374.763ZM388.774 821V801.364H393.964V804.828H394.194C394.603 803.678 395.285 802.77 396.24 802.105C397.194 801.44 398.336 801.108 399.666 801.108C401.013 801.108 402.159 801.445 403.105 802.118C404.051 802.783 404.682 803.686 404.997 804.828H405.201C405.602 803.703 406.326 802.804 407.375 802.131C408.432 801.449 409.68 801.108 411.121 801.108C412.953 801.108 414.44 801.692 415.582 802.859C416.733 804.018 417.308 805.663 417.308 807.794V821H411.875V808.868C411.875 807.777 411.585 806.959 411.005 806.413C410.426 805.868 409.701 805.595 408.832 805.595C407.844 805.595 407.072 805.911 406.518 806.541C405.964 807.163 405.687 807.986 405.687 809.009V821H400.407V808.753C400.407 807.79 400.13 807.023 399.576 806.452C399.031 805.881 398.311 805.595 397.416 805.595C396.811 805.595 396.265 805.749 395.78 806.055C395.302 806.354 394.923 806.776 394.642 807.321C394.361 807.858 394.22 808.489 394.22 809.213V821H388.774ZM426.489 821.371C425.236 821.371 424.12 821.153 423.14 820.719C422.16 820.276 421.384 819.624 420.813 818.763C420.251 817.893 419.969 816.811 419.969 815.516C419.969 814.425 420.17 813.509 420.57 812.767C420.971 812.026 421.516 811.429 422.207 810.977C422.897 810.526 423.681 810.185 424.559 809.955C425.445 809.724 426.374 809.562 427.346 809.469C428.488 809.349 429.408 809.239 430.107 809.136C430.806 809.026 431.313 808.864 431.629 808.651C431.944 808.437 432.102 808.122 432.102 807.705V807.628C432.102 806.818 431.846 806.192 431.334 805.749C430.832 805.305 430.116 805.084 429.187 805.084C428.207 805.084 427.427 805.301 426.847 805.736C426.268 806.162 425.884 806.699 425.697 807.347L420.66 806.938C420.915 805.744 421.418 804.713 422.168 803.844C422.918 802.966 423.886 802.293 425.07 801.824C426.263 801.347 427.644 801.108 429.212 801.108C430.303 801.108 431.347 801.236 432.344 801.491C433.35 801.747 434.241 802.143 435.016 802.68C435.8 803.217 436.418 803.908 436.87 804.751C437.322 805.587 437.548 806.588 437.548 807.756V821H432.383V818.277H432.229C431.914 818.891 431.492 819.432 430.964 819.901C430.435 820.361 429.8 820.723 429.059 820.987C428.317 821.243 427.461 821.371 426.489 821.371ZM428.049 817.612C428.85 817.612 429.557 817.455 430.171 817.139C430.785 816.815 431.266 816.381 431.616 815.835C431.965 815.29 432.14 814.672 432.14 813.982V811.898C431.969 812.009 431.735 812.111 431.437 812.205C431.147 812.29 430.819 812.371 430.452 812.447C430.086 812.516 429.719 812.58 429.353 812.639C428.986 812.69 428.654 812.737 428.356 812.78C427.717 812.874 427.158 813.023 426.681 813.227C426.204 813.432 425.833 813.709 425.569 814.058C425.305 814.399 425.173 814.825 425.173 815.337C425.173 816.078 425.441 816.645 425.978 817.037C426.523 817.42 427.214 817.612 428.049 817.612ZM446.499 809.648V821H441.053V801.364H446.243V804.828H446.473C446.908 803.686 447.636 802.783 448.659 802.118C449.682 801.445 450.922 801.108 452.379 801.108C453.743 801.108 454.932 801.406 455.946 802.003C456.96 802.599 457.749 803.452 458.311 804.56C458.874 805.659 459.155 806.972 459.155 808.497V821H453.709V809.469C453.717 808.267 453.411 807.33 452.788 806.656C452.166 805.974 451.31 805.634 450.219 805.634C449.486 805.634 448.838 805.791 448.276 806.107C447.722 806.422 447.287 806.882 446.972 807.487C446.665 808.084 446.507 808.804 446.499 809.648ZM471.599 821.384C469.588 821.384 467.858 820.957 466.409 820.105C464.969 819.244 463.861 818.051 463.085 816.526C462.318 815 461.935 813.244 461.935 811.259C461.935 809.247 462.322 807.483 463.098 805.966C463.882 804.44 464.994 803.251 466.435 802.399C467.875 801.538 469.588 801.108 471.574 801.108C473.287 801.108 474.787 801.419 476.074 802.041C477.361 802.663 478.379 803.537 479.129 804.662C479.879 805.787 480.293 807.108 480.369 808.625H475.23C475.085 807.645 474.702 806.857 474.079 806.26C473.466 805.655 472.66 805.352 471.663 805.352C470.82 805.352 470.082 805.582 469.452 806.043C468.829 806.494 468.344 807.155 467.994 808.024C467.645 808.893 467.47 809.946 467.47 811.182C467.47 812.435 467.641 813.5 467.981 814.378C468.331 815.256 468.821 815.925 469.452 816.385C470.082 816.845 470.82 817.075 471.663 817.075C472.285 817.075 472.844 816.947 473.338 816.692C473.841 816.436 474.254 816.065 474.578 815.58C474.91 815.085 475.128 814.493 475.23 813.803H480.369C480.284 815.303 479.875 816.624 479.142 817.766C478.418 818.899 477.416 819.786 476.138 820.425C474.859 821.064 473.347 821.384 471.599 821.384ZM492.085 821.384C490.065 821.384 488.326 820.974 486.869 820.156C485.42 819.33 484.304 818.162 483.52 816.653C482.736 815.136 482.344 813.342 482.344 811.271C482.344 809.251 482.736 807.479 483.52 805.953C484.304 804.428 485.407 803.239 486.831 802.386C488.263 801.534 489.942 801.108 491.868 801.108C493.163 801.108 494.369 801.317 495.486 801.734C496.611 802.143 497.591 802.761 498.426 803.588C499.27 804.415 499.926 805.455 500.395 806.707C500.863 807.952 501.098 809.409 501.098 811.08V812.575H484.517V809.2H495.971C495.971 808.416 495.801 807.722 495.46 807.116C495.119 806.511 494.646 806.038 494.041 805.697C493.444 805.348 492.75 805.173 491.957 805.173C491.13 805.173 490.397 805.365 489.758 805.749C489.128 806.124 488.633 806.631 488.275 807.27C487.917 807.901 487.734 808.604 487.726 809.379V812.588C487.726 813.56 487.905 814.399 488.263 815.107C488.629 815.814 489.145 816.359 489.809 816.743C490.474 817.126 491.263 817.318 492.174 817.318C492.78 817.318 493.334 817.233 493.836 817.062C494.339 816.892 494.77 816.636 495.128 816.295C495.486 815.955 495.758 815.537 495.946 815.043L500.983 815.375C500.727 816.585 500.203 817.642 499.41 818.545C498.626 819.44 497.612 820.139 496.368 820.642C495.132 821.136 493.704 821.384 492.085 821.384ZM527.882 806.963L522.896 807.27C522.811 806.844 522.628 806.46 522.346 806.119C522.065 805.77 521.694 805.493 521.234 805.288C520.782 805.075 520.241 804.969 519.611 804.969C518.767 804.969 518.055 805.148 517.476 805.506C516.896 805.855 516.606 806.324 516.606 806.912C516.606 807.381 516.794 807.777 517.169 808.101C517.544 808.425 518.187 808.685 519.099 808.881L522.653 809.597C524.562 809.989 525.986 810.619 526.923 811.489C527.861 812.358 528.329 813.5 528.329 814.915C528.329 816.202 527.95 817.331 527.192 818.303C526.442 819.274 525.41 820.033 524.098 820.578C522.794 821.115 521.29 821.384 519.585 821.384C516.986 821.384 514.915 820.842 513.372 819.76C511.838 818.669 510.939 817.186 510.674 815.311L516.031 815.03C516.193 815.822 516.585 816.428 517.207 816.845C517.829 817.254 518.626 817.459 519.598 817.459C520.552 817.459 521.319 817.276 521.899 816.909C522.487 816.534 522.785 816.053 522.794 815.464C522.785 814.97 522.576 814.565 522.167 814.25C521.758 813.926 521.128 813.679 520.275 813.509L516.875 812.831C514.957 812.447 513.53 811.783 512.592 810.837C511.663 809.891 511.199 808.685 511.199 807.219C511.199 805.957 511.54 804.871 512.221 803.959C512.912 803.047 513.879 802.344 515.123 801.849C516.376 801.355 517.842 801.108 519.521 801.108C522.001 801.108 523.953 801.632 525.376 802.68C526.808 803.729 527.643 805.156 527.882 806.963ZM539.987 821.384C537.968 821.384 536.229 820.974 534.772 820.156C533.323 819.33 532.206 818.162 531.422 816.653C530.638 815.136 530.246 813.342 530.246 811.271C530.246 809.251 530.638 807.479 531.422 805.953C532.206 804.428 533.31 803.239 534.733 802.386C536.165 801.534 537.844 801.108 539.77 801.108C541.066 801.108 542.272 801.317 543.388 801.734C544.513 802.143 545.493 802.761 546.328 803.588C547.172 804.415 547.828 805.455 548.297 806.707C548.766 807.952 549 809.409 549 811.08V812.575H532.419V809.2H543.874C543.874 808.416 543.703 807.722 543.362 807.116C543.022 806.511 542.549 806.038 541.943 805.697C541.347 805.348 540.652 805.173 539.86 805.173C539.033 805.173 538.3 805.365 537.661 805.749C537.03 806.124 536.536 806.631 536.178 807.27C535.82 807.901 535.637 808.604 535.628 809.379V812.588C535.628 813.56 535.807 814.399 536.165 815.107C536.531 815.814 537.047 816.359 537.712 816.743C538.377 817.126 539.165 817.318 540.077 817.318C540.682 817.318 541.236 817.233 541.739 817.062C542.242 816.892 542.672 816.636 543.03 816.295C543.388 815.955 543.661 815.537 543.848 815.043L548.885 815.375C548.63 816.585 548.105 817.642 547.313 818.545C546.529 819.44 545.514 820.139 544.27 820.642C543.034 821.136 541.607 821.384 539.987 821.384ZM551.834 828.364V801.364H557.204V804.662H557.446C557.685 804.134 558.03 803.597 558.482 803.051C558.942 802.497 559.539 802.037 560.272 801.67C561.013 801.295 561.934 801.108 563.033 801.108C564.465 801.108 565.786 801.483 566.996 802.233C568.206 802.974 569.174 804.095 569.898 805.595C570.623 807.087 570.985 808.957 570.985 811.207C570.985 813.398 570.631 815.247 569.924 816.756C569.225 818.256 568.27 819.393 567.06 820.169C565.858 820.936 564.512 821.32 563.02 821.32C561.964 821.32 561.064 821.145 560.323 820.795C559.59 820.446 558.989 820.007 558.52 819.479C558.052 818.942 557.694 818.401 557.446 817.855H557.28V828.364H551.834ZM557.165 811.182C557.165 812.349 557.327 813.368 557.651 814.237C557.975 815.107 558.444 815.784 559.057 816.27C559.671 816.747 560.417 816.986 561.294 816.986C562.181 816.986 562.931 816.743 563.544 816.257C564.158 815.763 564.623 815.081 564.938 814.212C565.262 813.334 565.424 812.324 565.424 811.182C565.424 810.048 565.266 809.051 564.951 808.19C564.635 807.33 564.171 806.656 563.557 806.17C562.944 805.685 562.189 805.442 561.294 805.442C560.408 805.442 559.658 805.676 559.044 806.145C558.439 806.614 557.975 807.278 557.651 808.139C557.327 809 557.165 810.014 557.165 811.182ZM579.495 821.371C578.242 821.371 577.126 821.153 576.145 820.719C575.165 820.276 574.39 819.624 573.819 818.763C573.256 817.893 572.975 816.811 572.975 815.516C572.975 814.425 573.175 813.509 573.576 812.767C573.976 812.026 574.522 811.429 575.212 810.977C575.903 810.526 576.687 810.185 577.565 809.955C578.451 809.724 579.38 809.562 580.351 809.469C581.494 809.349 582.414 809.239 583.113 809.136C583.812 809.026 584.319 808.864 584.634 808.651C584.949 808.437 585.107 808.122 585.107 807.705V807.628C585.107 806.818 584.851 806.192 584.34 805.749C583.837 805.305 583.121 805.084 582.192 805.084C581.212 805.084 580.432 805.301 579.853 805.736C579.273 806.162 578.89 806.699 578.702 807.347L573.665 806.938C573.921 805.744 574.424 804.713 575.174 803.844C575.924 802.966 576.891 802.293 578.076 801.824C579.269 801.347 580.65 801.108 582.218 801.108C583.309 801.108 584.353 801.236 585.35 801.491C586.356 801.747 587.246 802.143 588.022 802.68C588.806 803.217 589.424 803.908 589.876 804.751C590.327 805.587 590.553 806.588 590.553 807.756V821H585.388V818.277H585.235C584.92 818.891 584.498 819.432 583.969 819.901C583.441 820.361 582.806 820.723 582.065 820.987C581.323 821.243 580.467 821.371 579.495 821.371ZM581.055 817.612C581.856 817.612 582.563 817.455 583.177 817.139C583.79 816.815 584.272 816.381 584.621 815.835C584.971 815.29 585.145 814.672 585.145 813.982V811.898C584.975 812.009 584.741 812.111 584.442 812.205C584.153 812.29 583.824 812.371 583.458 812.447C583.092 812.516 582.725 812.58 582.359 812.639C581.992 812.69 581.66 812.737 581.361 812.78C580.722 812.874 580.164 813.023 579.687 813.227C579.209 813.432 578.839 813.709 578.574 814.058C578.31 814.399 578.178 814.825 578.178 815.337C578.178 816.078 578.447 816.645 578.984 817.037C579.529 817.42 580.219 817.612 581.055 817.612ZM594.058 821V801.364H599.338V804.79H599.543C599.901 803.571 600.501 802.651 601.345 802.028C602.189 801.398 603.161 801.082 604.26 801.082C604.533 801.082 604.827 801.099 605.142 801.134C605.457 801.168 605.734 801.214 605.973 801.274V806.107C605.717 806.03 605.364 805.962 604.912 805.902C604.46 805.842 604.047 805.812 603.672 805.812C602.871 805.812 602.155 805.987 601.524 806.337C600.902 806.678 600.408 807.155 600.041 807.768C599.683 808.382 599.504 809.089 599.504 809.891V821H594.058ZM613.106 821.371C611.853 821.371 610.736 821.153 609.756 820.719C608.776 820.276 608.001 819.624 607.43 818.763C606.867 817.893 606.586 816.811 606.586 815.516C606.586 814.425 606.786 813.509 607.187 812.767C607.587 812.026 608.133 811.429 608.823 810.977C609.513 810.526 610.297 810.185 611.175 809.955C612.062 809.724 612.991 809.562 613.962 809.469C615.104 809.349 616.025 809.239 616.724 809.136C617.422 809.026 617.93 808.864 618.245 808.651C618.56 808.437 618.718 808.122 618.718 807.705V807.628C618.718 806.818 618.462 806.192 617.951 805.749C617.448 805.305 616.732 805.084 615.803 805.084C614.823 805.084 614.043 805.301 613.464 805.736C612.884 806.162 612.501 806.699 612.313 807.347L607.276 806.938C607.532 805.744 608.035 804.713 608.785 803.844C609.535 802.966 610.502 802.293 611.687 801.824C612.88 801.347 614.261 801.108 615.829 801.108C616.92 801.108 617.964 801.236 618.961 801.491C619.967 801.747 620.857 802.143 621.633 802.68C622.417 803.217 623.035 803.908 623.486 804.751C623.938 805.587 624.164 806.588 624.164 807.756V821H618.999V818.277H618.846C618.53 818.891 618.109 819.432 617.58 819.901C617.052 820.361 616.417 820.723 615.675 820.987C614.934 821.243 614.077 821.371 613.106 821.371ZM614.665 817.612C615.467 817.612 616.174 817.455 616.788 817.139C617.401 816.815 617.883 816.381 618.232 815.835C618.582 815.29 618.756 814.672 618.756 813.982V811.898C618.586 812.009 618.351 812.111 618.053 812.205C617.763 812.29 617.435 812.371 617.069 812.447C616.702 812.516 616.336 812.58 615.969 812.639C615.603 812.69 615.27 812.737 614.972 812.78C614.333 812.874 613.775 813.023 613.297 813.227C612.82 813.432 612.449 813.709 612.185 814.058C611.921 814.399 611.789 814.825 611.789 815.337C611.789 816.078 612.057 816.645 612.594 817.037C613.14 817.42 613.83 817.612 614.665 817.612ZM627.771 821V794.818H633.217V804.662H633.384C633.622 804.134 633.967 803.597 634.419 803.051C634.879 802.497 635.476 802.037 636.209 801.67C636.95 801.295 637.871 801.108 638.97 801.108C640.402 801.108 641.723 801.483 642.933 802.233C644.144 802.974 645.111 804.095 645.835 805.595C646.56 807.087 646.922 808.957 646.922 811.207C646.922 813.398 646.568 815.247 645.861 816.756C645.162 818.256 644.207 819.393 642.997 820.169C641.796 820.936 640.449 821.32 638.957 821.32C637.901 821.32 637.001 821.145 636.26 820.795C635.527 820.446 634.926 820.007 634.457 819.479C633.989 818.942 633.631 818.401 633.384 817.855H633.141V821H627.771ZM633.102 811.182C633.102 812.349 633.264 813.368 633.588 814.237C633.912 815.107 634.381 815.784 634.994 816.27C635.608 816.747 636.354 816.986 637.232 816.986C638.118 816.986 638.868 816.743 639.482 816.257C640.095 815.763 640.56 815.081 640.875 814.212C641.199 813.334 641.361 812.324 641.361 811.182C641.361 810.048 641.203 809.051 640.888 808.19C640.572 807.33 640.108 806.656 639.494 806.17C638.881 805.685 638.126 805.442 637.232 805.442C636.345 805.442 635.595 805.676 634.982 806.145C634.376 806.614 633.912 807.278 633.588 808.139C633.264 809 633.102 810.014 633.102 811.182ZM649.836 821V801.364H655.282V821H649.836ZM652.572 798.832C651.762 798.832 651.067 798.564 650.488 798.027C649.917 797.482 649.631 796.83 649.631 796.071C649.631 795.321 649.917 794.678 650.488 794.141C651.067 793.595 651.762 793.322 652.572 793.322C653.381 793.322 654.072 793.595 654.643 794.141C655.222 794.678 655.512 795.321 655.512 796.071C655.512 796.83 655.222 797.482 654.643 798.027C654.072 798.564 653.381 798.832 652.572 798.832ZM664.37 794.818V821H658.924V794.818H664.37ZM668.013 821V801.364H673.459V821H668.013ZM670.749 798.832C669.939 798.832 669.245 798.564 668.665 798.027C668.094 797.482 667.808 796.83 667.808 796.071C667.808 795.321 668.094 794.678 668.665 794.141C669.245 793.595 669.939 793.322 670.749 793.322C671.558 793.322 672.249 793.595 672.82 794.141C673.399 794.678 673.689 795.321 673.689 796.071C673.689 796.83 673.399 797.482 672.82 798.027C672.249 798.564 671.558 798.832 670.749 798.832ZM687.546 801.364V805.455H675.721V801.364H687.546ZM678.406 796.659H683.852V814.966C683.852 815.469 683.928 815.861 684.082 816.142C684.235 816.415 684.448 816.607 684.721 816.717C685.002 816.828 685.326 816.884 685.692 816.884C685.948 816.884 686.204 816.862 686.46 816.82C686.715 816.768 686.911 816.73 687.048 816.705L687.904 820.757C687.631 820.842 687.248 820.94 686.754 821.051C686.259 821.17 685.658 821.243 684.951 821.268C683.639 821.32 682.488 821.145 681.499 820.744C680.519 820.344 679.756 819.722 679.211 818.878C678.665 818.034 678.397 816.969 678.406 815.682V796.659ZM693.736 828.364C693.046 828.364 692.398 828.308 691.793 828.197C691.196 828.095 690.702 827.963 690.31 827.801L691.537 823.736C692.176 823.932 692.752 824.038 693.263 824.055C693.783 824.072 694.23 823.953 694.605 823.697C694.989 823.442 695.3 823.007 695.539 822.393L695.858 821.562L688.814 801.364H694.541L698.607 815.784H698.811L702.915 801.364H708.681L701.048 823.122C700.682 824.179 700.183 825.099 699.553 825.884C698.931 826.676 698.142 827.286 697.188 827.712C696.233 828.146 695.083 828.364 693.736 828.364Z" fill="black"/>
+<path d="M1099.12 468.121C1100.29 466.95 1100.29 465.05 1099.12 463.879L1080.03 444.787C1078.86 443.615 1076.96 443.615 1075.79 444.787C1074.62 445.958 1074.62 447.858 1075.79 449.029L1092.76 466L1075.79 482.971C1074.62 484.142 1074.62 486.042 1075.79 487.213C1076.96 488.385 1078.86 488.385 1080.03 487.213L1099.12 468.121ZM725 466V469H1097V466V463H725V466Z" fill="black"/>
+<path d="M908.867 865.379C907.695 866.55 907.695 868.45 908.867 869.621L927.958 888.713C929.13 889.885 931.03 889.885 932.201 888.713C933.373 887.542 933.373 885.642 932.201 884.471L915.231 867.5L932.201 850.529C933.373 849.358 933.373 847.458 932.201 846.287C931.03 845.115 929.13 845.115 927.958 846.287L908.867 865.379ZM1097.01 867.5V864.5L910.988 864.5V867.5V870.5L1097.01 870.5V867.5Z" fill="black"/>
+<path d="M501.707 398.707C502.098 398.317 502.098 397.683 501.707 397.293L495.343 390.929C494.953 390.538 494.319 390.538 493.929 390.929C493.538 391.319 493.538 391.953 493.929 392.343L499.586 398L493.929 403.657C493.538 404.047 493.538 404.681 493.929 405.071C494.319 405.462 494.953 405.462 495.343 405.071L501.707 398.707ZM451 398V399H501V398V397H451V398Z" fill="black"/>
+<path d="M501.707 530.707C502.098 530.317 502.098 529.683 501.707 529.293L495.343 522.929C494.953 522.538 494.319 522.538 493.929 522.929C493.538 523.319 493.538 523.953 493.929 524.343L499.586 530L493.929 535.657C493.538 536.047 493.538 536.681 493.929 537.071C494.319 537.462 494.953 537.462 495.343 537.071L501.707 530.707ZM451 530V531H501V530V529H451V530Z" fill="black"/>
+<path d="M501.707 659.707C502.098 659.317 502.098 658.683 501.707 658.293L495.343 651.929C494.953 651.538 494.319 651.538 493.929 651.929C493.538 652.319 493.538 652.953 493.929 653.343L499.586 659L493.929 664.657C493.538 665.047 493.538 665.681 493.929 666.071C494.319 666.462 494.953 666.462 495.343 666.071L501.707 659.707ZM451 659V660H501V659V658H451V659Z" fill="black"/>
+<path d="M465 892.5H502C503.933 892.5 505.5 894.067 505.5 896V932C505.5 933.933 503.933 935.5 502 935.5H465C463.067 935.5 461.5 933.933 461.5 932V896C461.5 894.067 463.067 892.5 465 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M490.563 897.591L482.126 928.938H477.434L485.871 897.591H490.563Z" fill="black"/>
+<path d="M261 894.5H298C299.933 894.5 301.5 896.067 301.5 898V934C301.5 935.933 299.933 937.5 298 937.5H261C259.067 937.5 257.5 935.933 257.5 934V898C257.5 896.067 259.067 894.5 261 894.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M269.993 927.332C269.149 927.332 268.424 927.034 267.819 926.438C267.223 925.832 266.924 925.108 266.924 924.264C266.924 923.429 267.223 922.713 267.819 922.116C268.424 921.52 269.149 921.222 269.993 921.222C270.811 921.222 271.527 921.52 272.14 922.116C272.754 922.713 273.061 923.429 273.061 924.264C273.061 924.827 272.916 925.342 272.626 925.811C272.345 926.271 271.974 926.642 271.514 926.923C271.054 927.196 270.547 927.332 269.993 927.332ZM279.995 927.332C279.151 927.332 278.427 927.034 277.822 926.438C277.225 925.832 276.927 925.108 276.927 924.264C276.927 923.429 277.225 922.713 277.822 922.116C278.427 921.52 279.151 921.222 279.995 921.222C280.813 921.222 281.529 921.52 282.143 922.116C282.757 922.713 283.063 923.429 283.063 924.264C283.063 924.827 282.919 925.342 282.629 925.811C282.347 926.271 281.977 926.642 281.517 926.923C281.056 927.196 280.549 927.332 279.995 927.332ZM289.998 927.332C289.154 927.332 288.43 927.034 287.825 926.438C287.228 925.832 286.93 925.108 286.93 924.264C286.93 923.429 287.228 922.713 287.825 922.116C288.43 921.52 289.154 921.222 289.998 921.222C290.816 921.222 291.532 921.52 292.146 922.116C292.759 922.713 293.066 923.429 293.066 924.264C293.066 924.827 292.921 925.342 292.631 925.811C292.35 926.271 291.979 926.642 291.519 926.923C291.059 927.196 290.552 927.332 289.998 927.332Z" fill="black"/>
+<path d="M689 892.5H726C727.933 892.5 729.5 894.067 729.5 896V932C729.5 933.933 727.933 935.5 726 935.5H689C687.067 935.5 685.5 933.933 685.5 932V896C685.5 894.067 687.067 892.5 689 892.5Z" fill="#D9D9D9" stroke="black"/>
+<path d="M699 916.78V912.28L717 904.354V909.531L704.676 914.479L704.842 914.21V914.849L704.676 914.581L717 919.528V924.706L699 916.78Z" fill="black"/>
+<rect x="538" y="334" width="152" height="261" rx="2" stroke="black" stroke-width="4"/>
+<rect x="526" y="843" width="346" height="141" rx="6" stroke="black" stroke-width="4"/>
+<defs>
+<clipPath id="clip0_13_16077">
+<rect width="212" height="217" fill="white" transform="translate(1152 383)"/>
+</clipPath>
+<clipPath id="clip1_13_16077">
+<rect width="95" height="95" fill="white" transform="translate(566 609)"/>
+</clipPath>
+<clipPath id="clip2_13_16077">
+<rect width="212" height="217" fill="white" transform="translate(1656 383)"/>
+</clipPath>
+</defs>
+</svg>

--- a/docs/source/examples/complementarity.rst
+++ b/docs/source/examples/complementarity.rst
@@ -1,0 +1,5 @@
+examples.complementarity.py
+===================================
+
+.. automodule:: examples.complementarity
+   :members:

--- a/docs/source/examples/separability.rst
+++ b/docs/source/examples/separability.rst
@@ -1,0 +1,5 @@
+examples.separability.py
+===================================
+
+.. automodule:: examples.separability
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -169,7 +169,7 @@ If you use RINGS in your research, please cite our paper:
 .. code-block:: bibtex
 
    @inproceedings{
-   coupette2025,
+   coupette2025metric,
    title={No Metric to Rule Them All: Toward Principled Evaluations of Graph-Learning Datasets},
    author={Corinna Coupette and Jeremy Wayland and Emily Simons and Bastian Rieck},
    booktitle={Forty-second International Conference on Machine Learning},

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -174,23 +174,28 @@ The script outputs complementarity statistics that measure how well node feature
    perturbations
    utils
 
+.. toctree::
+   :maxdepth: 2
+   :caption: 🔑 Performance Separability
+
+   separability/comparator
+   separability/functor
 
 .. toctree::
    :maxdepth: 2
-   :caption: -> Mode Complementarity
+   :caption: 🔑 Mode Complementarity
 
    complementarity/comparator
    complementarity/functor
    complementarity/metrics
    complementarity/utils
 
-
 .. toctree::
    :maxdepth: 2
-   :caption: -> Performance Separability
+   :caption: 🔍 Example Scripts
 
-   separability/comparator
-   separability/functor
+   examples/complementarity
+   examples/separability
 
 
 📚 Citation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,53 +25,54 @@ RINGS: Relevant Information in Node Features and Graph Structure documentation
 Welcome to the official repository for the 2025 ICML paper, `No Metric to Rule Them All: Toward Principled Evaluations of Graph-Learning Datasets <https://doi.org/10.48550/arXiv.2502.02379>`__, which introduces RINGS: a perturbation framework for attributed graphs, designed to facilitate more principled evaluations of graph learning benchmarks from first principles.
 
 |
+
 💍 Framework Overview
------------------------
+----------------------
 
-We are developing a community-friendly implementation of the **RINGS** framework introduced in the paper. Our goal is to make it easy for the graph learning community to:
+We are developing a community-friendly implementation of the **RINGS** framework introduced in the paper. Our goal is to make it easy for the graph-learning community to:
 
-- Apply dataset perturbations tailored to graph learning datasets
+- Apply dataset perturbations tailored to graph-learning datasets
 - Conduct more rigorous and insightful evaluations of both datasets and models
 - Promote better dataset practices and evaluation hygiene across the field
 
 If you have feedback on the paper or suggestions for how this package could better integrate with popular frameworks, please feel free to reach out to the authors.
 
+---
+
 📦 Installation
------------------
+----------------------
 
 RINGS uses `uv <https://github.com/astral-sh/uv>`_ as the package manager, which provides faster dependency resolution and installation.
 
 Prerequisites
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
-1. Install ``uv`` if you don’t have it already:
+Install ``uv`` if you don’t have it already::
 
-.. code-block:: bash
-
-   pip install uv
+    pip install uv
 
 Installing RINGS
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
-Clone the repository and install dependencies using ``uv``:
+Clone the repository and install dependencies using ``uv``::
 
-.. code-block:: bash
+    # Clone the repository
+    git clone https://github.com/aidos-lab/rings.git
+    cd rings
 
-   # Clone the repository
-   git clone https://github.com/aidos-lab/rings.git
-   cd rings
+    # Install dependencies
+    uv sync
 
-   # Install dependencies
-   uv sync
+    # Activate environment
+    source .venv/bin/activate
 
-   # Activate environment
-   source .venv/bin/activate
+---
 
-🚀 Key Components
-------------------
+🔑 Key Components
+----------------------
 
-Available Perturbations
-^^^^^^^^^^^^^^^^^^^^^^^
+Mode Perturbations
+^^^^^^^^^^^^^^^^^^^^^^
 
 RINGS provides several perturbation transforms that can be applied to graph datasets:
 
@@ -89,8 +90,24 @@ RINGS provides several perturbation transforms that can be applied to graph data
 - ``RandomGraph``: Generates a random graph structure
 - ``RandomConnectedGraph``: Generates a random graph that is guaranteed to be connected
 
+SeparabilityFunctor
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``SeparabilityFunctor`` computes statistically rigorous comparisons between multiple distributions to determine if they differ significantly. This is useful for:
+
+- Evaluating whether different graph perturbations produce statistically distinct model performances
+- Identifying which perturbations most impact model behavior
+- Making rigorous, statistically valid claims about distribution separability
+
+It employs statistical tests with permutation testing and built-in correction for multiple hypotheses (Bonferroni correction).
+
+Available comparators include:
+
+- ``KSComparator``: Kolmogorov–Smirnov test for comparing distributions
+- ``WilcoxonComparator``: Wilcoxon signed-rank test for paired comparisons
+
 ComplementarityFunctor
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``ComplementarityFunctor`` measures the alignment between node features and graph structure by comparing their induced metric spaces. It can help you understand:
 
@@ -98,38 +115,51 @@ The ``ComplementarityFunctor`` measures the alignment between node features and 
 - How different perturbations affect this complementarity
 - The distribution of information content across modalities in graph datasets
 
-✨ Example Usage
------------------
+---
 
-The repository includes an example script that demonstrates how to use RINGS to analyze graph datasets:
+🔍 Example Usage
+----------------------
+
+The repository includes example scripts that demonstrate how to use RINGS to analyze graph datasets.
+
+Performance Separability
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Measure distances between performance distributions to test whether the original dataset statistically outperforms perturbed versions.
+
+Run a basic separability analysis with the default KS comparator::
+
+    python -m examples.separability --comparator ks --alpha 0.05
+
+Use the Wilcoxon test comparator::
+
+    python -m examples.separability --comparator wilcoxon --alpha 0.01
+
+Get help and see all available options::
+
+    python -m examples.separability --help
+
+The script analyzes and compares distributions from synthetic data, showing how to determine if differences are statistically significant.
 
 Mode Complementarity
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An example on the MUTAG dataset with original (unperturbed) graphs. The script will output complementarity statistics that measure how well node features align with graph structure in the dataset.
+Assess the complementarity of geometric information in the metric spaces of node features and graph structure.
 
-.. code-block:: bash
+Run the example on the MUTAG dataset with original (unperturbed) graphs::
 
-   python -m examples.complementarity --dataset MUTAG --perturbation original
+    python -m examples.complementarity --dataset MUTAG --perturbation original
 
-Trying different perturbations.
+Try different perturbations::
 
-.. code-block:: bash
+    python -m examples.complementarity --dataset MUTAG --perturbation random-features
 
-   python -m examples.complementarity --dataset MUTAG --perturbation random-features
-   python -m examples.complementarity --dataset MUTAG --perturbation empty-graph
+Get help and see all available options::
 
-Using a different TU dataset.
+    python -m examples.complementarity --help
 
-.. code:: bash
+The script outputs complementarity statistics that measure how well node features align with graph structure in the dataset.
 
-   python -m examples.complementarity --dataset ENZYMES --perturbation original
-
-Get help and see all available options.
-
-.. code-block:: bash
-
-   python -m examples.complementarity --help
 
 
 🔍 Table of Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,9 @@ RINGS: Relevant Information in Node Features and Graph Structure documentation
    :align: left
 
 
-Welcome to the official repository for the 2025 ICML paper, `No Metric to Rule Them All: Toward Principled Evaluations of Graph-Learning Datasets <https://doi.org/10.48550/arXiv.2502.02379>`__, which introduces RINGS: a perturbation framework for attributed graphs, designed to facilitate more principled evaluations of graph learning benchmarks from first principles.
+Welcome to the official repository for the 2025 ICML paper, `No Metric to Rule Them All: Toward Principled Evaluations of Graph-Learning Datasets <https://doi.org/10.48550/arXiv.2502.02379>`__, which introduces RINGS: a perturbation framework for attributed graphs, designed to facilitate more principled evaluations of graph learning benchmarks from first principles. 
+
+The full repo is available `here <https://github.com/aidos-lab/rings>`__.
 
 |
 

--- a/docs/source/separability/comparator.rst
+++ b/docs/source/separability/comparator.rst
@@ -1,5 +1,14 @@
 separability.comparator.py
 ===================================
 
+|
+
+.. image:: ../_static/separability-comparator.svg
+   :width: 500
+   :alt: Code diagram highlighting comparator file
+   :align: center
+
+|
+
 .. automodule:: rings.separability.comparator
    :members:

--- a/docs/source/separability/functor.rst
+++ b/docs/source/separability/functor.rst
@@ -1,5 +1,14 @@
 separability.functor.py
 ===================================
 
+|
+
+.. image:: ../_static/separability-functor.svg
+   :width: 500
+   :alt: Code diagram highlighting functor file
+   :align: center
+
+|
+
 .. automodule:: rings.separability.functor
    :members:

--- a/examples/complementarity.py
+++ b/examples/complementarity.py
@@ -6,11 +6,11 @@ This script demonstrates how to:
 2. Apply various RINGS perturbations to the graph data
 3. Compute complementarity metrics
 
-Usage:
-    python complementarity.py --dataset MUTAG --perturbation original
+Usage (from root directory):
+    python -m examples.complementarity --dataset MUTAG --perturbation original
 
 For more options:
-    python complementarity.py --help
+    python -m examples.complementarity --help
 """
 
 import numpy as np
@@ -152,7 +152,15 @@ def compute_complementarity(dataloader, functor):
 
 
 def main():
-    """Main function to run the complementarity analysis."""
+    """Main function to run the complementarity analysis.
+
+    User inputs are handled via command line arguments:
+        --perturbation: "Perturbation to apply to the dataset (default: original)"
+        --dataset: "Name of the TU dataset to use (default: MUTAG)"
+        --seed: "Random seed for reproducibility (default: 42)"
+        --batch-size: "Batch size for dataloader (default: 32)"
+        --n-jobs: "Number of parallel jobs (-1 for all cores, default: 1)"
+    """
     # Parse command line arguments
     parser = argparse.ArgumentParser(
         description="Compute complementarity metrics for graph datasets"

--- a/examples/separability.py
+++ b/examples/separability.py
@@ -14,8 +14,7 @@ For more options:
 
 
 Have your own performance distributions and want to execute a separability analysis?
-Replace the distribution in `create_sample_distributions` function with your own and run the script:
-    python -m examples.separability --comparator ks --alpha 0.01
+Replace the distribution in `create_sample_distributions` function with your own and run the script.
 """
 
 import numpy as np

--- a/examples/separability.py
+++ b/examples/separability.py
@@ -6,11 +6,11 @@ This script demonstrates how to:
 2. Apply the SeparabilityFunctor to compare multiple distributions
 3. Visualize and interpret separability results
 
-Usage:
-    python separability.py --comparator ks --alpha 0.01
+Usage (from root directory):
+    python -m examples.separability --comparator ks --alpha 0.01
 
 For more options:
-    python separability.py --help
+    python -m examples.separability --help
 """
 
 import numpy as np
@@ -111,9 +111,7 @@ def basic_comparator_example(seed=42):
     print(f"   - Significant: {wc_result['significant']}")
 
 
-def run_separability_analysis(
-    comparator_name, alpha, n_permutations, n_jobs, seed
-):
+def run_separability_analysis(comparator_name, alpha, n_permutations, n_jobs, seed):
     """
     Run the separability analysis using the specified comparator.
 
@@ -220,7 +218,15 @@ def print_results_summary(results_df, results_list, comparator_name):
 
 
 def main():
-    """Main function to run the separability analysis."""
+    """Main function to run the separability analysis.
+    User inputs are handled via command line arguments:
+        --comparator: Name of the comparator to use (default: ks)
+        --alpha: Significance level for statistical tests (default: 0.01)
+        --seed: Random seed for reproducibility (default: 42)
+        --permutations: Number of permutations for the test (default: 1000)
+        --n-jobs: Number of parallel jobs (-1 for all cores, default: 1)
+        --skip-basic: Include --skip-basic argument to skip basic example, otherwise included by default
+    """
     # Parse command line arguments
     parser = argparse.ArgumentParser(
         description="Compute separability metrics for distributions"

--- a/examples/separability.py
+++ b/examples/separability.py
@@ -11,6 +11,11 @@ Usage (from root directory):
 
 For more options:
     python -m examples.separability --help
+
+
+Have your own performance distributions and want to execute a separability analysis?
+Replace the distribution in `create_sample_distributions` function with your own and run the script:
+    python -m examples.separability --comparator ks --alpha 0.01
 """
 
 import numpy as np


### PR DESCRIPTION
# Separability Documentation

The pull request ensures full documentation for the added performance separability functionality.

No changes made to the core functionality of the repo. Edits only to `docs/` folder and docstrings.

## Updates
1. Adding code structure figures for separability files.
![separability-overview](https://github.com/user-attachments/assets/d62b471b-246f-4e65-ba7d-8ec11cb333a5)
2. Adding documentation to example scripts and adding them to docs (`examples/complementarity.py` and `examples/separability.py`.
3. Updating homepage to reflect README updates.
